### PR TITLE
refactor: make policy the authoritative control state machine

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'components/**'
       - 'main/**'
+      - 'tests/**'
       - 'CMakeLists.txt'
       - 'partitions.csv'
       - 'sdkconfig.defaults'
@@ -14,6 +15,7 @@ on:
     paths:
       - 'components/**'
       - 'main/**'
+      - 'tests/**'
       - 'CMakeLists.txt'
       - 'partitions.csv'
       - 'sdkconfig.defaults'
@@ -38,6 +40,9 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           submodules: recursive
+
+      - name: Test authoritative policy state machine
+        run: sh tests/run_policy_host_test.sh
 
       - name: Build (ESP-IDF v5.3)
         uses: espressif/esp-idf-ci-action@9d38657f3d789ca759b2b37aaf5ceffbc42c4f0d # v1

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ re-implemented.
 | `pb_ntc` | ✅ Stock conversion ported; **hardware-validated** (reads chamber temp matching the printer) |
 | `pb_heater` | ✅ Bang-bang + full safety cutoffs; SSR confirmed, heat cycle validated on hardware |
 | `pb_fan` | ✅ TRIAC **on/off held-gate** (stock model — the gate is never PWM'd/phase-chopped) |
-| `pb_policy` | ✅ Fan-follows-heater glue |
+| `pb_policy` | 🚧 Authoritative mode/target/lease state machine (API v2 foundation) |
 | Network core: `pv_wifi` / `pv_evlog` / `pv_moonraker` | ✅ Referenced from OpenVent (submodule); WiFi + Moonraker validated on hardware |
 | Portal / status dashboard / heat LED | ✅ Breath-local; captive-portal provisioning + live dashboard validated |
 | HTTP control API (`pb_httpd`) | ✅ `/status` `/target` `/heartbeat` `/reset`; CSRF-gated mutations |
@@ -145,7 +145,7 @@ components/
   pb_ntc/      ADC -> temperature (RE'd stock conversion)
   pb_heater/   SSR control + safety cutoffs + comms watchdog
   pb_fan/      TRIAC on/off held-gate blower control (never PWM)
-  pb_policy/   controller-state -> actuators glue
+  pb_policy/   authoritative control state, modes, leases -> actuators
   pb_httpd/    HTTP control API (CSRF-gated mutations)
   pb_portal/   captive-portal provisioning + live status dashboard
 main/          app_main: safety-first init + control loop

--- a/components/pb_httpd/CMakeLists.txt
+++ b/components/pb_httpd/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "pb_httpd.c"
     INCLUDE_DIRS "include"
-    REQUIRES esp_http_server pb_heater pb_ntc json nvs_flash app_update mbedtls
+    REQUIRES esp_http_server pb_heater pb_ntc pb_policy json nvs_flash app_update mbedtls
 )

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -2,6 +2,7 @@
 #include "pb_httpd.h"
 #include "pb_heater.h"
 #include "pb_ntc.h"
+#include "pb_policy.h"
 
 #include "esp_http_server.h"
 #include "esp_log.h"
@@ -88,26 +89,34 @@ static void add_num1(cJSON *o, const char *key, float v)
 // when a channel isn't reading OK, alongside explicit per-sensor status.
 static esp_err_t status_get(httpd_req_t *req)
 {
-    pb_ntc_status_t cs = pb_ntc_last_status(PB_NTC_CHAMBER);
-    pb_ntc_status_t ps = pb_ntc_last_status(PB_NTC_PTC);
+    pb_policy_snapshot_t snap;
+    pb_policy_get_snapshot(&snap);
+    pb_ntc_status_t cs = snap.chamber_status;
+    pb_ntc_status_t ps = snap.ptc_status;
 
     cJSON *o = cJSON_CreateObject();
     if (!o) { httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "oom"); return ESP_FAIL; }
 
-    add_num1(o, "temp", cs == PB_NTC_OK ? pb_ntc_smoothed_c(PB_NTC_CHAMBER) : NAN);
-    add_num1(o, "ptc",  ps == PB_NTC_OK ? pb_ntc_smoothed_c(PB_NTC_PTC)     : NAN);
+    add_num1(o, "temp", snap.chamber_c);
+    add_num1(o, "ptc", snap.ptc_c);
     cJSON_AddStringToObject(o, "chamber_status", ntc_status_str(cs));
     cJSON_AddStringToObject(o, "ptc_status", ntc_status_str(ps));
-    add_num1(o, "target", pb_heater_get_target_c());
-    cJSON_AddBoolToObject(o, "heating", pb_heater_is_on());
-    cJSON_AddBoolToObject(o, "fault", pb_heater_is_faulted());
-    const char *fr = pb_heater_fault_reason();
-    if (fr) cJSON_AddStringToObject(o, "fault_reason", fr);
+    add_num1(o, "target", snap.effective_target_c);
+    cJSON_AddBoolToObject(o, "heating", snap.heater_output);
+    cJSON_AddBoolToObject(o, "fault", snap.fault_latched);
+    if (snap.fault_reason[0])
+        cJSON_AddStringToObject(o, "fault_reason", snap.fault_reason);
     else    cJSON_AddNullToObject(o, "fault_reason");
     add_num1(o, "max", pb_heater_get_max_target_c());
     add_num1(o, "max_abs", PB_HEATER_ABS_MAX_TARGET_C);
     cJSON_AddNumberToObject(o, "comms_ms", pb_heater_get_comms_timeout_ms());
     cJSON_AddStringToObject(o, "version", esp_app_get_description()->version);
+    // Transitional visibility while the dashboard/helper still use the alpha
+    // routes. API v2 replaces this entire document with the canonical snapshot.
+    cJSON_AddNumberToObject(o, "revision", snap.state_revision);
+    cJSON_AddStringToObject(o, "mode", pb_policy_mode_str(snap.mode));
+    cJSON_AddStringToObject(o, "source", pb_policy_source_str(snap.source));
+    cJSON_AddBoolToObject(o, "lease_active", snap.lease_active);
 
     char *out = cJSON_PrintUnformatted(o);
     httpd_resp_set_type(req, "application/json");
@@ -122,7 +131,14 @@ static esp_err_t status_get(httpd_req_t *req)
 static esp_err_t heartbeat_post(httpd_req_t *req)
 {
     if (auth_reject(req)) return ESP_OK;
-    pb_heater_notify_link_alive();
+    pb_policy_result_t r = pb_policy_heartbeat_legacy();
+    if (r != PB_POLICY_OK) {
+        httpd_resp_set_status(req, "409 Conflict");
+        httpd_resp_set_type(req, "application/json");
+        char b[80];
+        snprintf(b, sizeof b, "{\"error\":\"%s\"}", pb_policy_result_str(r));
+        return httpd_resp_sendstr(req, b);
+    }
     httpd_resp_set_type(req, "application/json");
     return httpd_resp_sendstr(req, "{\"ok\":true}");
 }
@@ -139,7 +155,14 @@ static esp_err_t reset_post(httpd_req_t *req)
         return httpd_resp_sendstr(req,
             "{\"error\":\"heater permanently inhibited — reboot required\"}");
     }
-    pb_heater_clear_fault();
+    pb_policy_result_t r = pb_policy_clear_fault(PB_SOURCE_WEB);
+    if (r != PB_POLICY_OK) {
+        httpd_resp_set_status(req, "409 Conflict");
+        httpd_resp_set_type(req, "application/json");
+        char b[80];
+        snprintf(b, sizeof b, "{\"error\":\"%s\"}", pb_policy_result_str(r));
+        return httpd_resp_sendstr(req, b);
+    }
     httpd_resp_set_type(req, "application/json");
     return httpd_resp_sendstr(req, "{\"ok\":true}");
 }
@@ -183,20 +206,31 @@ static esp_err_t target_set(httpd_req_t *req)
         return ESP_FAIL;
     }
 
