### PR TITLE
ci: reproducible firmware releases + CHANGELOG (Phase 0.2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: firmware-release
+
+# Cut a reproducible release from a tag (Phase 0.2). Pushing a tag like v0.2.0
+# builds the firmware in CI and publishes a GitHub Release with a single-file
+# first-install image, the OTA app image, a complete install bundle, a provenance
+# manifest, and SHA-256 checksums. workflow_dispatch produces a DRAFT for dry runs.
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+# Least-privilege: only the release job needs write, to create the Release.
+permissions:
+  contents: write
+
+concurrency:
+  group: firmware-release-${{ github.ref }}
+  cancel-in-progress: false   # never cancel a release mid-publish
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Determine version
+        id: ver
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            V="${{ github.ref_name }}"
+          else
+            V="$(git describe --tags --always --dirty)"
+          fi
+          echo "version=$V" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Build (ESP-IDF v5.3.5)
+        uses: espressif/esp-idf-ci-action@9d38657f3d789ca759b2b37aaf5ceffbc42c4f0d # v1
+        with:
+          esp_idf_version: v5.3.5
+          target: esp32c3
+          path: '.'
+
+      - name: Package release artifacts
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          SOURCE_SHA: ${{ github.sha }}
+          IDF_VERSION: v5.3.5
+        run: |
+          # esptool for the merged factory image (script falls back to python -m esptool)
+          pipx install esptool >/dev/null 2>&1 \
+            || pip install --user esptool \
+            || pip install --user --break-system-packages esptool
+          export PATH="$HOME/.local/bin:$PATH"
+          ./tools/package_release.sh
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.ver.outputs.version }}
+          IS_TAG: ${{ github.ref_type == 'tag' }}
+        run: |
+          notes="$(cat <<EOF
+          DragonBreath firmware \`${VERSION}\` — BIGTREETECH Panda Breath (ESP32-C3).
+
+          **First install (USB):**
+          \`\`\`
+          esptool.py --chip esp32c3 write_flash 0x0 dragonbreath-${VERSION}-factory.bin
+          \`\`\`
+          **OTA update** (device already on DragonBreath): upload \`dragonbreath-${VERSION}.bin\` via the web UI (\`/fw\`).
+
+          | asset | purpose |
+          |---|---|
+          | \`dragonbreath-${VERSION}-factory.bin\` | single-file first install (flash @ 0x0) |
+          | \`dragonbreath-${VERSION}.bin\` | application image for OTA |
+          | \`dragonbreath-${VERSION}-install-bundle.zip\` | all components + flasher + FLASHING.txt |
+          | \`manifest.json\` | provenance (source SHA, ESP-IDF, submodule) + per-artifact SHA-256 |
+          | \`SHA256SUMS.txt\` | \`sha256sum -c SHA256SUMS.txt\` |
+          EOF
+          )"
+          flags=(--title "DragonBreath firmware ${VERSION}" --notes "$notes")
+          [ "$IS_TAG" = "true" ] || flags+=(--draft)
+          case "$VERSION" in *alpha*|*beta*|*rc*) flags+=(--prerelease);; esac
+          gh release create "$VERSION" "${flags[@]}" \
+            "dist/dragonbreath-${VERSION}.bin" \
+            "dist/dragonbreath-${VERSION}-factory.bin" \
+            "dist/dragonbreath-${VERSION}-install-bundle.zip" \
+            dist/manifest.json \
+            dist/SHA256SUMS.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,14 +62,16 @@ jobs:
           VERSION: ${{ steps.ver.outputs.version }}
           IS_TAG: ${{ github.ref_type == 'tag' }}
         run: |
-          notes="$(cat <<EOF
-          DragonBreath firmware \`${VERSION}\` — BIGTREETECH Panda Breath (ESP32-C3).
-
-          **First install (USB):**
-          \`\`\`
-          esptool.py --chip esp32c3 write_flash 0x0 dragonbreath-${VERSION}-factory.bin
-          \`\`\`
-          **OTA update** (device already on DragonBreath): upload \`dragonbreath-${VERSION}.bin\` via the web UI (\`/fw\`).
+          # Pull this version's section from CHANGELOG.md (## [x.y.z] .. next ## [).
+          changelog="$(awk -v v="${VERSION#v}" '
+            $0 ~ ("^## \\[" v "\\]") {f=1; next}
+            f && /^## \[/ {exit}
+            f {print}
+          ' CHANGELOG.md 2>/dev/null || true)"
+          install="$(cat <<EOF
+          **First install (USB, recommended — backs up stock):** download \`dragonbreath-${VERSION}-install-bundle.zip\`, verify (\`sha256sum -c SHA256SUMS.txt\`), unzip, then \`python3 flash.py --build-dir .\`.
+          Advanced single-image (only if already backed up): \`esptool.py --chip esp32c3 write_flash 0x0 dragonbreath-${VERSION}-factory.bin\`.
+          **OTA** (device already on DragonBreath): upload \`dragonbreath-${VERSION}.bin\` via the web UI (\`/fw\`).
 
           | asset | purpose |
           |---|---|
@@ -80,6 +82,11 @@ jobs:
           | \`SHA256SUMS.txt\` | \`sha256sum -c SHA256SUMS.txt\` |
           EOF
           )"
+          if [ -n "$(printf '%s' "$changelog" | tr -d '[:space:]')" ]; then
+            notes="${changelog}"$'\n\n'"${install}"
+          else
+            notes="$install"
+          fi
           flags=(--title "DragonBreath firmware ${VERSION}" --notes "$notes")
           [ "$IS_TAG" = "true" ] || flags+=(--draft)
           case "$VERSION" in *alpha*|*beta*|*rc*) flags+=(--prerelease);; esac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to the **DragonBreath** firmware are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/); versions are the
+firmware release tags (`vX.Y.Z`). The release workflow pulls the matching section
+below into the GitHub Release notes.
+
+## [Unreleased]
+
+### Added
+- **Reproducible release pipeline** — pushing a `v*` tag builds in CI (pinned
+  ESP-IDF v5.3.5) and publishes a GitHub Release with a single-file
+  `-factory.bin` (first install, flash @ 0x0), the `.bin` application image (OTA),
+  a complete `-install-bundle.zip` (flasher + components + `FLASHING.txt`), a
+  `manifest.json` (source SHA, ESP-IDF version, submodule, per-artifact SHA-256),
+  and `SHA256SUMS.txt`.
+- **Post-print fan cooldown** — after a print, the blower keeps running until the
+  chamber cools below 40 °C, then stops. Gated on a heat-this-session flag, so it
+  never auto-starts on temperature alone (a reboot-while-hot leaves the fan off).
+
+### Changed
+- **Renamed OpenBreath → DragonBreath** across the firmware: build/project
+  identity and OTA image-identity gate, HTTP auth header `X-DragonBreath-Auth`,
+  Wi-Fi AP SSID `DragonBreath_XXXX` (with migration of the legacy default), mDNS
+  hostname `dragonbreath.local` (app-layer override; shared OpenVent core
+  untouched), web-UI title (🐉) and strings, logs, and docs. "Panda Breath"
+  remains only as the underlying-hardware descriptor.
+
+### Migration
+- The OTA image-identity gate now requires `project_name == dragonbreath`, so a
+  device on pre-rename firmware must be **USB-reflashed once** to cross over; OTA
+  works normally afterward.

--- a/README.md
+++ b/README.md
@@ -118,12 +118,21 @@ can return to stock. Flashing is over the on-board CH340K USB-C bridge
 python3 tools/flash.py                 # backup stock, then flash DragonBreath
 python3 tools/flash.py --restore backups/stock-YYYYmmdd-HHMMSS.bin   # back to stock
 ```
