### PR TITLE
feat: post-print fan cooldown above 40°C

### DIFF
--- a/components/pb_policy/pb_policy.c
+++ b/components/pb_policy/pb_policy.c
@@ -50,12 +50,16 @@ void pb_policy_tick(void)
 
     // Post-print cooldown: once the heater has run, keep airflow going after it
     // turns off until the chamber cools below the threshold, then disarm (don't
-    // re-trigger until the next heating session). Smoothed chamber temp; a NAN /
-    // failed reading disarms rather than fanning blindly.
+    // re-trigger until the next heating session). Only trust the smoothed temp if
+    // the latest read was OK — on a sensor fault pb_ntc_smoothed_c() keeps
+    // returning the last (stale) moving average, NOT NaN, which could otherwise
+    // pin the fan on forever. On fault/no-reading, disarm; the heater's own fault
+    // path (pb_heater_is_faulted) still drives airflow if it latches.
     bool cooldown = false;
     if (!heat && s_heated_this_session) {
         float chamber_c = pb_ntc_smoothed_c(PB_NTC_CHAMBER);
-        if (!isnan(chamber_c) && chamber_c > PB_COOLDOWN_TEMP_C) {
+        if (pb_ntc_last_status(PB_NTC_CHAMBER) == PB_NTC_OK
+                && !isnan(chamber_c) && chamber_c > PB_COOLDOWN_TEMP_C) {
             cooldown = true;
         } else {
             s_heated_this_session = false;

--- a/components/pb_policy/pb_policy.c
+++ b/components/pb_policy/pb_policy.c
@@ -2,16 +2,31 @@
 #include "pb_policy.h"
 #include "pb_heater.h"
 #include "pb_fan.h"
+#include "pb_ntc.h"
 
 #include "esp_log.h"
+#include <math.h>
 
 static const char *TAG = "pb_policy";
 
+// Post-print cooldown: after the heater has run this session, keep the fan going
+// until the chamber falls below this threshold. NOT a temperature trigger on its
+// own — it is gated by s_heated_this_session (see below).
+#define PB_COOLDOWN_TEMP_C 40.0f
+
 static uint8_t s_requested_fan;
+
+// Set true the moment the heater enters heat mode this power cycle; this (not the
+// chamber temperature) is what arms the post-print cooldown. Deliberately RAM-only
+// / never persisted: a power cycle clears it, so a reboot-while-hot must NOT spin
+// the fan. The fan only ever *continues* cooling after an actual heating session —
+// it never auto-starts on temperature alone.
+static bool s_heated_this_session;
 
 esp_err_t pb_policy_init(void)
 {
     s_requested_fan = 0;
+    s_heated_this_session = false;
     ESP_LOGI(TAG, "init");
     return ESP_OK;
 }
@@ -28,11 +43,30 @@ void pb_policy_tick(void)
 {
     pb_heater_tick();
 
+    bool heat = pb_heater_heat_mode();
+    // Latch that the heater ran this session — this (not the chamber temp) arms
+    // the post-print cooldown, so the fan never auto-starts on temperature alone.
+    if (heat) s_heated_this_session = true;
+
+    // Post-print cooldown: once the heater has run, keep airflow going after it
+    // turns off until the chamber cools below the threshold, then disarm (don't
+    // re-trigger until the next heating session). Smoothed chamber temp; a NAN /
+    // failed reading disarms rather than fanning blindly.
+    bool cooldown = false;
+    if (!heat && s_heated_this_session) {
+        float chamber_c = pb_ntc_smoothed_c(PB_NTC_CHAMBER);
+        if (!isnan(chamber_c) && chamber_c > PB_COOLDOWN_TEMP_C) {
+            cooldown = true;
+        } else {
+            s_heated_this_session = false;
+        }
+    }
+
     // Ensure airflow while in heat mode (steady across the SSR's bang-bang
-    // cycling — not pb_heater_is_on(), which chatters) AND while a fault is
-    // latched, so a just-tripped over-temp chamber keeps getting cooled until the
-    // operator resets. Otherwise honor the requested fan level.
-    bool want_airflow = pb_heater_heat_mode() || pb_heater_is_faulted();
+    // cycling — not pb_heater_is_on(), which chatters), while a fault is latched
+    // (keep cooling a just-tripped over-temp chamber until the operator resets),
+    // and during the post-print cooldown. Otherwise honor the requested fan level.
+    bool want_airflow = heat || pb_heater_is_faulted() || cooldown;
     if (want_airflow && s_requested_fan < 30) {
         pb_fan_set_level(30);
     } else {


### PR DESCRIPTION
## What
After a print, keep the blower running until the chamber cools below **40 °C**, then stop — so the chamber self-cools after heating instead of holding residual heat (and a just-tripped over-temp chamber keeps getting cooled).

## Behaviour / decision
Gated on a **RAM-only "heater ran this session" flag** (set when `pb_heater_heat_mode()` goes true), **not** on chamber temperature alone:
- ✅ Fan **continues** cooling after the target drops to 0, while chamber > 40 °C.
- ✅ Never **auto-starts** on temperature — a warm chamber for other reasons (hot day, ambient) does nothing.
- ✅ **Power-cycle-while-hot → fan stays off** (flag isn't persisted). This was the explicit requirement: "no one wants the fan blowing if they didn't just finish a print."
- Disarms once cooled below 40 °C (no re-trigger until the next heat cycle); a NAN/failed chamber read disarms rather than fanning blindly.

## Implementation
All in `pb_policy_tick()` (`components/pb_policy/pb_policy.c`) — the existing fan-control point. Adds `s_heated_this_session` + a `PB_COOLDOWN_TEMP_C` (40 °C) check against the smoothed chamber temp (`pb_ntc_smoothed_c(PB_NTC_CHAMBER)`). No API/CMake changes (`pb_ntc` was already a dependency). Builds clean on ESP-IDF v5.3 (esp32c3).

## Test plan (on device)
1. Set a target ≥ ~45 °C, let the chamber pass 40 °C.
2. Set target 0 (end print) → **fan keeps running**; watch chamber fall; **fan stops when it drops below 40 °C**.
3. Heat > 40 °C, then **power-cycle** → after boot the **fan stays off** despite the hot chamber.
4. Cold boot / warm ambient with no heating → fan stays off.

Credit: cooldown idea from wildtang3nt (@justinh-rahb); session-gating requirement from @plastikman.