-    pb_heater_notify_link_alive();                   // a command counts as liveness
-    esp_err_t se = pb_heater_set_target_c(t);        // validates + clamps internally
-    if (se == ESP_ERR_INVALID_STATE) {               // heat requested while faulted
+    pb_policy_result_t pr;
+    pb_policy_lease_t lease = {0};
+    if (t <= 0.0f) {
+        pb_policy_set_mode_off(PB_SOURCE_WEB);
+        pr = PB_POLICY_OK;
+    } else {
+        pr = pb_policy_set_power_on(
+            t, PB_SOURCE_WEB, "legacy-http", PB_POLICY_REVISION_ANY, &lease);
+    }
+    if (pr == PB_POLICY_FAULT_LATCHED || pr == PB_POLICY_INHIBITED) {
         httpd_resp_set_status(req, "409 Conflict");
         httpd_resp_set_type(req, "application/json");
         return httpd_resp_sendstr(req,
             "{\"error\":\"fault latched — POST /reset, then set a target\"}");
     }
-    if (se != ESP_OK) {
+    if (pr != PB_POLICY_OK) {
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "invalid target");
         return ESP_FAIL;
     }
-    char buf[48];
-    int n = snprintf(buf, sizeof buf, "{\"target\":%.1f}", pb_heater_get_target_c());
+    pb_policy_snapshot_t snap;
+    pb_policy_get_snapshot(&snap);
+    char buf[160];
+    int n = snprintf(buf, sizeof buf,
+        "{\"target\":%.1f,\"revision\":%lu,\"lease\":\"%s\"}",
+        snap.effective_target_c, (unsigned long)snap.state_revision, lease.id);
     httpd_resp_set_type(req, "application/json");
     return httpd_resp_send(req, buf, n);
 }
@@ -303,7 +337,9 @@ static esp_err_t update_post(httpd_req_t *req)
     if (auth_reject(req)) return ESP_OK;
 
     // Block while heating (chosen safety policy).
-    if (pb_heater_is_on() || pb_heater_get_target_c() > 0.0f)
+    pb_policy_snapshot_t snap;
+    pb_policy_get_snapshot(&snap);
+    if (snap.heater_output || snap.effective_target_c > 0.0f)
         return ota_fail(req, "409 Conflict", 0, "turn the heater off before updating");
 
     const esp_partition_t *part = esp_ota_get_next_update_partition(NULL);

--- a/components/pb_policy/CMakeLists.txt
+++ b/components/pb_policy/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "pb_policy.c"
     INCLUDE_DIRS "include"
-    REQUIRES pb_heater pb_fan pb_ntc pb_leds
+    REQUIRES pb_heater pb_fan pb_ntc pb_leds esp_timer esp_system freertos
 )

--- a/components/pb_policy/include/pb_policy.h
+++ b/components/pb_policy/include/pb_policy.h
@@ -1,28 +1,139 @@
 // SPDX-License-Identifier: MIT
-// pb_policy — glue between the network layer (Moonraker/HA, imported from the
-// OpenVent shared core) and the device actuators (pb_heater, pb_fan).
+// pb_policy — the sole owner of DragonBreath control state.
 //
-// It owns the automation rules: translate a desired chamber set-point + printer
-// state into heater target + fan level, and feed the heater comms watchdog while
-// a controller link is alive. Kept deliberately thin so the same shape can be
-// shared across the Panda family.
+// Network transports, the dashboard, Moonraker integration, and physical
+// buttons submit commands here.  They never write pb_heater or pb_fan directly.
+// The policy owns mode transitions, targets, controller leases, deadlines, and
+// the canonical snapshot consumed by API v2.
 #pragma once
 
 #include <stdbool.h>
+#include <stdint.h>
+
 #include "esp_err.h"
+#include "pb_ntc.h"
+
+#define PB_POLICY_REVISION_ANY UINT32_MAX
+#define PB_POLICY_LEASE_ID_LEN 32
+#define PB_POLICY_OWNER_LEN    31
+
+// Remote POWER_ON leases follow pb_heater's runtime-configurable comms deadman,
+// so the advertised lease runway and the hardware watchdog cannot disagree.
+#define PB_POLICY_LOCAL_POWER_MAX_MS  (12U * 60U * 60U * 1000U)
+
+typedef enum {
+    PB_MODE_OFF = 0,
+    PB_MODE_POWER_ON,
+    PB_MODE_AUTO,
+    PB_MODE_DRYING,
+} pb_mode_t;
+
+typedef enum {
+    PB_SOURCE_BOOT = 0,
+    PB_SOURCE_WEB,
+    PB_SOURCE_KLIPPER,
+    PB_SOURCE_BUTTON,
+    PB_SOURCE_SAFETY,
+    PB_SOURCE_WATCHDOG,
+} pb_source_t;
+
+typedef enum {
+    PB_POLICY_OK = 0,
+    PB_POLICY_INVALID,
+    PB_POLICY_REVISION_CONFLICT,
+    PB_POLICY_FAULT_LATCHED,
+    PB_POLICY_INHIBITED,
+    PB_POLICY_STALE_LEASE,
+} pb_policy_result_t;
 
 typedef struct {
-    float chamber_target_c;   // requested chamber set-point (0 = off)
-    uint8_t fan_percent;      // requested fan speed 0..100
-    bool link_alive;          // a controller (Moonraker/HA) is currently connected
-} pb_policy_input_t;
+    char id[PB_POLICY_LEASE_ID_LEN + 1];
+} pb_policy_lease_t;
+
+typedef struct {
+    uint32_t state_revision;
+    pb_mode_t mode;
+    pb_source_t source;
+
+    float requested_target_c;
+    float effective_target_c;
+    bool heater_demand;
+    bool heater_output;
+
+    uint8_t requested_fan_percent;
+    uint8_t effective_fan_percent;
+    bool thermal_purge;
+
+    float chamber_c;
+    float ptc_c;
+    pb_ntc_status_t chamber_status;
+    pb_ntc_status_t ptc_status;
+
+    bool moonraker_connected;
+    float bed_c;
+    bool auto_engaged;
+    float auto_bed_threshold_c;
+
+    bool drying;
+    uint32_t drying_remaining_s;
+
+    bool lease_active;
+    char lease_id[PB_POLICY_LEASE_ID_LEN + 1];
+    char lease_owner[PB_POLICY_OWNER_LEN + 1];
+    uint32_t lease_expires_ms;
+
+    bool fault_latched;
+    bool inhibited;
+    char fault_reason[64];
+} pb_policy_snapshot_t;
 
 esp_err_t pb_policy_init(void);
 
-// Apply the latest desired state from the controller. Safe to call on every
-// update / message. Applies clamps and feeds the heater watchdog.
-void pb_policy_apply(const pb_policy_input_t *in);
+// Remote WEB/KLIPPER POWER_ON commands receive a device-issued lease.  A lease
+// is RAM-only, changes on every accepted heat command, and is invalidated by
+// OFF, another mode command, safety/watchdog action, or reboot.
+pb_policy_result_t pb_policy_set_power_on(
+    float target_c,
+    pb_source_t source,
+    const char *owner,
+    uint32_t expected_revision,
+    pb_policy_lease_t *lease_out);
 
-// Periodic tick (call at ~1-2 Hz): drives pb_heater_tick() and any local
-// autonomous behaviour (e.g. run the fan while the heater is on).
+pb_policy_result_t pb_policy_set_auto(
+    float target_c,
+    float bed_threshold_c,
+    pb_source_t source,
+    uint32_t expected_revision);
+
+pb_policy_result_t pb_policy_start_drying(
+    float target_c,
+    uint8_t hours,
+    pb_source_t source,
+    uint32_t expected_revision);
+
+// OFF is deliberately unconditional: stale state must never prevent a caller
+// from making the device safer.
+void pb_policy_set_mode_off(pb_source_t source);
+void pb_policy_stop_drying(pb_source_t source);
+
+// Update printer environment used by AUTO.  This is observer input, not a
+// control command, and therefore never creates or refreshes a control lease.
+void pb_policy_set_env(float bed_c, bool moonraker_connected);
+
+// Refresh exactly the active lease.  A stale/superseded lease cannot keep heat
+// alive.  The legacy helper exists only until API v2 replaces the alpha routes.
+pb_policy_result_t pb_policy_heartbeat(const pb_policy_lease_t *lease);
+pb_policy_result_t pb_policy_heartbeat_legacy(void);
+
+pb_policy_result_t pb_policy_clear_fault(pb_source_t source);
+
+// Periodic control tick (call at ~1-2 Hz).  Computes the effective target,
+// applies the heater/fan outputs, enforces deadlines, and synchronizes safety
+// trips back into the authoritative state.
 void pb_policy_tick(void);
+
+void pb_policy_get_snapshot(pb_policy_snapshot_t *out);
+pb_mode_t pb_policy_get_mode(void);
+const char *pb_policy_mode_str(pb_mode_t mode);
+const char *pb_policy_source_str(pb_source_t source);
+const char *pb_policy_result_str(pb_policy_result_t result);

--- a/components/pb_policy/pb_policy.c
+++ b/components/pb_policy/pb_policy.c
@@ -1,95 +1,583 @@
 // SPDX-License-Identifier: MIT
 #include "pb_policy.h"
-#include "pb_heater.h"
+
 #include "pb_fan.h"