+**Or from a published [release](../../releases)** (no build needed): download
+`dragonbreath-<ver>-install-bundle.zip`, verify it (`sha256sum -c SHA256SUMS.txt`),
+unzip, and run `python3 flash.py --build-dir .` — the same stock-backup-first flow.
+A single-image `dragonbreath-<ver>-factory.bin` is also published for
+`esptool.py --chip esp32c3 write_flash 0x0 …`, but that path does **not** back up
+stock — use it only if you already have a backup. Each release also ships a
+`manifest.json` (source SHA, ESP-IDF version, submodule + per-artifact SHA-256).
+
 First boot with no stored WiFi starts an `DragonBreath_XXXX` AP + captive portal for
 provisioning. The AP password is **`987654321`** (same as the stock Panda). Connect
 to it and a browser should pop the setup page automatically (or open `http://192.168.4.1`).
 
 **Updating DragonBreath:** once running, open the **Firmware update** link on the
-status page (the `/fw` page) and upload `build/dragonbreath.bin`. The image lands in
+status page (the `/fw` page) and upload `build/dragonbreath.bin` (or the
+`dragonbreath-<ver>.bin` app image from a release). The image lands in
 the inactive OTA slot, is verified, and the device reboots into it; a bad image
 rolls back on the next boot. Web OTA is **DragonBreath-only** — it does **not**
 restore stock firmware (use `tools/flash.py --restore` for that) and is refused

