### PR TITLE
rename: OpenBreath → DragonBreath (firmware)

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -37,9 +37,9 @@ jobs:
       - name: Upload firmware artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: openbreath-firmware
+          name: dragonbreath-firmware
           path: |
-            build/openbreath.bin
+            build/dragonbreath.bin
             build/bootloader/bootloader.bin
             build/partition_table/partition-table.bin
           if-no-files-found: warn

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# OpenBreath — open firmware for the BIGTREETECH Panda Breath (ESP32-C3)
+# DragonBreath — open firmware for the BIGTREETECH Panda Breath (ESP32-C3)
 cmake_minimum_required(VERSION 3.16)
 # Shared core from the OpenVent family (git submodule, pinned). These components
 # are made AVAILABLE here but are not yet linked — they build into the app only
@@ -15,29 +15,29 @@ set(EXTRA_COMPONENT_DIRS
 execute_process(
     COMMAND git describe --tags --exact-match
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    OUTPUT_VARIABLE OB_TAG OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_QUIET RESULT_VARIABLE OB_TAG_RC)
-if(OB_TAG_RC EQUAL 0 AND OB_TAG)
-    set(PROJECT_VER "${OB_TAG}")
+    OUTPUT_VARIABLE DB_TAG OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET RESULT_VARIABLE DB_TAG_RC)
+if(DB_TAG_RC EQUAL 0 AND DB_TAG)
+    set(PROJECT_VER "${DB_TAG}")
 else()
     execute_process(
         COMMAND git rev-parse --short HEAD
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        OUTPUT_VARIABLE OB_HASH OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET RESULT_VARIABLE OB_HASH_RC)
+        OUTPUT_VARIABLE DB_HASH OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET RESULT_VARIABLE DB_HASH_RC)
     execute_process(
         COMMAND git status --porcelain --untracked-files=no
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        OUTPUT_VARIABLE OB_DIRTY OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
-    if(NOT OB_HASH_RC EQUAL 0)
+        OUTPUT_VARIABLE DB_DIRTY OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+    if(NOT DB_HASH_RC EQUAL 0)
         set(PROJECT_VER "unknown")
-    elseif(OB_DIRTY)
-        set(PROJECT_VER "${OB_HASH}-dirty")
+    elseif(DB_DIRTY)
+        set(PROJECT_VER "${DB_HASH}-dirty")
     else()
-        set(PROJECT_VER "${OB_HASH}")
+        set(PROJECT_VER "${DB_HASH}")
     endif()
 endif()
-message(STATUS "OpenBreath version: ${PROJECT_VER}")
+message(STATUS "DragonBreath version: ${PROJECT_VER}")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-project(openbreath)
+project(dragonbreath)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 OpenBreath contributors
+Copyright (c) 2026 DragonBreath contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenBreath
+# DragonBreath
 
 Open firmware for the **BIGTREETECH Panda Breath** chamber heater (ESP32-C3),
 replacing the stock cloud integration with **Moonraker/Klipper** (and Home
@@ -6,7 +6,7 @@ Assistant) control.
 
 Sibling to [OpenVent](https://github.com/justinh-rahb/OpenVent) — part of an
 open-firmware **family for the BTT Panda line** that shares a common core.
-OpenBreath mirrors OpenVent's ESP-IDF + `components/` layout on purpose, so the
+DragonBreath mirrors OpenVent's ESP-IDF + `components/` layout on purpose, so the
 shared core (WiFi, captive portal, Moonraker client) is lifted in rather than
 re-implemented.
 
@@ -29,9 +29,9 @@ re-implemented.
 | Network core: `pv_wifi` / `pv_evlog` / `pv_moonraker` | ✅ Referenced from OpenVent (submodule); WiFi + Moonraker validated on hardware |
 | Portal / status dashboard / heat LED | ✅ Breath-local; captive-portal provisioning + live dashboard validated |
 | HTTP control API (`pb_httpd`) | ✅ `/status` `/target` `/heartbeat` `/reset`; CSRF-gated mutations |
-| Klipper-side helper (M141 / Fluidd) | ✅ [openbreath-klipper](https://github.com/plastikman/openbreath-klipper) — HTTP transport, M141/M191, Fluidd chamber card |
+| Klipper-side helper (M141 / Fluidd) | ✅ [dragonbreath-klipper](https://github.com/plastikman/dragonbreath-klipper) — HTTP transport, M141/M191, Fluidd chamber card |
 | Flasher (`tools/flash.py`) | ✅ Backs up full stock flash first, then flashes; `--restore` returns to stock |
-| Web OTA update | ✅ Dual-OTA + rollback; upload from the UI, verified on hardware (OpenBreath-only, refused while heating) |
+| Web OTA update | ✅ Dual-OTA + rollback; upload from the UI, verified on hardware (DragonBreath-only, refused while heating) |
 
 **Shared-core boundary:** board-agnostic infrastructure (WiFi, event log, Moonraker
 client) is referenced from the [OpenVent](https://github.com/justinh-rahb/OpenVent)
@@ -47,7 +47,7 @@ LED / button UI — stays in this repo.
 </p>
 
 Left → right: the live status dashboard, Wi-Fi / printer setup (captive portal),
-and the OpenBreath-only OTA firmware-update page. Served by the device itself over
+and the DragonBreath-only OTA firmware-update page. Served by the device itself over
 plain HTTP on your LAN.
 
 ## Hardware
@@ -75,7 +75,7 @@ before touching heater code and supervise the device.
 | POST | `/reset` | clear a latched safety fault |
 
 Every **mutating** endpoint (and the portal's STA-mode `/save`) requires a custom
-`X-OpenBreath-Auth` header. A cross-origin HTML form can't set a custom header and
+`X-DragonBreath-Auth` header. A cross-origin HTML form can't set a custom header and
 CORS is never enabled, so an ordinary drive-by web page can't drive the heater or
 rewrite the WiFi config. This is **CSRF hardening for a trusted LAN, not transport
 security** — the API is unencrypted HTTP. For untrusted networks, set a control
@@ -94,7 +94,7 @@ Fully reverse-engineered from the stock firmware — a low-side resistance divid
 ## Build
 Requires ESP-IDF v5.3+.
 ```bash
-git clone --recurse-submodules https://github.com/plastikman/OpenBreath
+git clone --recurse-submodules https://github.com/plastikman/DragonBreath
 idf.py set-target esp32c3
 idf.py build
 ```
@@ -102,7 +102,7 @@ idf.py build
 ## Install & update
 
 > 🛑 **BACK UP YOUR DEVICE FIRST. THIS IS IRREVERSIBLE WITHOUT A BACKUP.**
-> Installing OpenBreath **overwrites the entire flash** and **erases the stock
+> Installing DragonBreath **overwrites the entire flash** and **erases the stock
 > firmware**. BIGTREETECH does **not** publish stock images, so **the full backup
 > you take is the ONLY way back to stock.** If you skip the backup (or lose the
 > file), there is **no going back** — you will be permanently on custom firmware.
@@ -110,22 +110,22 @@ idf.py build
 > **do not use `--no-backup`** unless you already have a known-good backup stored
 > somewhere safe. Copy the backup off your machine (cloud/USB) before flashing.
 
-**First install (stock → OpenBreath):** use the flasher, which backs up the
+**First install (stock → DragonBreath):** use the flasher, which backs up the
 *entire* stock flash to a timestamped image **before** writing anything, so you
 can return to stock. Flashing is over the on-board CH340K USB-C bridge
 (native USB is unavailable — GPIO18 is the SSR):
 ```bash
-python3 tools/flash.py                 # backup stock, then flash OpenBreath
+python3 tools/flash.py                 # backup stock, then flash DragonBreath
 python3 tools/flash.py --restore backups/stock-YYYYmmdd-HHMMSS.bin   # back to stock
 ```
-First boot with no stored WiFi starts an `OpenPanda_XXXX` AP + captive portal for
+First boot with no stored WiFi starts an `DragonBreath_XXXX` AP + captive portal for
 provisioning. The AP password is **`987654321`** (same as the stock Panda). Connect
 to it and a browser should pop the setup page automatically (or open `http://192.168.4.1`).
 
-**Updating OpenBreath:** once running, open the **Firmware update** link on the
-status page (the `/fw` page) and upload `build/openbreath.bin`. The image lands in
+**Updating DragonBreath:** once running, open the **Firmware update** link on the
+status page (the `/fw` page) and upload `build/dragonbreath.bin`. The image lands in
 the inactive OTA slot, is verified, and the device reboots into it; a bad image
-rolls back on the next boot. Web OTA is **OpenBreath-only** — it does **not**
+rolls back on the next boot. Web OTA is **DragonBreath-only** — it does **not**
 restore stock firmware (use `tools/flash.py --restore` for that) and is refused
 while the heater is on.
 
@@ -149,7 +149,7 @@ this project's `klipper-esp32` history and the OpenVent architecture
 ([justinh-rahb](https://github.com/justinh-rahb)). MIT licensed.
 
 ## Support
-If OpenBreath is useful to you, you can support development here:
+If DragonBreath is useful to you, you can support development here:
 
 [![Buy Me A Coffee](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://buymeacoffee.com/plastikman)
 [![Donate with PayPal](https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif)](https://www.paypal.com/donate/?business=MPMX47RUYQFKJ&no_recurring=1&currency_code=USD)

--- a/components/pb_httpd/include/pb_httpd.h
+++ b/components/pb_httpd/include/pb_httpd.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // pb_httpd — tiny HTTP control API so a Klipper-side helper can surface the
-// chamber in Fluidd (temp + settable target) and map M141/M191 to OpenBreath.
+// chamber in Fluidd (temp + settable target) and map M141/M191 to DragonBreath.
 //
 //   GET  /status       -> {temp,ptc,target,heating,fault,max}  READ-ONLY, no side effects
 //   POST /target?t=<C> -> set chamber setpoint in C (0=off); also counts as liveness
@@ -12,7 +12,7 @@
 // off. GET /status never feeds the watchdog. Start after WiFi is up.
 //
 // CSRF / control gate: every mutating endpoint (/target, /reset, /heartbeat, and
-// the portal's STA-mode /save) requires the custom header "X-OpenBreath-Auth".
+// the portal's STA-mode /save) requires the custom header "X-DragonBreath-Auth".
 // A cross-origin HTML form cannot set a custom header and we never enable CORS,
 // so an ordinary drive-by page cannot command the heater or rewrite its Wi-Fi
 // config. GET /status stays open (read-only). This is CSRF hardening for a
@@ -23,7 +23,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 
-#define PB_AUTH_HEADER "X-OpenBreath-Auth"
+#define PB_AUTH_HEADER "X-DragonBreath-Auth"
 
 esp_err_t pb_httpd_start(void);
 

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -199,7 +199,7 @@ static esp_err_t target_set(httpd_req_t *req)
     return httpd_resp_send(req, buf, n);
 }
 
-// POST /update — stream a new OpenBreath .bin into the inactive OTA slot, verify,
+// POST /update — stream a new DragonBreath .bin into the inactive OTA slot, verify,
 // set it as boot, and reboot. Auth-gated. SAFETY: refused while the heater is
 // armed/on — a reboot mid-heat leaves the SSR state undefined until re-init, so
 // the operator must turn the heater off first. Rollback (PENDING_VERIFY) means a
@@ -271,15 +271,15 @@ static esp_err_t update_post(httpd_req_t *req)
     if (err != ESP_OK)
         return ota_fail(req, "400 Bad Request", 0, "invalid firmware image");
 
-    // Identity check: only boot images that are actually OpenBreath — reject any
+    // Identity check: only boot images that are actually DragonBreath — reject any
     // other (even a valid ESP32-C3) app. The app descriptor's project_name comes
-    // from CMake project(openbreath).
+    // from CMake project(dragonbreath).
     esp_app_desc_t desc;
     if (esp_ota_get_partition_description(part, &desc) != ESP_OK)
         return ota_fail(req, "400 Bad Request", 0, "cannot read image descriptor");
-    if (strcmp(desc.project_name, "openbreath") != 0) {
-        ESP_LOGE(TAG, "OTA rejected: project_name='%s' (not openbreath)", desc.project_name);
-        return ota_fail(req, "400 Bad Request", 0, "not an OpenBreath image");
+    if (strcmp(desc.project_name, "dragonbreath") != 0) {
+        ESP_LOGE(TAG, "OTA rejected: project_name='%s' (not dragonbreath)", desc.project_name);
+        return ota_fail(req, "400 Bad Request", 0, "not an DragonBreath image");
     }
 
     if (esp_ota_set_boot_partition(part) != ESP_OK)

--- a/components/pb_portal/include/pb_portal.h
+++ b/components/pb_portal/include/pb_portal.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// pb_portal — captive-portal / config web UI for OpenBreath. Registers its
+// pb_portal — captive-portal / config web UI for DragonBreath. Registers its
 // handlers on the shared pb_httpd server and (in AP mode) runs a captive DNS.
 // Lets the user provision WiFi + Moonraker from a browser — nothing hardcoded.
 // Call after pb_httpd_start().

--- a/components/pb_portal/pb_portal.c
+++ b/components/pb_portal/pb_portal.c
@@ -23,19 +23,19 @@ static const char *TAG = "pb_portal";
 #define SEND(req, s) do { const char *_s = (s); if (_s && _s[0]) httpd_resp_send_chunk((req), _s, HTTPD_RESP_USE_STRLEN); } while (0)
 
 // Shared client-side auth helpers, injected into every control page's <script>.
-// window.OB_TOK holds the CSRF sentinel ("web") ONLY when no control token is
-// configured. When a token IS configured the device sets window.OB_NEEDTOK
+// window.DB_TOK holds the CSRF sentinel ("web") ONLY when no control token is
+// configured. When a token IS configured the device sets window.DB_NEEDTOK
 // instead and never emits the secret — we prompt for it and cache it in
 // localStorage, so a configured token is genuine auth rather than a value baked
 // into this public page. On a 403 the cached token is dropped and re-prompted.
-#define OB_AUTH_JS \
-    "function tok(){if(window.OB_TOK)return window.OB_TOK;" \
-    "var t=localStorage.getItem('ob_tok');" \
-    "if(!t){t=prompt('OpenBreath control token')||'';if(t)localStorage.setItem('ob_tok',t);}" \
+#define DB_AUTH_JS \
+    "function tok(){if(window.DB_TOK)return window.DB_TOK;" \
+    "var t=localStorage.getItem('db_tok');" \
+    "if(!t){t=prompt('DragonBreath control token')||'';if(t)localStorage.setItem('db_tok',t);}" \
     "return t;}" \
-    "function hdr(){return {'X-OpenBreath-Auth':tok()};}" \
+    "function hdr(){return {'X-DragonBreath-Auth':tok()};}" \
     "function post(u){return fetch(u,{method:'POST',headers:hdr()}).then(function(r){" \
-    "if(r.status==403){localStorage.removeItem('ob_tok');alert('Control token rejected \\u2014 try again.');}return r;});}"
+    "if(r.status==403){localStorage.removeItem('db_tok');alert('Control token rejected \\u2014 try again.');}return r;});}"
 
 // ---- form parsing (application/x-www-form-urlencoded) ----
 static int hexval(char c)
@@ -113,7 +113,7 @@ static void html_attr_escape(const char *in, char *out, size_t outsz)
 static const char PAGE_HEAD[] =
     "<!doctype html><html><head><meta charset=utf-8>"
     "<meta name=viewport content='width=device-width,initial-scale=1'>"
-    "<title>OpenPanda</title><style>"
+    "<title>DragonBreath</title><style>"
     ":root{--bg:#272525;--card:#333;--accent:#4087FE;--text:#F0F0F0;--input:#2c2c2c;--border:rgba(255,255,255,.12);color-scheme:dark}"
     "*{box-sizing:border-box}"
     "body{margin:0;background:var(--bg);font-family:Arial,Helvetica,sans-serif;color:var(--text)}"
@@ -133,7 +133,7 @@ static const char PAGE_HEAD[] =
     "button:disabled{opacity:.4;cursor:not-allowed}"
     ".srow{display:flex;justify-content:space-between;padding:8px 0;border-bottom:1px solid rgba(255,255,255,.07)}.srow:last-child{border:0}"
     "small{color:#8a8a8a}a{color:#4aa3ff}</style></head><body>"
-    "<div class=hdr><h1>\xF0\x9F\x90\xBC OpenPanda</h1><p>Panda Breath</p></div>"
+    "<div class=hdr><h1>\xF0\x9F\x90\xBC DragonBreath</h1><p>Panda Breath</p></div>"
     "<div class=wrap>";
 
 // Wi-Fi form card (config page).
@@ -166,11 +166,11 @@ static const char STATUS_BODY[] =
     "<p style='text-align:center'><small><a href='/setup'>Wi-Fi / printer setup</a>"
     " &middot; <a href='/fw'>Firmware update</a></small></p>"
     "<p style='text-align:center;margin-top:-6px'><small style='color:#6f6f6f'>"
-    "Firmware update installs <b>OpenBreath</b> updates only \xE2\x80\x94 it does <b>not</b> "
+    "Firmware update installs <b>DragonBreath</b> updates only \xE2\x80\x94 it does <b>not</b> "
     "restore the stock Panda firmware.</small></p>"
     "<div id=ver style='text-align:center;color:#5a5a5a;font-size:.72rem;margin-top:2px'></div></div>"
-    "<script>" OB_AUTH_JS
-    "if(window.OB_VER)document.getElementById('ver').textContent='OpenBreath '+window.OB_VER;"
+    "<script>" DB_AUTH_JS
+    "if(window.DB_VER)document.getElementById('ver').textContent='DragonBreath '+window.DB_VER;"
     // iOwn: did THIS tab start the current heat? We heartbeat ONLY then, so a
     // passive or freshly-reloaded dashboard (iOwn=false) never pets the comms
     // watchdog and therefore can't mask a Klippy/controller failure.
@@ -207,26 +207,26 @@ static const char STATUS_BODY[] =
     "refresh();setInterval(refresh,2000);"
     "</script></body></html>";
 
-// Dedicated firmware-update page (GET /fw) — OpenBreath OTA only, its own page so
+// Dedicated firmware-update page (GET /fw) — DragonBreath OTA only, its own page so
 // it isn't mixed in with Wi-Fi/printer setup.
 static const char FW_BODY[] =
     "<div class=card><h2>Firmware update</h2>"
     "<p style='margin:.2em 0 .7em;font-size:.85rem;color:#bdbdbd'>Installs an "
-    "<b>OpenBreath</b> firmware update (upload <code>openbreath.bin</code>). The "
+    "<b>DragonBreath</b> firmware update (upload <code>dragonbreath.bin</code>). The "
     "image is verified and the device reboots into it; a bad image rolls back on "
     "the next boot.</p>"
     "<div class=card style='background:#3a2f1f;color:#ffe0b0;font-size:.8rem'>"
     "\xE2\x9A\xA0 This does <b>not</b> restore the stock Panda firmware. To go back to "
     "stock, reflash your saved backup over USB with <code>tools/flash.py --restore</code>.</div>"
-    "<label>OpenBreath firmware (.bin)</label>"
+    "<label>DragonBreath firmware (.bin)</label>"
     "<input type=file id=fw accept='.bin' onchange='fwsel()'>"
     "<button type=button id=fwbtn class=go onclick='doUpdate()' disabled>Upload &amp; flash</button>"
     "<div id=fwmsg style='margin-top:.6em;word-break:break-all'><small>Turn the heater OFF first "
     "(updates are refused while heating). Do not power off during the update.</small></div></div>"
     "<p style='text-align:center'><small><a href='/'>\xE2\x86\x90 Back to status</a></small></p>"
     "<div id=ver style='text-align:center;color:#5a5a5a;font-size:.72rem;margin-top:2px'></div></div>"
-    "<script>" OB_AUTH_JS
-    "if(window.OB_VER)document.getElementById('ver').textContent='OpenBreath '+window.OB_VER;"
+    "<script>" DB_AUTH_JS
+    "if(window.DB_VER)document.getElementById('ver').textContent='DragonBreath '+window.DB_VER;"
     // Enable the flash button only once a file is chosen.
     "function fwsel(){document.getElementById('fwbtn').disabled=!document.getElementById('fw').files.length;}"
     // Stream the chosen .bin to /update with the auth header; device validates,
@@ -251,8 +251,8 @@ static const char PAGE_TAIL[] =
     "<button type=submit class=go>Save &amp; Connect</button></form>"
     "<div id=msg style='text-align:center'><small>The device reboots and joins your network after saving.</small></div>"
     "<p style='text-align:center'><small><a href='/fw'>Firmware update</a></small></p></div>"
-    "<script>" OB_AUTH_JS
-    // Submit via fetch so we can attach the X-OpenBreath-Auth header (a plain form
+    "<script>" DB_AUTH_JS
+    // Submit via fetch so we can attach the X-DragonBreath-Auth header (a plain form
     // POST can't). Required in STA /setup (the /save handler gates on it there);
     // harmless in AP mode. The device reboots on save, so a dropped connection on
     // the .then/.catch is the expected success path.
@@ -276,22 +276,22 @@ static const char PAGE_TAIL[] =
 
 // Inject the client-side auth bootstrap. If a control token is configured we emit
 // only a NEEDTOK flag (never the secret) so the page prompts for it; otherwise we
-// emit the "web" CSRF sentinel. Paired with OB_AUTH_JS's tok()/hdr().
+// emit the "web" CSRF sentinel. Paired with DB_AUTH_JS's tok()/hdr().
 static void send_auth_inject(httpd_req_t *req)
 {
     char tok[65];
     pb_httpd_ctl_token(tok, sizeof tok);   // 65-byte buffer: never false-negative
     SEND(req, tok[0]
-        ? "<script>window.OB_NEEDTOK=1;</script>"
-        : "<script>window.OB_TOK=\"web\";</script>");
+        ? "<script>window.DB_NEEDTOK=1;</script>"
+        : "<script>window.DB_TOK=\"web\";</script>");
 }
 
 // Inject the firmware version (git tag for releases, short hash for PR/local) as
-// window.OB_VER so pages can show it. From the ESP app descriptor (see CMakeLists).
+// window.DB_VER so pages can show it. From the ESP app descriptor (see CMakeLists).
 static void send_version_inject(httpd_req_t *req)
 {
     char b[128];
-    snprintf(b, sizeof b, "<script>window.OB_VER=\"%s\";</script>",
+    snprintf(b, sizeof b, "<script>window.DB_VER=\"%s\";</script>",
              esp_app_get_description()->version);
     SEND(req, b);
 }
@@ -400,7 +400,7 @@ static esp_err_t save_post(httpd_req_t *req)
     if (pv_wifi_state() != PV_WIFI_STATE_AP_PORTAL && !pb_httpd_auth_ok(req)) {
         httpd_resp_set_status(req, "403 Forbidden");
         httpd_resp_set_type(req, "application/json");
-        return httpd_resp_sendstr(req, "{\"error\":\"missing/invalid X-OpenBreath-Auth header\"}");
+        return httpd_resp_sendstr(req, "{\"error\":\"missing/invalid X-DragonBreath-Auth header\"}");
     }
 
     char body[640];

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -2,5 +2,5 @@ idf_component_register(
     SRCS "app_main.c"
     INCLUDE_DIRS "."
     REQUIRES pb_board pb_ntc pb_heater pb_fan pb_policy pb_httpd pb_portal
-             pv_wifi pv_moonraker nvs_flash esp_wifi app_update
+             pv_wifi pv_moonraker nvs_flash esp_wifi esp_netif mdns app_update
 )

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenBreath — open firmware for the BIGTREETECH Panda Breath (ESP32-C3).
+// DragonBreath — open firmware for the BIGTREETECH Panda Breath (ESP32-C3).
 //
 // Safety-first init: the heater SSR is forced OFF before anything can request
 // heat, and the control/telemetry loop is started BEFORE networking so it runs
@@ -17,6 +17,7 @@
 #include "nvs_flash.h"
 #include "nvs.h"
 #include <stdbool.h>
+#include <string.h>
 
 #include "pb_board.h"
 #include "pb_ntc.h"
@@ -26,6 +27,8 @@
 
 #include "esp_wifi.h"
 #include "esp_mac.h"
+#include "esp_netif.h"
+#include "mdns.h"
 #include "pv_wifi.h"
 #include "pv_moonraker.h"
 
@@ -41,7 +44,7 @@
 #  endif
 #endif
 
-static const char *TAG = "openbreath";
+static const char *TAG = "dragonbreath";
 
 #define PB_TICK_PERIOD_MS 500
 
@@ -52,29 +55,53 @@ static volatile bool s_net_up = false;
 // failed to initialize (its internal state/mutex may be unset).
 static volatile bool s_mk_up = false;
 
-// Brand the captive-portal AP as "OpenPanda_XXXX". The shared pv_wifi reads the
-// AP SSID from NVS (key "ap_ssid"), so we override its "OpenVent_" default this
-// way without patching the shared component. (mDNS hostname stays OpenVent.local
-// until pv_wifi is made configurable upstream.)
+// Brand the captive-portal AP as "DragonBreath_XXXX". The shared pv_wifi reads the
+// AP SSID from NVS (key "ap_ssid"), so we override its "OpenVent_" default this way
+// without patching the shared component. We also migrate the previous "OpenPanda_"
+// default (pre-DragonBreath rebrand) so an already-provisioned device adopts the new
+// name, while preserving any user-customized SSID. (mDNS hostname is overridden
+// separately in brand_hostname().)
 static void brand_ap(void)
 {
     nvs_handle_t h;
     if (nvs_open("app_nvs", NVS_READWRITE, &h) != ESP_OK) return;
-    // Only set the default once — don't rewrite NVS (flash wear) every boot, and
-    // don't clobber a user-customized AP name.
-    size_t sz = 0;
-    if (nvs_get_str(h, "ap_ssid", NULL, &sz) == ESP_OK && sz > 1) {
+    // Set the default once (avoid NVS flash wear each boot) and never clobber a
+    // user-customized name — but DO migrate the legacy "OpenPanda_" default.
+    char cur[33] = {0};
+    size_t sz = sizeof cur;
+    esp_err_t r = nvs_get_str(h, "ap_ssid", cur, &sz);
+    if (r == ESP_OK && sz > 1 && strncmp(cur, "OpenPanda_", 10) != 0) {
         nvs_close(h);
         return;
     }
     uint8_t mac[6] = {0};
     esp_read_mac(mac, ESP_MAC_WIFI_SOFTAP);
     char ssid[33];
-    snprintf(ssid, sizeof ssid, "OpenPanda_%02X%02X", mac[4], mac[5]);
+    snprintf(ssid, sizeof ssid, "DragonBreath_%02X%02X", mac[4], mac[5]);
     nvs_set_str(h, "ap_ssid", ssid);
     nvs_commit(h);
     nvs_close(h);
     ESP_LOGI(TAG, "AP SSID default set: %s", ssid);
+}
+
+// Override the shared pv_wifi mDNS/netif hostname ("OpenVent") so the device
+// advertises as dragonbreath.local, WITHOUT patching the OpenVent submodule.
+// Call AFTER pv_wifi_start() (which runs mdns_init + sets the OpenVent default);
+// these calls just update the already-registered records. Best-effort / log-only:
+// a failure only means the device keeps the OpenVent.local name — it never affects
+// the safety loop or WiFi. (Interim until the shared core exposes a hostname API —
+// see plans/rebrand-dragonbreath.md.)
+static void brand_hostname(void)
+{
+    static const char *HN = "dragonbreath";
+    esp_netif_t *sta = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+    esp_netif_t *ap  = esp_netif_get_handle_from_ifkey("WIFI_AP_DEF");
+    if (sta) esp_netif_set_hostname(sta, HN);
+    if (ap)  esp_netif_set_hostname(ap, HN);
+    mdns_hostname_set(HN);
+    mdns_instance_name_set(HN);
+    mdns_service_instance_name_set("_http", "_tcp", HN);
+    ESP_LOGI(TAG, "mDNS hostname override: %s.local", HN);
 }
 
 static void nvs_init(void)
@@ -86,7 +113,7 @@ static void nvs_init(void)
     }
 }
 
-#if defined(OB_WIFI_SSID) || defined(OB_MOONRAKER_HOST)
+#if defined(DB_WIFI_SSID) || defined(DB_MOONRAKER_HOST)
 // Dev-only: seed WiFi creds + Moonraker config into the NVS layout the shared
 // components load at start (namespace app_nvs; keys ssid/password + mk_host/mk_port).
 // This is what the portal would normally write. IMPORTANT: seed via NVS and let
@@ -105,13 +132,13 @@ static void seed_dev_config(void)
         ESP_LOGI(TAG, "WiFi creds already in NVS; not seeding dev_config");
         return;
     }
-#ifdef OB_WIFI_SSID
-    nvs_set_str(h, "ssid", OB_WIFI_SSID);
-    nvs_set_str(h, "password", OB_WIFI_PASS);
+#ifdef DB_WIFI_SSID
+    nvs_set_str(h, "ssid", DB_WIFI_SSID);
+    nvs_set_str(h, "password", DB_WIFI_PASS);
 #endif
-#ifdef OB_MOONRAKER_HOST
-    nvs_set_str(h, "mk_host", OB_MOONRAKER_HOST);
-    nvs_set_u16(h, "mk_port", OB_MOONRAKER_PORT);
+#ifdef DB_MOONRAKER_HOST
+    nvs_set_str(h, "mk_host", DB_MOONRAKER_HOST);
+    nvs_set_u16(h, "mk_port", DB_MOONRAKER_PORT);
 #endif
     nvs_commit(h);
     nvs_close(h);
@@ -168,7 +195,7 @@ static void control_task(void *arg)
 
 void app_main(void)
 {
-    ESP_LOGI(TAG, "OpenBreath starting");
+    ESP_LOGI(TAG, "DragonBreath starting");
 
     pb_board_init();
     ESP_ERROR_CHECK(pb_heater_init());     // SSR forced OFF before anything else
@@ -184,8 +211,8 @@ void app_main(void)
     // Bring up networking. If a start call blocks under a flaky link, the control
     // loop above is already running, so safety + telemetry continue.
     nvs_init();
-    brand_ap();                              // AP name = OpenPanda_XXXX
-#if defined(OB_WIFI_SSID) || defined(OB_MOONRAKER_HOST)
+    brand_ap();                              // AP name = DragonBreath_XXXX
+#if defined(DB_WIFI_SSID) || defined(DB_MOONRAKER_HOST)
     seed_dev_config();
 #endif
     // Network bring-up is LOG-AND-CONTINUE, never ESP_ERROR_CHECK: a transient
@@ -194,6 +221,8 @@ void app_main(void)
     esp_err_t e;
     if ((e = pv_wifi_start()) != ESP_OK)
         ESP_LOGE(TAG, "pv_wifi_start: %s (continuing; safety loop unaffected)", esp_err_to_name(e));
+    else
+        brand_hostname();                    // advertise as dragonbreath.local
     // Mains-powered device: disable WiFi modem-sleep so the control API stays
     // responsive (power-save adds ~0.5s latency spikes to incoming requests).
     esp_wifi_set_ps(WIFI_PS_NONE);

--- a/main/dev_config.h.example
+++ b/main/dev_config.h.example
@@ -2,7 +2,7 @@
 // Copy this file to `dev_config.h` (gitignored) and fill in your values for local
 // hardware bring-up. Without dev_config.h the firmware still builds — it just
 // comes up unconfigured (no WiFi credentials seeded).
-#define OB_WIFI_SSID       "your-2.4GHz-ssid"
-#define OB_WIFI_PASS       "your-wifi-password"
-#define OB_MOONRAKER_HOST  "192.168.1.50"   // IP/hostname of the printer running Moonraker
-#define OB_MOONRAKER_PORT  7125
+#define DB_WIFI_SSID       "your-2.4GHz-ssid"
+#define DB_WIFI_PASS       "your-wifi-password"
+#define DB_MOONRAKER_HOST  "192.168.1.50"   // IP/hostname of the printer running Moonraker
+#define DB_MOONRAKER_PORT  7125

--- a/partitions.csv
+++ b/partitions.csv
@@ -1,4 +1,4 @@
-# OpenBreath partition table — ESP32-C3, 4MB flash, dual-OTA.
+# DragonBreath partition table — ESP32-C3, 4MB flash, dual-OTA.
 #
 # TODO (before first flash): reconcile the flashing strategy.
 #   - If we KEEP the stock 2nd-stage bootloader, this table's offsets/layout must

--- a/plans/rebrand-dragonbreath.md
+++ b/plans/rebrand-dragonbreath.md
@@ -1,0 +1,114 @@
+# Rebrand: OpenBreath → DragonBreath
+
+> **Status:** proposal / RFC — sharing for input before execution.
+> **Owner:** plastikman. Justin's review is advisory (esp. the OpenVent shared-core boundary — see *Input wanted*).
+
+## Context
+We're renaming the open chamber-heater project **OpenBreath → DragonBreath** (one word).
+It's a cooler, on-the-nose name (a chamber heater that "breathes" hot air) and it clears up
+a real naming problem: **"OpenBreath" is crowded** — it collides with the CERN open-hardware
+*OpenBreath lung ventilator* and a Hackaday 3D-printed ventilator, so "OpenBreath" reads as
+"open-source ventilator" to search engines. **"DragonBreath"** is unused in the
+3D-printing / Klipper / chamber-heater space. (It does share a name with a niche Windows-malware
+APT campaign, but that's irrelevant to a printer-firmware audience and was explicitly accepted.)
+
+This affects three repos plus the PAXX firmware overlay:
+- **`plastikman/OpenBreath`** — the ESP-IDF device firmware (`project(openbreath)`, ESP32-C3).
+- **`plastikman/openbreath-klipper`** — the Klipper `extras` helper that drives the firmware's HTTP API.
+- **PAXX overlay** (`SnapmakerU1-Extended-Firmware` fork) — installs the helper, ships the cfg, and
+  provides the "Chamber Heater" settings dropdown.
+- *Not affected:* `klipper-esp32` (a separate Klipper-MCU port) and the shared **OpenVent** core submodule.
+
+## Decisions (locked with the owner)
+- **Clean break** — no backward-compat aliases. There's no meaningful external OpenBreath user base
+  yet, so existing `printer.cfg` users would edit config + reflash. Simpler and cleaner than shims.
+- **Full scope** — firmware, Klipper helper, PAXX overlay, and the GitHub repos all rename.
+- **Rename reach = everything, including network identity** — rename the WiFi AP SSID and override the
+  mDNS hostname (details below). Keep **"Panda Breath"** only as the underlying BIQU *hardware*
+  descriptor. **Do not rebrand the shared OpenVent submodule.**
+- **Migration = USB reflash** — the firmware's OTA image-identity gate rejects a cross-brand OTA, so
+  the first DragonBreath image is flashed over USB; OTA works normally afterward.
+- **Naming convention** — `DragonBreath` for display/class names; lowercase `dragonbreath` for config
+  keys, filenames, identifiers, and the hostname (mirrors today's lowercase `openbreath`).
+
+## ⭐ Input wanted from Justin — the OpenVent shared-core boundary
+The firmware sits on the shared **OpenVent** core (`external/OpenVent/…`, `pv_wifi`/`pv_evlog`/
+`pv_moonraker`). Two "everything" rename items touch that boundary, and we want to keep them
+**upstream-friendly** (no edits to the submodule):
+1. **mDNS hostname.** Today it inherits `PV_WIFI_HOSTNAME = "OpenVent"` → `OpenVent.local`. Plan is to
+   override it to `dragonbreath` **from the app layer** (`main/app_main.c`, right where the SSID prefix
+   is already overridden), leaving `external/OpenVent/.../pv_wifi.h` untouched. **Is app-layer override
+   the intended extension point, or should the core expose a cleaner hostname-override API?**
+2. **WiFi AP SSID.** Today `OpenPanda_XXXX` (an app-layer override of the core's `OpenVent_` default).
+   Plan changes it to `DragonBreath_XXXX`. Same mechanism — flagging in case you'd prefer a
+   core-level convention.
+
+Everything else below is app/product-level and doesn't touch OpenVent.
+
+## Wire contract — must flip in lockstep (firmware + helper)
+- **HTTP auth header** `X-OpenBreath-Auth` → `X-DragonBreath-Auth` — firmware `PB_AUTH_HEADER`
+  (`components/pb_httpd/include/pb_httpd.h`), the portal JS + its `ob_tok` localStorage key
+  (`pb_portal.c`), and the Klipper helper all validate/send it. Change together or auth breaks.
+- **Klipper module name** `openbreath` → `dragonbreath` drives the config section `[dragonbreath]`,
+  `sensor_type: dragonbreath`, the `heater_pin: dragonbreath:pwm` chip, and the overlay cfg + settings
+  state key — these move as one unit.
+- **Brand-neutral — deliberately unchanged:** HTTP route paths (`/status /target /heartbeat /reset
+  /update`), JSON field names, and the NVS namespace `app_nvs` + keys (`ctl_token`, …). Because no NVS
+  key is named after the project, **the rename does NOT wipe device settings.**
+
+## Footprint by repo
+
+### 1. Device firmware (`OpenBreath` → repo `DragonBreath`)
+- **Build identity:** `CMakeLists.txt` `project(openbreath)` → `project(dragonbreath)`; banner/version vars `OB_*` → `DB_*`.
+- **OTA identity gate (why USB reflash is needed):** `pb_httpd.c` rejects any uploaded image whose
+  `project_name != "openbreath"`. Flip to `"dragonbreath"`; deployed units can't OTA across the rename.
+- **Image name:** `openbreath.bin` → `dragonbreath.bin` (`tools/flash.py`, portal OTA copy, README).
+- **Auth header / SSID / hostname:** as in the wire-contract + shared-core sections above.
+- **Cosmetic:** log tag + boot logs, web-UI OpenBreath strings and title (`OpenPanda` → `DragonBreath`,
+  keeping the "Panda Breath" hardware subtitle), `docs/`, `plans/`, README prose, repo URLs.
+
+### 2. Klipper helper (`openbreath-klipper` → `dragonbreath-klipper`)
+- git-rename `openbreath.py` → `dragonbreath.py` (⚠ the filename *is* the Klipper config-section name),
+  `config/openbreath.cfg` → `dragonbreath.cfg`, and the repo.
+- In the module: class names `OpenBreath*`/`_OpenBreathHTTP` → `DragonBreath*`; the sensor-factory and
+  pin-chip registration strings; `OPENBREATH_RESET` → `DRAGONBREATH_RESET`; the auth header; log prefixes.
+- cfg / README / `install.sh`: section names, `sensor_type`, `heater_pin`, `[heater_generic dragonbreath]`,
+  `HEATER=dragonbreath`, clone URL/paths, Moonraker `[update_manager dragonbreath-klipper]`, example host
+  `dragonbreath.local`.
+- Tests (`tests/test_async_transport.py`) update imports; re-run (9/9, incl. `-W error::ResourceWarning`).
+
+### 3. PAXX overlay (`37-feature-chamber-heater/`)
+- git-rename the install script + the two shipped cfg fragments to `dragonbreath*`.
+- install script: point `GIT_URL` at the renamed helper repo and **bump `GIT_SHA`** to its new main HEAD;
+  update install paths + echoes.
+- cfg fragments: all `[dragonbreath]` / `heater_generic` / `heater_pin` / `sensor_type` / `verify_heater`
+  / `HEATER=` / `SENSOR=` refs + the `X-DragonBreath-Auth` comment + example host.
+- Settings YAML (`25_settings_snapmaker_components_chamber_heater.yaml`): keep the 3-option dropdown
+  (**Disabled / Panda Auto / DragonBreath**); rename the option key, get_cmd state key + `.cfg` detection,
+  `OPENBREATH_IP` → `DRAGONBREATH_IP`, the config-writer section arg, `help_url`, and all display strings.
+
+### 4. GitHub repos/org
+- Rename `plastikman/openbreath-klipper` → `dragonbreath-klipper` and `plastikman/OpenBreath` →
+  `DragonBreath` (GitHub keeps redirects). Update every cross-link (install-script `GIT_URL`, READMEs,
+  settings `help_url`, `update_manager` origin).
+
+## Sequencing (avoids a broken-build window)
+1. Rename the **helper repo** (files + tokens), tests green, merge → capture new main SHA.
+2. Rename the **firmware** (project/OTA gate/header/SSID/hostname/UI), build.
+3. **USB-reflash** the device; confirm boot + `dragonbreath.local`.
+4. Update the **PAXX overlay** (new `GIT_URL` + `GIT_SHA`, cfg/YAML) on a branch; build via CI.
+5. Do the **GitHub repo renames** (redirects cover stragglers).
+6. Flash the new PAXX firmware to the U1; verify end-to-end.
+
+## Verification
+- Helper: `python3 tests/test_async_transport.py` (9/9) + `py_compile`.
+- Firmware: builds; after USB flash, `dragonbreath.local` resolves, web UI shows DragonBreath, and the
+  OTA gate now accepts `dragonbreath` images.
+- End-to-end on the U1: `[dragonbreath]` loads, `SET_HEATER_TEMPERATURE HEATER=dragonbreath` drives the
+  device, the helper authenticates with `X-DragonBreath-Auth`, Fluidd shows the DragonBreath heater.
+  *(Reminder: reloading a changed `extras/*.py` needs a klippy **process** restart, not FIRMWARE_RESTART.)*
+
+## Out of scope
+- The shared **OpenVent** submodule and the "Panda Breath" hardware descriptor.
+- The separate device-side Wi-Fi/HTTP "flap" bug (tracked independently).
+- The chamber-heater dropdown structure is unchanged (Disabled / Panda Auto / DragonBreath; MQTT already dropped).

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -1,4 +1,4 @@
-# OpenBreath default sdkconfig — ESP32-C3-MINI-1 (4MB flash)
+# DragonBreath default sdkconfig — ESP32-C3-MINI-1 (4MB flash)
 CONFIG_IDF_TARGET="esp32c3"
 
 # Flash / partitions

--- a/tools/flash.py
+++ b/tools/flash.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
-"""OpenBreath installer/flasher for the BIGTREETECH Panda Breath (ESP32-C3).
+"""DragonBreath installer/flasher for the BIGTREETECH Panda Breath (ESP32-C3).
 
 *** READ THIS FIRST ***
-Installing OpenBreath OVERWRITES THE ENTIRE FLASH and ERASES the stock firmware.
+Installing DragonBreath OVERWRITES THE ENTIRE FLASH and ERASES the stock firmware.
 BIGTREETECH does not publish stock images, so THE FULL BACKUP THIS TOOL TAKES IS
 THE ONLY WAY BACK TO STOCK. If you skip the backup or lose the backup file, THERE
 IS NO GOING BACK. Store the backup somewhere safe (copy it off this machine).
 
 Backs up the ENTIRE existing flash to a timestamped file BEFORE writing anything,
-then flashes the OpenBreath build. The backup is a full 4 MB image, so you can
+then flashes the DragonBreath build. The backup is a full 4 MB image, so you can
 return to stock:
 
-    # First-time install (back up stock, then flash OpenBreath):
+    # First-time install (back up stock, then flash DragonBreath):
     python3 tools/flash.py
 
     # Restore a previous backup (e.g. go back to stock):
@@ -34,12 +34,12 @@ import sys
 
 CHIP = "esp32c3"
 FLASH_SIZE = 0x400000  # 4 MB
-# OpenBreath image layout (matches build/flash_args / partitions.csv).
+# DragonBreath image layout (matches build/flash_args / partitions.csv).
 IMAGES = [
     ("0x0",      "bootloader/bootloader.bin"),
     ("0x8000",   "partition_table/partition-table.bin"),
     ("0xf000",   "ota_data_initial.bin"),
-    ("0x20000",  "openbreath.bin"),
+    ("0x20000",  "dragonbreath.bin"),
 ]
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -129,8 +129,8 @@ def do_flash(port, baud, build_dir):
             print("       Build first:  idf.py set-target esp32c3 && idf.py build")
             return 1
         args += [offset, p]
-    app = os.path.join(build_dir, "openbreath.bin")
-    print(f"\n[3/3] Flashing OpenBreath from {build_dir}")
+    app = os.path.join(build_dir, "dragonbreath.bin")
+    print(f"\n[3/3] Flashing DragonBreath from {build_dir}")
     print(f"      app image SHA-256: {sha256_file(app)}")
     return run(esptool_cmd(port, baud,
                            "--before", "default_reset", "--after", "hard_reset",
@@ -174,7 +174,7 @@ def do_restore(port, baud, image):
 
 
 def main():
-    ap = argparse.ArgumentParser(description="OpenBreath flasher (backs up stock first).")
+    ap = argparse.ArgumentParser(description="DragonBreath flasher (backs up stock first).")
     ap.add_argument("--port", help="serial port (default: esptool auto-detect)")
     ap.add_argument("--baud", type=int, default=460800, help="baud rate (default 460800)")
     ap.add_argument("--build-dir", default=os.path.join(REPO_ROOT, "build"),
@@ -194,7 +194,7 @@ def main():
         return do_restore(args.port, args.baud, args.restore)
 
     print("=" * 70)
-    print(" OpenBreath flasher")
+    print(" DragonBreath flasher")
     print(" !! THIS OVERWRITES THE WHOLE DEVICE AND ERASES THE STOCK FIRMWARE !!")
     print(" There is NO way back to stock without a full backup, and BIGTREETECH")
     print(" does not publish stock images. The backup taken below is your ONLY")
@@ -215,15 +215,15 @@ def main():
         print(f"\n*** IMPORTANT: keep {path} safe — it is the ONLY way back to")
         print("*** stock. Copy it off this machine (cloud/USB) before continuing. ***")
 
-    print("\n[2/3] Ready to flash OpenBreath.")
+    print("\n[2/3] Ready to flash DragonBreath.")
     if not confirm("Proceed with flashing?"):
         print("Aborted. Your backup (if taken) is kept.")
         return 1
 
     rc = do_flash(args.port, args.baud, args.build_dir)
     if rc == 0:
-        print("\nDone. The board reboots into OpenBreath. On first boot with no saved")
-        print("Wi-Fi it starts an 'OpenPanda_XXXX' AP — connect and open http://192.168.4.1")
+        print("\nDone. The board reboots into DragonBreath. On first boot with no saved")
+        print("Wi-Fi it starts an 'DragonBreath_XXXX' AP — connect and open http://192.168.4.1")
     else:
         print("\nFlash FAILED. If the board is unresponsive, restore your backup:")
         print("  python3 tools/flash.py --restore <backup.bin>")


### PR DESCRIPTION
Device-firmware rebrand (clean break). project/OTA-gate/image/auth-header/SSID/hostname/UI/docs renamed; app-layer mDNS override (no submodule patch); builds clean on ESP-IDF v5.3. Part of the DragonBreath rebrand (RFC #2).