+#include "pb_heater.h"
 #include "pb_ntc.h"
 #include "pb_leds.h"
 
 #include "esp_log.h"
+#include "esp_random.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+
 #include <math.h>
+#include <stdio.h>
+#include <string.h>
 
 static const char *TAG = "pb_policy";
 
-// Post-print cooldown: after the heater has run this session, keep the fan going
-// until the chamber falls below this threshold. NOT a temperature trigger on its
-// own — it is gated by s_heated_this_session (see below).
-#define PB_COOLDOWN_TEMP_C 40.0f
+#define PB_COOLDOWN_TEMP_C          40.0f
+#define PB_AUTO_BED_HYSTERESIS_C     3.0f
+#define PB_DRYING_MAX_HOURS         12U
+#define PB_MIN_MODE_TARGET_C        30.0f
 
-static uint8_t s_requested_fan;
+typedef struct {
+    pb_mode_t mode;
+    pb_source_t source;
+    uint32_t revision;
 
-// Set true the moment the heater enters heat mode this power cycle; this (not the
-// chamber temperature) is what arms the post-print cooldown. Deliberately RAM-only
-// / never persisted: a power cycle clears it, so a reboot-while-hot must NOT spin
-// the fan. The fan only ever *continues* cooling after an actual heating session —
-// it never auto-starts on temperature alone.
-static bool s_heated_this_session;
+    float requested_target_c;
+    uint8_t requested_fan_percent;
+
+    bool mk_connected;
+    float bed_c;
+    float auto_bed_threshold_c;
+    bool auto_engaged;
+
+    int64_t drying_deadline_us;
+    int64_t local_power_deadline_us;
+
+    bool lease_active;
+    pb_policy_lease_t lease;
+    char lease_owner[PB_POLICY_OWNER_LEN + 1];
+    int64_t lease_deadline_us;
+
+    bool heated_this_session;
+    bool last_faulted;
+} policy_state_t;
+
+static SemaphoreHandle_t s_lock;
+static policy_state_t s;
+
+static bool source_is_remote(pb_source_t source)
+{
+    return source == PB_SOURCE_WEB || source == PB_SOURCE_KLIPPER;
+}
+
+static void copy_text(char *dst, size_t dst_size, const char *src)
+{
+    if (!dst || dst_size == 0) return;
+    snprintf(dst, dst_size, "%s", src ? src : "");
+}
+
+static void revision_advance_locked(pb_source_t source)
+{
+    // Reserve zero as "no snapshot received".  Natural uint32 rollover remains
+    // valid; skip zero so clients never confuse it with an uninitialized value.
+    s.revision++;
+    if (s.revision == 0) s.revision = 1;
+    s.source = source;
+}
+
+static void lease_invalidate_locked(void)
+{
+    s.lease_active = false;
+    memset(&s.lease, 0, sizeof s.lease);
+    s.lease_owner[0] = '\0';
+    s.lease_deadline_us = 0;
+}
+
+static int64_t remote_lease_ttl_us(void)
+{
+    return (int64_t)pb_heater_get_comms_timeout_ms() * 1000;
+}
+
+static void lease_issue_locked(const char *owner, int64_t now_us,
+                               pb_policy_lease_t *out)
+{
+    uint8_t random[PB_POLICY_LEASE_ID_LEN / 2];
+    esp_fill_random(random, sizeof random);
+    for (size_t i = 0; i < sizeof random; ++i) {
+        snprintf(&s.lease.id[i * 2], 3, "%02x", random[i]);
+    }
+    s.lease.id[PB_POLICY_LEASE_ID_LEN] = '\0';
+    copy_text(s.lease_owner, sizeof s.lease_owner,
+              owner && owner[0] ? owner : "remote");
+    s.lease_deadline_us = now_us + remote_lease_ttl_us();
+    s.lease_active = true;
+    if (out) *out = s.lease;
+}
+
+static bool revision_matches_locked(uint32_t expected)
+{
+    return expected == PB_POLICY_REVISION_ANY || expected == s.revision;
+}
+
+static pb_policy_result_t heat_precheck_locked(float target_c,
+                                                uint32_t expected_revision)
+{
+    if (!revision_matches_locked(expected_revision))
+        return PB_POLICY_REVISION_CONFLICT;
+    if (!isfinite(target_c) || target_c < PB_MIN_MODE_TARGET_C)
+        return PB_POLICY_INVALID;
+    if (pb_heater_is_inhibited())
+        return PB_POLICY_INHIBITED;
+    if (pb_heater_is_faulted())
+        return PB_POLICY_FAULT_LATCHED;
+    return PB_POLICY_OK;
+}
+
+static void set_off_locked(pb_source_t source)
+{
+    // Target zero is accepted even while faulted/inhibited.
+    (void)pb_heater_set_target_c(0.0f);
+    s.mode = PB_MODE_OFF;
+    s.requested_target_c = 0.0f;
+    s.auto_engaged = false;
+    s.drying_deadline_us = 0;
+    s.local_power_deadline_us = 0;
+    lease_invalidate_locked();
+    revision_advance_locked(source);
+}
 
 esp_err_t pb_policy_init(void)
 {
-    s_requested_fan = 0;
-    s_heated_this_session = false;
-    ESP_LOGI(TAG, "init");
+    if (!s_lock) s_lock = xSemaphoreCreateMutex();
+    if (!s_lock) return ESP_ERR_NO_MEM;
+
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    memset(&s, 0, sizeof s);
+    s.mode = PB_MODE_OFF;
+    s.source = PB_SOURCE_BOOT;
+    s.revision = 1;
+    s.auto_bed_threshold_c = 100.0f;
+    s.last_faulted = pb_heater_is_faulted();
+    xSemaphoreGive(s_lock);
+
+    // The heater was forced off before policy initialization.  Do not restore
+    // mode, target, deadlines, or leases from storage.
+    (void)pb_heater_set_target_c(0.0f);
+    ESP_LOGI(TAG, "authoritative state initialized: OFF revision=1");
     return ESP_OK;
 }
 