--- a/tools/package_release.sh
+++ b/tools/package_release.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# package_release.sh — assemble reproducible DragonBreath release artifacts from a
+# completed ESP-IDF build (Phase 0.2: release correctness).
+#
+# Produces, in $OUT (default ./dist):
+#   dragonbreath-<VER>.bin              — application image (for web OTA / /update)
+#   dragonbreath-<VER>-factory.bin      — single first-install image, flash @ 0x0
+#   dragonbreath-<VER>-install-bundle.zip — complete first-install bundle
+#       (bootloader, partition table, ota_data_initial, app, factory, flasher,
+#        dependencies.lock, manifest.json, SHA256SUMS.txt, FLASHING.txt)
+#   manifest.json                       — provenance + per-artifact SHA-256
+#   SHA256SUMS.txt                      — checksums of the published assets
+#
+# Requires: python3, zip, git, sha256sum, and esptool (esptool.py or `python3 -m
+# esptool`). Run from the repo root after `idf.py build`.
+#
+#   VERSION=v0.2.0 ./tools/package_release.sh
+set -euo pipefail
+
+VERSION="${VERSION:?set VERSION (e.g. v0.2.0)}"
+BUILD_DIR="${BUILD_DIR:-build}"
+OUT="${OUT:-dist}"
+SOURCE_SHA="${SOURCE_SHA:-$(git rev-parse HEAD)}"
+TARGET="${TARGET:-esp32c3}"
+BOARD="${BOARD:-BIGTREETECH Panda Breath (ESP32-C3), V1.0.1}"
+# IDF version: prefer an explicit env, else read the project's dependency lock.
+IDF_VERSION="${IDF_VERSION:-$(sed -n '/^  idf:/,/version:/s/^ *version: *//p' dependencies.lock 2>/dev/null | tail -1)}"
+IDF_VERSION="${IDF_VERSION:-unknown}"
+BUILT_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+esptool() { if command -v esptool.py >/dev/null; then esptool.py "$@"; else python3 -m esptool "$@"; fi; }
+
+for f in dragonbreath.bin bootloader/bootloader.bin partition_table/partition-table.bin ota_data_initial.bin flash_args; do
+    [ -f "$BUILD_DIR/$f" ] || { echo "missing $BUILD_DIR/$f — run idf.py build first" >&2; exit 1; }
+done
+
+rm -rf "$OUT" bundle-stage
+mkdir -p "$OUT" bundle-stage
+
+APP="dragonbreath-${VERSION}.bin"
+FACTORY="dragonbreath-${VERSION}-factory.bin"
+BUNDLE="dragonbreath-${VERSION}-install-bundle.zip"
+
+# 1. OTA application image (published separately for web OTA)
+cp "$BUILD_DIR/dragonbreath.bin" "$OUT/$APP"
+
+# 2. single-file first-install image (bootloader+ptable+otadata+app), flash @ 0x0
+( cd "$BUILD_DIR" && esptool --chip "$TARGET" merge_bin -o "$OLDPWD/$OUT/$FACTORY" @flash_args >/dev/null )
+
+# 3. stage the complete bundle — preserve the nested build/ layout so the bundled
+#    flasher (tools/flash.py --build-dir .) works directly AND takes the stock backup.
+mkdir -p bundle-stage/bootloader bundle-stage/partition_table
+cp "$BUILD_DIR/bootloader/bootloader.bin"           bundle-stage/bootloader/
+cp "$BUILD_DIR/partition_table/partition-table.bin" bundle-stage/partition_table/
+cp "$BUILD_DIR/ota_data_initial.bin" "$BUILD_DIR/dragonbreath.bin" "$OUT/$FACTORY" bundle-stage/
+cp tools/flash.py bundle-stage/ 2>/dev/null || true
+cp dependencies.lock bundle-stage/ 2>/dev/null || true
+
+cat > bundle-stage/FLASHING.txt <<EOF
+DragonBreath ${VERSION} — flashing (${TARGET})
+
+⚠️  Installing OVERWRITES the entire flash and ERASES the stock firmware. There is
+    NO published stock image — the backup the flasher makes is the ONLY way back.
+
+RECOMMENDED first install (backs up stock, then flashes) — from this bundle:
+  python3 flash.py --build-dir .
+
+ADVANCED single-image install — ONLY if you already have a stock backup
+(this path does NOT back anything up):
+  esptool.py --chip ${TARGET} write_flash 0x0 ${FACTORY}
+
+Over-the-air update (device already on DragonBreath): upload dragonbreath-${VERSION}.bin
+via the device web UI (/fw) — the app image only; never restores stock.
+
+Verify downloads first:  sha256sum -c SHA256SUMS.txt
+EOF
+
+# 4. provenance manifest (per-artifact SHA-256)
+OV_SHA="$(git -C external/OpenVent rev-parse HEAD 2>/dev/null || echo unknown)"
+OV_DESC="$(git -C external/OpenVent describe --tags --always 2>/dev/null || echo unknown)"
+export VERSION SOURCE_SHA IDF_VERSION TARGET BOARD BUILT_AT OV_SHA OV_DESC
+python3 - "$OUT/$APP" "$OUT/$FACTORY" \
+    "$BUILD_DIR/bootloader/bootloader.bin" \
+    "$BUILD_DIR/partition_table/partition-table.bin" \
+    "$BUILD_DIR/ota_data_initial.bin" <<PY > "$OUT/manifest.json"
+import hashlib, json, os, sys
+def h(p):
+    with open(p,'rb') as f: return hashlib.sha256(f.read()).hexdigest()
+arts=[{"name":os.path.basename(p),"size":os.path.getsize(p),"sha256":h(p)} for p in sys.argv[1:]]
+print(json.dumps({
+    "product":"dragonbreath","version":os.environ["VERSION"],
+    "source_sha":os.environ["SOURCE_SHA"],
+    "idf_version":os.environ["IDF_VERSION"],
+    "target":os.environ["TARGET"],"board":os.environ["BOARD"],
+    "openvent_submodule":{"sha":os.environ["OV_SHA"],"describe":os.environ["OV_DESC"]},
+    "built_at_utc":os.environ["BUILT_AT"],
+    "note":"managed component versions in dependencies.lock (bundled)",
+    "artifacts":arts,
+}, indent=2))
+PY
+cp "$OUT/manifest.json" bundle-stage/
+
+# 5. zip the complete first-install bundle (stdlib zipfile — no external `zip` dep)
+( cd bundle-stage && python3 -m zipfile -c "$OLDPWD/$OUT/$BUNDLE" * )
+rm -rf bundle-stage
+
+# 6. top-level checksums for the published assets
+( cd "$OUT" && sha256sum "$APP" "$FACTORY" "$BUNDLE" manifest.json > SHA256SUMS.txt )
+
+echo ">> release artifacts in $OUT/:"
+( cd "$OUT" && ls -la && echo && cat SHA256SUMS.txt )