-void pb_policy_apply(const pb_policy_input_t *in)
+pb_policy_result_t pb_policy_set_power_on(
+    float target_c,
+    pb_source_t source,
+    const char *owner,
+    uint32_t expected_revision,
+    pb_policy_lease_t *lease_out)
 {
-    if (!in) return;
-    if (in->link_alive) pb_heater_notify_link_alive();
-    pb_heater_set_target_c(in->chamber_target_c);
-    s_requested_fan = in->fan_percent;
+    if (!s_lock) return PB_POLICY_INHIBITED;
+    if (lease_out) memset(lease_out, 0, sizeof *lease_out);
+
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    pb_policy_result_t r = heat_precheck_locked(target_c, expected_revision);
+    if (r != PB_POLICY_OK) {
+        xSemaphoreGive(s_lock);
+        return r;
+    }
+
+    esp_err_t hr = pb_heater_set_target_c(target_c);
+    if (hr != ESP_OK) {
+        r = hr == ESP_ERR_INVALID_STATE
+            ? PB_POLICY_FAULT_LATCHED : PB_POLICY_INVALID;
+        xSemaphoreGive(s_lock);
+        return r;
+    }
+
+    int64_t now = esp_timer_get_time();
+    lease_invalidate_locked();
+    s.mode = PB_MODE_POWER_ON;
+    s.requested_target_c = pb_heater_get_target_c(); // includes heater clamp
+    s.auto_engaged = false;
+    s.drying_deadline_us = 0;
+    s.local_power_deadline_us = 0;
+
+    if (source_is_remote(source)) {
+        lease_issue_locked(owner, now, lease_out);
+        pb_heater_notify_link_alive();
+    } else {
+        s.local_power_deadline_us =
+            now + (int64_t)PB_POLICY_LOCAL_POWER_MAX_MS * 1000;
+    }
+    revision_advance_locked(source);
+    xSemaphoreGive(s_lock);
+    return PB_POLICY_OK;
+}
+
+pb_policy_result_t pb_policy_set_auto(
+    float target_c,
+    float bed_threshold_c,
+    pb_source_t source,
+    uint32_t expected_revision)
+{
+    if (!s_lock || !isfinite(bed_threshold_c)
+            || bed_threshold_c < 40.0f || bed_threshold_c > 120.0f)
+        return PB_POLICY_INVALID;
+
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    pb_policy_result_t r = heat_precheck_locked(target_c, expected_revision);
+    if (r != PB_POLICY_OK) {
+        xSemaphoreGive(s_lock);
+        return r;
+    }
+    lease_invalidate_locked();
+    s.mode = PB_MODE_AUTO;
+    float max_target_c = pb_heater_get_max_target_c();
+    s.requested_target_c =
+        target_c > max_target_c ? max_target_c : target_c;
+    s.auto_bed_threshold_c = bed_threshold_c;
+    s.auto_engaged = false;
+    s.drying_deadline_us = 0;
+    s.local_power_deadline_us = 0;
+    (void)pb_heater_set_target_c(0.0f);
+    revision_advance_locked(source);
+    xSemaphoreGive(s_lock);
+    return PB_POLICY_OK;
+}
+
+pb_policy_result_t pb_policy_start_drying(
+    float target_c,
+    uint8_t hours,
+    pb_source_t source,
+    uint32_t expected_revision)
+{
+    if (!s_lock || hours == 0 || hours > PB_DRYING_MAX_HOURS)
+        return PB_POLICY_INVALID;
+
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    pb_policy_result_t r = heat_precheck_locked(target_c, expected_revision);
+    if (r != PB_POLICY_OK) {
+        xSemaphoreGive(s_lock);
+        return r;
+    }
+    esp_err_t hr = pb_heater_set_target_c(target_c);
+    if (hr != ESP_OK) {
+        r = hr == ESP_ERR_INVALID_STATE
+            ? PB_POLICY_FAULT_LATCHED : PB_POLICY_INVALID;
+        xSemaphoreGive(s_lock);
+        return r;
+    }
+    lease_invalidate_locked();
+    s.mode = PB_MODE_DRYING;
+    s.requested_target_c = pb_heater_get_target_c();
+    s.auto_engaged = false;
+    s.local_power_deadline_us = 0;
+    s.drying_deadline_us = esp_timer_get_time()
+        + (int64_t)hours * 60 * 60 * 1000000;
+    revision_advance_locked(source);
+    xSemaphoreGive(s_lock);
+    return PB_POLICY_OK;
+}
+
+void pb_policy_set_mode_off(pb_source_t source)
+{
+    if (!s_lock) return;
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    set_off_locked(source);
+    xSemaphoreGive(s_lock);
+}
+
+void pb_policy_stop_drying(pb_source_t source)
+{
+    pb_policy_set_mode_off(source);
+}
+
+void pb_policy_set_env(float bed_c, bool moonraker_connected)
+{
+    if (!s_lock) return;
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    s.bed_c = isfinite(bed_c) ? bed_c : 0.0f;
+    s.mk_connected = moonraker_connected;
+    xSemaphoreGive(s_lock);
+}
+
+pb_policy_result_t pb_policy_heartbeat(const pb_policy_lease_t *lease)
+{
+    if (!s_lock || !lease || lease->id[0] == '\0')
+        return PB_POLICY_STALE_LEASE;
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    if (!s.lease_active || strcmp(lease->id, s.lease.id) != 0
+            || s.mode != PB_MODE_POWER_ON) {
+        xSemaphoreGive(s_lock);
+        return PB_POLICY_STALE_LEASE;
+    }
+    int64_t now = esp_timer_get_time();
+    if (now >= s.lease_deadline_us) {
+        xSemaphoreGive(s_lock);
+        return PB_POLICY_STALE_LEASE;
+    }
+    s.lease_deadline_us = now + remote_lease_ttl_us();
+    pb_heater_notify_link_alive();
+    xSemaphoreGive(s_lock);
+    return PB_POLICY_OK;
+}
+
+pb_policy_result_t pb_policy_heartbeat_legacy(void)
+{
+    // Transitional adapter for the alpha /heartbeat route.  API v2 removes this
+    // capability and requires the device-issued lease ID on every heartbeat.
+    if (!s_lock) return PB_POLICY_STALE_LEASE;
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    // The deployed alpha helper heartbeats even while idle. Keep that harmless
+    // during the v1->v2 transition, but never let it revive a missing/expired
+    // POWER_ON lease.
+    if (s.mode != PB_MODE_POWER_ON) {
+        xSemaphoreGive(s_lock);
+        return PB_POLICY_OK;
+    }
+    if (!s.lease_active) {
+        xSemaphoreGive(s_lock);
+        return PB_POLICY_STALE_LEASE;
+    }
+    int64_t now = esp_timer_get_time();
+    if (now >= s.lease_deadline_us) {
+        xSemaphoreGive(s_lock);
+        return PB_POLICY_STALE_LEASE;
+    }
+    s.lease_deadline_us = now + remote_lease_ttl_us();
+    pb_heater_notify_link_alive();
+    xSemaphoreGive(s_lock);
+    return PB_POLICY_OK;
+}
+
+pb_policy_result_t pb_policy_clear_fault(pb_source_t source)
+{
+    if (!s_lock) return PB_POLICY_INHIBITED;
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    if (pb_heater_is_inhibited()) {
+        xSemaphoreGive(s_lock);
+        return PB_POLICY_INHIBITED;
+    }
+    pb_heater_clear_fault();
+    s.last_faulted = false;
+    set_off_locked(source);
+    xSemaphoreGive(s_lock);
+    return PB_POLICY_OK;
 }
 
 void pb_policy_tick(void)
 {
+    if (!s_lock) return;
+    int64_t now = esp_timer_get_time();
+    bool watchdog_trip = false;
+    bool local_limit_expired = false;
+    const char *watchdog_reason = NULL;
+    float target = 0.0f;
+    bool autonomous = false;
+
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    switch (s.mode) {
+        case PB_MODE_POWER_ON:
+            if (s.lease_active && now >= s.lease_deadline_us) {
+                watchdog_trip = true;
+                watchdog_reason = "controller lease expired";
+            } else if (!s.lease_active && s.local_power_deadline_us > 0
+                       && now >= s.local_power_deadline_us) {
+                local_limit_expired = true;
+                set_off_locked(PB_SOURCE_WATCHDOG);
+            } else {
+                target = s.requested_target_c;
+                autonomous = !s.lease_active;
+            }
+            break;
+
+        case PB_MODE_AUTO:
+        {
+            bool was_engaged = s.auto_engaged;
+            if (!s.mk_connected) {
+                s.auto_engaged = false;
+            } else if (!s.auto_engaged && s.bed_c >= s.auto_bed_threshold_c) {
+                s.auto_engaged = true;
+            } else if (s.auto_engaged
+                       && s.bed_c < s.auto_bed_threshold_c
+                                      - PB_AUTO_BED_HYSTERESIS_C) {
+                s.auto_engaged = false;
+            }
+            if (s.auto_engaged != was_engaged)
+                revision_advance_locked(s.source);
+            if (s.auto_engaged) {
+                target = s.requested_target_c;
+                autonomous = true;
+            }
+            break;
+        }
+
+        case PB_MODE_DRYING:
+            if (now >= s.drying_deadline_us) {
+                set_off_locked(PB_SOURCE_WATCHDOG);
+            } else {
+                target = s.requested_target_c;
+                autonomous = true;
+            }
+            break;
+
+        case PB_MODE_OFF:
+        default:
+            break;
+    }
+
+    if (watchdog_trip) {
+        // Sole control-task path for a latching remote/local timeout.
+        lease_invalidate_locked();
+        s.mode = PB_MODE_OFF;
+        s.requested_target_c = 0.0f;
+        s.auto_engaged = false;
+        s.drying_deadline_us = 0;
+        s.local_power_deadline_us = 0;
+        revision_advance_locked(PB_SOURCE_WATCHDOG);
+    }
+
+    // Keep the computed transition and its actuator application under the same
+    // policy mutex. Otherwise an OFF command could land after this tick computed
+    // an old positive target but before it applied that target, allowing the
+    // stale tick to re-arm heat after OFF returned.
+    if (watchdog_trip) {
+        pb_heater_emergency_off(watchdog_reason);
+    } else {
+        // Avoid logging/reapplying an unchanged target on every 500 ms tick.
+        if (fabsf(pb_heater_get_target_c() - target) >= 0.05f)
+            (void)pb_heater_set_target_c(target);
+        if (autonomous && target > 0.0f)
+            pb_heater_notify_link_alive();
+    }
+
     pb_heater_tick();
 
     bool heat = pb_heater_heat_mode();
-    // Latch that the heater ran this session — this (not the chamber temp) arms
-    // the post-print cooldown, so the fan never auto-starts on temperature alone.
-    if (heat) s_heated_this_session = true;
+    bool faulted = pb_heater_is_faulted();
+    float chamber_c = pb_ntc_smoothed_c(PB_NTC_CHAMBER);
+    bool chamber_ok = pb_ntc_last_status(PB_NTC_CHAMBER) == PB_NTC_OK
+                      && isfinite(chamber_c);
 
-    // Post-print cooldown: once the heater has run, keep airflow going after it
-    // turns off until the chamber cools below the threshold, then disarm (don't
-    // re-trigger until the next heating session). Only trust the smoothed temp if
-    // the latest read was OK — on a sensor fault pb_ntc_smoothed_c() keeps
-    // returning the last (stale) moving average, NOT NaN, which could otherwise
-    // pin the fan on forever. On fault/no-reading, disarm; the heater's own fault
-    // path (pb_heater_is_faulted) still drives airflow if it latches.
+    if (heat) s.heated_this_session = true;
+
     bool cooldown = false;
-    if (!heat && s_heated_this_session) {
-        float chamber_c = pb_ntc_smoothed_c(PB_NTC_CHAMBER);
-        if (pb_ntc_last_status(PB_NTC_CHAMBER) == PB_NTC_OK
-                && !isnan(chamber_c) && chamber_c > PB_COOLDOWN_TEMP_C) {
+    if (!heat && s.heated_this_session) {
+        if (chamber_ok && chamber_c > PB_COOLDOWN_TEMP_C) {
             cooldown = true;
         } else {
-            s_heated_this_session = false;
+            s.heated_this_session = false;
         }
     }
 
-    // Ensure airflow while in heat mode (steady across the SSR's bang-bang
-    // cycling — not pb_heater_is_on(), which chatters), while a fault is latched
-    // (keep cooling a just-tripped over-temp chamber until the operator resets),
-    // and during the post-print cooldown. Otherwise honor the requested fan level.
-    bool want_airflow = heat || pb_heater_is_faulted() || cooldown;
-    if (want_airflow && s_requested_fan < 30) {
-        pb_fan_set_level(30);
-    } else {
-        pb_fan_set_level(s_requested_fan);
+    if (faulted && !s.last_faulted) {
+        s.mode = PB_MODE_OFF;
+        s.requested_target_c = 0.0f;
+        s.auto_engaged = false;
+        s.drying_deadline_us = 0;
+        s.local_power_deadline_us = 0;
+        lease_invalidate_locked();
+        // Preserve WATCHDOG attribution for a policy-triggered expiry.
+        if (!watchdog_trip) revision_advance_locked(PB_SOURCE_SAFETY);
     }
+    s.last_faulted = faulted;
 
-    // Heating indication, matching the stock panel: solid while heating, blinking
-    // on a latched safety fault (visible even while the fan keeps cooling a tripped
-    // chamber), off otherwise. pb_policy owns all LED indication; pb_heater drives
-    // no GPIO LED.
-    //   - "Power" (GPIO21) is the stock heating indicator — driven only in release
-    //     builds (CONFIG_PB_POWER_LED); in dev builds that pin is the console TX and
-    //     pb_leds skips it, so this call is a harmless no-op there.
-    //   - "On" (GPIO5) is driven the same way as an interim mode indicator until the
-    //     Phase B mode state machine owns Auto/On/Dry.
-    pb_led_pattern_t heat_pat = (pb_heater_is_faulted() || pb_heater_is_inhibited())
-                                    ? PB_LED_BLINK
-                                    : heat ? PB_LED_SOLID : PB_LED_OFF;
+    bool want_airflow = heat || faulted || cooldown;
+    uint8_t fan = s.requested_fan_percent;
+    if (want_airflow && fan < 30) fan = 30;
+    pb_fan_set_level(fan);
+
+    // Preserve Phase A's panel semantics through the state-machine rewrite.
+    // The Power LED is release-only because GPIO21 is also console TX; the On
+    // LED mirrors it until the later mode/button work owns Auto/On/Dry.
+    pb_led_pattern_t heat_pat =
+        faulted ? PB_LED_BLINK : heat ? PB_LED_SOLID : PB_LED_OFF;
     pb_leds_set(PB_LED_POWER, heat_pat);
     pb_leds_set(PB_LED_ON, heat_pat);
+
+    if (local_limit_expired)
+        ESP_LOGW(TAG, "local POWER_ON limit expired; mode set OFF");
+    xSemaphoreGive(s_lock);
+}
+
+void pb_policy_get_snapshot(pb_policy_snapshot_t *out)
+{
+    if (!out) return;
+    memset(out, 0, sizeof *out);
+    if (!s_lock) return;
+
+    int64_t now = esp_timer_get_time();
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    out->state_revision = s.revision;
+    out->mode = s.mode;
+    out->source = s.source;
+    out->requested_target_c = s.requested_target_c;
+    out->requested_fan_percent = s.requested_fan_percent;
+    out->moonraker_connected = s.mk_connected;
+    out->bed_c = s.bed_c;
+    out->auto_engaged = s.auto_engaged;
+    out->auto_bed_threshold_c = s.auto_bed_threshold_c;
+    out->drying = s.mode == PB_MODE_DRYING;
+    if (out->drying && s.drying_deadline_us > now) {
+        out->drying_remaining_s =
+            (uint32_t)((s.drying_deadline_us - now + 999999) / 1000000);
+    }
+    out->lease_active = s.lease_active && now < s.lease_deadline_us;
+    if (out->lease_active) {
+        copy_text(out->lease_id, sizeof out->lease_id, s.lease.id);
+        copy_text(out->lease_owner, sizeof out->lease_owner, s.lease_owner);
+        out->lease_expires_ms =
+            (uint32_t)((s.lease_deadline_us - now + 999) / 1000);
+    }
+    xSemaphoreGive(s_lock);
+
+    out->effective_target_c = pb_heater_get_target_c();
+    out->heater_demand = pb_heater_heat_mode();
+    out->heater_output = pb_heater_is_on();
+    out->effective_fan_percent = pb_fan_get_level();
+    out->fault_latched = pb_heater_is_faulted();
+    out->inhibited = pb_heater_is_inhibited();
+    const char *reason = pb_heater_fault_reason();
+    copy_text(out->fault_reason, sizeof out->fault_reason, reason);
+
+    out->chamber_status = pb_ntc_last_status(PB_NTC_CHAMBER);
+    out->ptc_status = pb_ntc_last_status(PB_NTC_PTC);
+    out->chamber_c = out->chamber_status == PB_NTC_OK
+        ? pb_ntc_smoothed_c(PB_NTC_CHAMBER) : NAN;
+    out->ptc_c = out->ptc_status == PB_NTC_OK
+        ? pb_ntc_smoothed_c(PB_NTC_PTC) : NAN;
+
+    out->thermal_purge = !out->heater_demand
+        && !out->fault_latched
+        && out->effective_fan_percent > out->requested_fan_percent;
+}
+
+pb_mode_t pb_policy_get_mode(void)
+{
+    if (!s_lock) return PB_MODE_OFF;
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    pb_mode_t mode = s.mode;
+    xSemaphoreGive(s_lock);
+    return mode;
+}
+
+const char *pb_policy_mode_str(pb_mode_t mode)
+{
+    switch (mode) {
+        case PB_MODE_POWER_ON: return "power_on";
+        case PB_MODE_AUTO:     return "auto";
+        case PB_MODE_DRYING:   return "drying";
+        case PB_MODE_OFF:
+        default:               return "off";
+    }
+}
+
+const char *pb_policy_source_str(pb_source_t source)
+{
+    switch (source) {
+        case PB_SOURCE_WEB:     return "web";
+        case PB_SOURCE_KLIPPER: return "klipper";
+        case PB_SOURCE_BUTTON:  return "button";
+        case PB_SOURCE_SAFETY:  return "safety";
+        case PB_SOURCE_WATCHDOG:return "watchdog";
+        case PB_SOURCE_BOOT:
+        default:                return "boot";
+    }
+}
+
+const char *pb_policy_result_str(pb_policy_result_t result)
+{
+    switch (result) {
+        case PB_POLICY_OK:                return "ok";
+        case PB_POLICY_INVALID:           return "invalid";
+        case PB_POLICY_REVISION_CONFLICT: return "revision_conflict";
+        case PB_POLICY_FAULT_LATCHED:     return "fault_latched";
+        case PB_POLICY_INHIBITED:         return "inhibited";
+        case PB_POLICY_STALE_LEASE:       return "stale_lease";
+        default:                          return "unknown";
+    }
 }

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -167,25 +167,31 @@ static void control_task(void *arg)
     }
 
     for (;;) {
+        pv_moonraker_status_t st = {0};
+        if (s_net_up && s_mk_up) pv_moonraker_get_status(&st);
+        bool mk_connected = s_mk_up && st.state == PV_MK_SUBSCRIBED;
+        pb_policy_set_env(st.bed_temp, mk_connected);
+
         // Safety/control loop: enforces every heater cutoff + fan-follows-heater.
-        // The chamber setpoint is owned by the HTTP API (pb_httpd -> pb_heater),
-        // and the comms watchdog is fed by controller polls in pb_httpd — so we
-        // must NOT set the target here (that would clobber the HTTP-set value).
+        // pb_policy is the sole mode/target writer. Network clients and local
+        // inputs submit commands to it; this task applies the resulting outputs.
         pb_policy_tick();
         if (wdt_armed) esp_task_wdt_reset();   // successful loop iteration
 
         if (++dbg >= 4) {   // ~2 s
             dbg = 0;
             bool net = s_net_up;
-            pv_moonraker_status_t st = {0};
-            if (net && s_mk_up) pv_moonraker_get_status(&st);
+            pb_policy_snapshot_t snap;
+            pb_policy_get_snapshot(&snap);
             uint32_t zc = 0, zciv = 0;
             pb_fan_zc_diag(&zc, &zciv);
             ESP_LOGI(TAG,
-                "target=%.0fC heater=%s | chamber=%.1fC ptc=%.1fC | "
+                "rev=%lu mode=%s source=%s target=%.0fC heater=%s | chamber=%.1fC ptc=%.1fC | "
                 "wifi=%d mk=%d printer=%s bed=%.1f | ZC n=%lu dt=%luus",
-                pb_heater_get_target_c(), pb_heater_is_on() ? "ON" : "off",
-                pb_ntc_smoothed_c(PB_NTC_CHAMBER), pb_ntc_smoothed_c(PB_NTC_PTC),
+                (unsigned long)snap.state_revision,
+                pb_policy_mode_str(snap.mode), pb_policy_source_str(snap.source),
+                snap.effective_target_c, snap.heater_output ? "ON" : "off",
+                snap.chamber_c, snap.ptc_c,
                 net ? (int)pv_wifi_state() : -1, (int)st.state,
                 pv_printer_state_str(st.printer), st.bed_temp,
                 (unsigned long)zc, (unsigned long)zciv);

--- a/plans/iteration-2-stock-parity-and-config.md
+++ b/plans/iteration-2-stock-parity-and-config.md
@@ -98,6 +98,21 @@ added alongside `POST /settings` (bounds + current values in one read); `max_uri
 
 ## Phase B — Authoritative state + API v2 + modes
 
+**Delivery split.** Land this phase as a stacked series so safety/control review
+is not mixed with HTTP parsing:
+1. **Authoritative state-machine foundation:** make `pb_policy` the only
+   mode/target writer; add canonical snapshots, revisions, AUTO/DRYING,
+   device-issued leases, stale-lease rejection, boot-OFF, and bounded local
+   operation. Temporarily adapt the alpha HTTP handlers to call policy so there
+   is no second actuator owner between PRs.
+2. **API v2 protocol + observers:** delete the alpha `/status`, `/target`,
+   `/heartbeat`, and `/reset` contract; add the versioned JSON command/state
+   protocol and event stream; migrate the dashboard. `dragonbreath-klipper`
+   moves directly from the alpha API to v2 after the firmware contract lands.
+
+The persistent-fault/thermal-purge work in B2 remains independently reviewable
+safety work and must not be hidden inside transport parsing.
+
 **B1. `pb_policy` becomes the sole control-state and target writer.** Rewrite
 `components/pb_policy/`:
 - Remove `pb_policy_input_t` + the dead `pb_policy_apply()`.

--- a/tests/pb_policy_host_test.c
+++ b/tests/pb_policy_host_test.c
@@ -1,0 +1,366 @@
+#include "pb_policy.h"
+#include "pb_heater.h"
+#include "pb_leds.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int64_t fake_now_us;
+static unsigned random_generation;
+static float heater_target;
+static bool heater_on;
+static bool heater_fault;
+static bool heater_inhibited;
+static const char *heater_reason;
+static unsigned heater_link_pets;
+static float heater_max_target_c;
+static uint32_t heater_comms_timeout_ms;
+static uint8_t fan_level;
+static pb_led_pattern_t led_pattern[PB_LED_COUNT];
+static float chamber_c = 25.0f;
+static float ptc_c = 25.0f;
+static pb_ntc_status_t chamber_status = PB_NTC_OK;
+static pb_ntc_status_t ptc_status = PB_NTC_OK;
+
+#define CHECK(expr) do { \
+    if (!(expr)) { \
+        fprintf(stderr, "%s:%d: CHECK failed: %s\n", __FILE__, __LINE__, #expr); \
+        exit(1); \
+    } \
+} while (0)
+
+int64_t esp_timer_get_time(void) { return fake_now_us; }
+
+void esp_fill_random(void *buf, size_t len)
+{
+    unsigned char *p = buf;
+    random_generation++;
+    for (size_t i = 0; i < len; ++i)
+        p[i] = (unsigned char)(random_generation + i);
+}
+
+esp_err_t pb_heater_set_target_c(float target)
+{
+    if (!isfinite(target)) return ESP_ERR_INVALID_ARG;
+    if ((heater_fault || heater_inhibited) && target > 0.0f)
+        return ESP_ERR_INVALID_STATE;
+    if (target < 0.0f) target = 0.0f;
+    if (target > heater_max_target_c) target = heater_max_target_c;
+    heater_target = target;
+    return ESP_OK;
+}
+
+float pb_heater_get_target_c(void) { return heater_target; }
+float pb_heater_get_max_target_c(void) { return heater_max_target_c; }
+uint32_t pb_heater_get_comms_timeout_ms(void)
+{
+    return heater_comms_timeout_ms;
+}
+void pb_heater_notify_link_alive(void) { heater_link_pets++; }
+void pb_heater_tick(void) { heater_on = heater_target > 0.0f && !heater_fault; }
+
+void pb_heater_emergency_off(const char *reason)
+{
+    heater_target = 0.0f;
+    heater_on = false;
+    heater_fault = true;
+    heater_reason = reason;
+}
+
+void pb_heater_clear_fault(void)
+{
+    if (heater_inhibited) return;
+    heater_fault = false;
+    heater_target = 0.0f;
+    heater_reason = NULL;
+}
+
+bool pb_heater_is_inhibited(void) { return heater_inhibited; }
+bool pb_heater_is_faulted(void) { return heater_fault || heater_inhibited; }
+const char *pb_heater_fault_reason(void) { return heater_reason; }
+bool pb_heater_is_on(void) { return heater_on; }
+bool pb_heater_heat_mode(void)
+{
+    return heater_target > 0.0f && !heater_fault && !heater_inhibited;
+}
+
+void pb_fan_set_level(uint8_t percent) { fan_level = percent ? 100 : 0; }
+uint8_t pb_fan_get_level(void) { return fan_level; }
+void pb_leds_set(pb_led_id_t id, pb_led_pattern_t pattern)
+{
+    if (id >= 0 && id < PB_LED_COUNT) led_pattern[id] = pattern;
+}
+
+pb_ntc_status_t pb_ntc_last_status(pb_ntc_channel_t channel)
+{
+    return channel == PB_NTC_CHAMBER ? chamber_status : ptc_status;
+}
+
+float pb_ntc_smoothed_c(pb_ntc_channel_t channel)
+{
+    return channel == PB_NTC_CHAMBER ? chamber_c : ptc_c;
+}
+
+static void reset_fixture(void)
+{
+    fake_now_us = 1000000;
+    heater_target = 0.0f;
+    heater_on = false;
+    heater_fault = false;
+    heater_inhibited = false;
+    heater_reason = NULL;
+    heater_link_pets = 0;
+    heater_max_target_c = 70.0f;
+    heater_comms_timeout_ms = 5U * 60U * 1000U;
+    fan_level = 0;
+    memset(led_pattern, 0, sizeof led_pattern);
+    chamber_c = 25.0f;
+    ptc_c = 25.0f;
+    chamber_status = PB_NTC_OK;
+    ptc_status = PB_NTC_OK;
+    CHECK(pb_policy_init() == ESP_OK);
+}
+
+static pb_policy_snapshot_t snapshot(void)
+{
+    pb_policy_snapshot_t snap;
+    pb_policy_get_snapshot(&snap);
+    return snap;
+}
+
+static void test_boot_is_off(void)
+{
+    reset_fixture();
+    pb_policy_snapshot_t snap = snapshot();
+    CHECK(snap.state_revision == 1);
+    CHECK(snap.mode == PB_MODE_OFF);
+    CHECK(snap.source == PB_SOURCE_BOOT);
+    CHECK(snap.effective_target_c == 0.0f);
+    CHECK(!snap.lease_active);
+}
+
+static void test_remote_lease_and_stale_revision(void)
+{
+    reset_fixture();
+    pb_policy_lease_t first;
+    CHECK(pb_policy_set_power_on(
+        45.0f, PB_SOURCE_KLIPPER, "u1", 1, &first) == PB_POLICY_OK);
+    CHECK(strlen(first.id) == PB_POLICY_LEASE_ID_LEN);
+
+    pb_policy_snapshot_t snap = snapshot();
+    CHECK(snap.state_revision == 2);
+    CHECK(snap.mode == PB_MODE_POWER_ON);
+    CHECK(snap.source == PB_SOURCE_KLIPPER);
+    CHECK(snap.requested_target_c == 45.0f);
+    CHECK(snap.lease_active);
+    CHECK(strcmp(snap.lease_owner, "u1") == 0);
+    CHECK(heater_link_pets == 1);
+
+    pb_policy_lease_t rejected = {0};
+    CHECK(pb_policy_set_power_on(
+        50.0f, PB_SOURCE_WEB, "old-tab", 1, &rejected)
+        == PB_POLICY_REVISION_CONFLICT);
+    CHECK(rejected.id[0] == '\0');
+    CHECK(snapshot().requested_target_c == 45.0f);
+
+    CHECK(pb_policy_heartbeat(&first) == PB_POLICY_OK);
+    CHECK(heater_link_pets == 2);
+}
+
+static void test_new_command_supersedes_old_lease_and_off_is_unconditional(void)
+{
+    reset_fixture();
+    pb_policy_lease_t first, second;
+    CHECK(pb_policy_set_power_on(
+        45.0f, PB_SOURCE_WEB, "tab-1", 1, &first) == PB_POLICY_OK);
+    uint32_t rev = snapshot().state_revision;
+    CHECK(pb_policy_set_power_on(
+        50.0f, PB_SOURCE_KLIPPER, "u1", rev, &second) == PB_POLICY_OK);
+    CHECK(strcmp(first.id, second.id) != 0);
+    CHECK(pb_policy_heartbeat(&first) == PB_POLICY_STALE_LEASE);
+    CHECK(pb_policy_heartbeat(&second) == PB_POLICY_OK);
+
+    // OFF ignores an arbitrarily stale caller revision by design.
+    pb_policy_set_mode_off(PB_SOURCE_WEB);
+    pb_policy_snapshot_t snap = snapshot();
+    CHECK(snap.mode == PB_MODE_OFF);
+    CHECK(snap.effective_target_c == 0.0f);
+    CHECK(!snap.lease_active);
+    CHECK(pb_policy_heartbeat(&second) == PB_POLICY_STALE_LEASE);
+}
+
+static void test_lease_expiry_latches_watchdog_fault(void)
+{
+    reset_fixture();
+    pb_policy_lease_t lease;
+    CHECK(pb_policy_set_power_on(
+        55.0f, PB_SOURCE_KLIPPER, "u1", 1, &lease) == PB_POLICY_OK);
+    pb_policy_tick();
+    CHECK(pb_heater_is_on());
+
+    fake_now_us += (int64_t)heater_comms_timeout_ms * 1000 + 1;
+    pb_policy_tick();
+    pb_policy_snapshot_t snap = snapshot();
+    CHECK(snap.mode == PB_MODE_OFF);
+    CHECK(snap.source == PB_SOURCE_WATCHDOG);
+    CHECK(snap.fault_latched);
+    CHECK(strcmp(snap.fault_reason, "controller lease expired") == 0);
+    CHECK(!snap.heater_output);
+    CHECK(!snap.lease_active);
+    CHECK(pb_policy_heartbeat(&lease) == PB_POLICY_STALE_LEASE);
+}
+
+static void test_auto_requires_live_moonraker_and_uses_hysteresis(void)
+{
+    reset_fixture();
+    CHECK(pb_policy_set_auto(
+        60.0f, 100.0f, PB_SOURCE_WEB, 1) == PB_POLICY_OK);
+
+    pb_policy_set_env(99.0f, true);
+    pb_policy_tick();
+    CHECK(snapshot().effective_target_c == 0.0f);
+
+    pb_policy_set_env(100.0f, true);
+    pb_policy_tick();
+    pb_policy_snapshot_t snap = snapshot();
+    CHECK(snap.auto_engaged);
+    CHECK(snap.effective_target_c == 60.0f);
+
+    pb_policy_set_env(98.0f, true);
+    pb_policy_tick();
+    CHECK(snapshot().auto_engaged);
+
+    pb_policy_set_env(96.9f, true);
+    pb_policy_tick();
+    snap = snapshot();
+    CHECK(!snap.auto_engaged);
+    CHECK(snap.effective_target_c == 0.0f);
+
+    pb_policy_set_env(105.0f, false);
+    pb_policy_tick();
+    CHECK(!snapshot().auto_engaged);
+}
+
+static void test_drying_is_bounded_and_expires_off(void)
+{
+    reset_fixture();
+    CHECK(pb_policy_start_drying(
+        55.0f, 13, PB_SOURCE_WEB, 1) == PB_POLICY_INVALID);
+    CHECK(pb_policy_start_drying(
+        55.0f, 1, PB_SOURCE_WEB, 1) == PB_POLICY_OK);
+    pb_policy_tick();
+    CHECK(snapshot().drying);
+    CHECK(snapshot().effective_target_c == 55.0f);
+
+    fake_now_us += (int64_t)60 * 60 * 1000000 + 1;
+    pb_policy_tick();
+    pb_policy_snapshot_t snap = snapshot();
+    CHECK(snap.mode == PB_MODE_OFF);
+    CHECK(!snap.drying);
+    CHECK(snap.effective_target_c == 0.0f);
+}
+
+static void test_runtime_limits_drive_auto_and_remote_lease(void)
+{
+    reset_fixture();
+    heater_max_target_c = 52.0f;
+    CHECK(pb_policy_set_auto(
+        65.0f, 100.0f, PB_SOURCE_WEB, 1) == PB_POLICY_OK);
+    CHECK(snapshot().requested_target_c == 52.0f);
+    pb_policy_set_env(100.0f, true);
+    pb_policy_tick();
+    CHECK(snapshot().effective_target_c == 52.0f);
+
+    reset_fixture();
+    heater_comms_timeout_ms = 10000;
+    pb_policy_lease_t lease;
+    CHECK(pb_policy_set_power_on(
+        45.0f, PB_SOURCE_KLIPPER, "u1", 1, &lease) == PB_POLICY_OK);
+    CHECK(snapshot().lease_expires_ms == heater_comms_timeout_ms);
+    fake_now_us += (int64_t)heater_comms_timeout_ms * 1000 + 1;
+    pb_policy_tick();
+    CHECK(snapshot().fault_latched);
+}
+
+static void test_legacy_idle_heartbeat_is_benign(void)
+{
+    reset_fixture();
+    CHECK(pb_policy_heartbeat_legacy() == PB_POLICY_OK);
+    CHECK(heater_link_pets == 0);
+    CHECK(snapshot().mode == PB_MODE_OFF);
+}
+
+static void test_local_power_limit_expires_off_without_fault(void)
+{
+    reset_fixture();
+    CHECK(pb_policy_set_power_on(
+        45.0f, PB_SOURCE_BUTTON, "panel", 1, NULL) == PB_POLICY_OK);
+    pb_policy_tick();
+    CHECK(snapshot().heater_output);
+
+    fake_now_us += (int64_t)PB_POLICY_LOCAL_POWER_MAX_MS * 1000 + 1;
+    pb_policy_tick();
+    pb_policy_snapshot_t snap = snapshot();
+    CHECK(snap.mode == PB_MODE_OFF);
+    CHECK(snap.source == PB_SOURCE_WATCHDOG);
+    CHECK(!snap.fault_latched);
+    CHECK(snap.effective_target_c == 0.0f);
+
+    CHECK(pb_policy_set_power_on(
+        45.0f, PB_SOURCE_BUTTON, "panel", snap.state_revision, NULL)
+        == PB_POLICY_OK);
+}
+
+static void test_external_fault_sync_off_and_clear(void)
+{
+    reset_fixture();
+    pb_policy_lease_t lease;
+    CHECK(pb_policy_set_power_on(
+        45.0f, PB_SOURCE_KLIPPER, "u1", 1, &lease) == PB_POLICY_OK);
+    pb_policy_tick();
+    CHECK(led_pattern[PB_LED_POWER] == PB_LED_SOLID);
+    CHECK(led_pattern[PB_LED_ON] == PB_LED_SOLID);
+
+    pb_heater_emergency_off("external trip");
+    pb_policy_tick();
+    pb_policy_snapshot_t snap = snapshot();
+    CHECK(snap.mode == PB_MODE_OFF);
+    CHECK(snap.source == PB_SOURCE_SAFETY);
+    CHECK(snap.fault_latched);
+    CHECK(strcmp(snap.fault_reason, "external trip") == 0);
+    CHECK(!snap.lease_active);
+    CHECK(led_pattern[PB_LED_POWER] == PB_LED_BLINK);
+    CHECK(led_pattern[PB_LED_ON] == PB_LED_BLINK);
+
+    // OFF is unconditional even while the underlying safety fault remains latched.
+    pb_policy_set_mode_off(PB_SOURCE_WEB);
+    snap = snapshot();
+    CHECK(snap.mode == PB_MODE_OFF);
+    CHECK(snap.effective_target_c == 0.0f);
+    CHECK(snap.fault_latched);
+
+    CHECK(pb_policy_clear_fault(PB_SOURCE_WEB) == PB_POLICY_OK);
+    snap = snapshot();
+    CHECK(snap.mode == PB_MODE_OFF);
+    CHECK(snap.source == PB_SOURCE_WEB);
+    CHECK(!snap.fault_latched);
+    CHECK(snap.effective_target_c == 0.0f);
+}
+
+int main(void)
+{
+    test_boot_is_off();
+    test_remote_lease_and_stale_revision();
+    test_new_command_supersedes_old_lease_and_off_is_unconditional();
+    test_lease_expiry_latches_watchdog_fault();
+    test_auto_requires_live_moonraker_and_uses_hysteresis();
+    test_drying_is_bounded_and_expires_off();
+    test_runtime_limits_drive_auto_and_remote_lease();
+    test_legacy_idle_heartbeat_is_benign();
+    test_local_power_limit_expires_off_without_fault();
+    test_external_fault_sync_off_and_clear();
+    puts("pb_policy host tests: PASS");
+    return 0;
+}

--- a/tests/run_policy_host_test.sh
+++ b/tests/run_policy_host_test.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eu
+
+root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+out="${TMPDIR:-/tmp}/dragonbreath-pb-policy-test"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  -I"$root/tests/stubs" \
+  -I"$root/components/pb_policy/include" \
+  "$root/components/pb_policy/pb_policy.c" \
+  "$root/tests/pb_policy_host_test.c" \
+  -lm -o "$out"
+
+"$out"

--- a/tests/stubs/esp_err.h
+++ b/tests/stubs/esp_err.h
@@ -1,0 +1,6 @@
+#pragma once
+typedef int esp_err_t;
+#define ESP_OK 0
+#define ESP_ERR_NO_MEM 0x101
+#define ESP_ERR_INVALID_ARG 0x102
+#define ESP_ERR_INVALID_STATE 0x103

--- a/tests/stubs/esp_log.h
+++ b/tests/stubs/esp_log.h
@@ -1,0 +1,4 @@
+#pragma once
+#define ESP_LOGI(tag, ...) ((void)(tag))
+#define ESP_LOGW(tag, ...) ((void)(tag))
+#define ESP_LOGE(tag, ...) ((void)(tag))

--- a/tests/stubs/esp_random.h
+++ b/tests/stubs/esp_random.h
@@ -1,0 +1,3 @@
+#pragma once
+#include <stddef.h>
+void esp_fill_random(void *buf, size_t len);

--- a/tests/stubs/esp_timer.h
+++ b/tests/stubs/esp_timer.h
@@ -1,0 +1,3 @@
+#pragma once
+#include <stdint.h>
+int64_t esp_timer_get_time(void);

--- a/tests/stubs/freertos/FreeRTOS.h
+++ b/tests/stubs/freertos/FreeRTOS.h
@@ -1,0 +1,2 @@
+#pragma once
+#define portMAX_DELAY 0xffffffffU

--- a/tests/stubs/freertos/semphr.h
+++ b/tests/stubs/freertos/semphr.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <stdint.h>
+typedef void *SemaphoreHandle_t;
+static inline SemaphoreHandle_t xSemaphoreCreateMutex(void) { return (void *)1; }
+static inline int xSemaphoreTake(SemaphoreHandle_t sem, uint32_t wait)
+{
+    (void)sem;
+    (void)wait;
+    return 1;
+}
+static inline int xSemaphoreGive(SemaphoreHandle_t sem)
+{
+    (void)sem;
+    return 1;
+}

--- a/tests/stubs/pb_fan.h
+++ b/tests/stubs/pb_fan.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <stdint.h>
+void pb_fan_set_level(uint8_t percent);
+uint8_t pb_fan_get_level(void);

--- a/tests/stubs/pb_heater.h
+++ b/tests/stubs/pb_heater.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <stdbool.h>
+#include <stdint.h>
+#include "esp_err.h"
+
+esp_err_t pb_heater_set_target_c(float target_c);
+float pb_heater_get_target_c(void);
+float pb_heater_get_max_target_c(void);
+uint32_t pb_heater_get_comms_timeout_ms(void);
+void pb_heater_notify_link_alive(void);
+void pb_heater_tick(void);
+void pb_heater_emergency_off(const char *reason);
+void pb_heater_clear_fault(void);
+bool pb_heater_is_inhibited(void);
+bool pb_heater_is_faulted(void);
+const char *pb_heater_fault_reason(void);
+bool pb_heater_is_on(void);
+bool pb_heater_heat_mode(void);

--- a/tests/stubs/pb_leds.h
+++ b/tests/stubs/pb_leds.h
@@ -1,0 +1,19 @@
+#pragma once
+
+typedef enum {
+    PB_LED_AUTO = 0,
+    PB_LED_ON,
+    PB_LED_DRY,
+    PB_LED_POWER,
+    PB_LED_COUNT,
+} pb_led_id_t;
+
+typedef enum {
+    PB_LED_OFF = 0,
+    PB_LED_SOLID,
+    PB_LED_BLINK,
+    PB_LED_BLINK_SLOW,
+    PB_LED_CODE,
+} pb_led_pattern_t;
+
+void pb_leds_set(pb_led_id_t id, pb_led_pattern_t pattern);

--- a/tests/stubs/pb_ntc.h
+++ b/tests/stubs/pb_ntc.h
@@ -1,0 +1,13 @@
+#pragma once
+typedef enum {
+    PB_NTC_OK = 0,
+    PB_NTC_OPEN,
+    PB_NTC_SHORT,
+    PB_NTC_UNINIT,
+} pb_ntc_status_t;
+typedef enum {
+    PB_NTC_CHAMBER = 0,
+    PB_NTC_PTC,
+} pb_ntc_channel_t;
+pb_ntc_status_t pb_ntc_last_status(pb_ntc_channel_t channel);
+float pb_ntc_smoothed_c(pb_ntc_channel_t channel);


### PR DESCRIPTION
## What

Establishes `pb_policy` as DragonBreath's sole owner of modes, requested/effective targets, controller leases, deadlines, and the canonical control snapshot.

This is the first half of the API v2 series. A stacked follow-up will delete the alpha `/status`, `/target`, `/heartbeat`, and `/reset` contract and expose this state through the versioned JSON API and event stream.

## Why

The existing HTTP handlers write `pb_heater` directly while `pb_policy` only provides fan glue. That leaves no single authoritative answer when Klipper, the dashboard, Moonraker, buttons, safety logic, and watchdogs disagree.

## Changes

- adds OFF, POWER_ON, AUTO, and DRYING policy modes
- adds monotonic control-state revisions and source attribution
- adds device-issued 128-bit remote POWER_ON leases
- rejects stale revisions and stale/superseded heartbeats
- makes explicit OFF unconditional and lease-invalidating
- gates AUTO on a live Moonraker subscription with bed hysteresis
- bounds DRYING to 12 hours and local POWER_ON to 12 hours
- keeps boot state OFF and all leases/deadlines RAM-only
- synchronizes heater faults/watchdog expiry back into the canonical snapshot
- routes the alpha HTTP handlers through policy as a temporary adapter
- adds host tests around the actual `pb_policy.c`
- documents the stacked state-machine/API-v2 delivery split

Persistent fault storage and the broader thermal-purge overhaul remain separate safety work; they are not hidden in this transport-independent refactor.

## Safety detail

Policy computation and actuator application share the same mutex. An OFF command therefore cannot be overtaken by a control tick that computed an older positive target.

## Validation

- `sh tests/run_policy_host_test.sh`
- ESP-IDF v5.3 ESP32-C3 build in the official `espressif/idf:v5.3` container
- firmware size: `0xf7c40` bytes; 47% of the smallest app partition remains free
- `git diff --check`

Hardware validation is still required before merge.