### PR DESCRIPTION
Completes **Phase 0.2 (release correctness)**.

**Tag-triggered release pipeline** (`release.yml`): push a `v*` tag → CI builds with pinned ESP-IDF v5.3.5 and publishes a GitHub Release containing:
- `dragonbreath-<ver>-factory.bin` — single-file first install (flash @ 0x0)
- `dragonbreath-<ver>.bin` — application image for OTA
- `dragonbreath-<ver>-install-bundle.zip` — nested `bootloader/`+`partition_table/`, ota_data, app, factory, **flasher**, `dependencies.lock`, `FLASHING.txt` (layout matches `flash.py --build-dir .` so the bundled flasher works directly **and keeps the mandatory stock backup**)
- `manifest.json` — source SHA, ESP-IDF version, OpenVent submodule, per-artifact SHA-256
- `SHA256SUMS.txt`

**`tools/package_release.sh`** does the packaging (stdlib `zipfile` + `esptool merge_bin`); **validated locally against a real build** (checksums verify). Least-privilege `permissions`, SHA-pinned actions, concurrency guard. `workflow_dispatch` → draft for dry runs.

**CHANGELOG.md** added; release notes pull the tag's section from it.

**README** documents install-from-release (flasher-with-backup primary; bare-esptool factory as advanced/already-backed-up) + OTA + manifest.

Resolves the CI/release/local image divergence. (Phase 0.1 identity was completed by the DragonBreath rename.)

Note: nothing publishes until a `v*` tag is pushed.