### PR TITLE
feat: add authoritative API v2

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -44,6 +44,11 @@ jobs:
       - name: Test authoritative policy state machine
         run: sh tests/run_policy_host_test.sh
 
+      - name: Check API v2 contract and dashboard ownership
+        run: |
+          sh tests/check_api_v2_contract.sh
+          node tests/check_dashboard_js.mjs
+
       - name: Build (ESP-IDF v5.3)
         uses: espressif/esp-idf-ci-action@9d38657f3d789ca759b2b37aaf5ceffbc42c4f0d # v1
         with:

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ re-implemented.
 | `pb_ntc` | ✅ Stock conversion ported; **hardware-validated** (reads chamber temp matching the printer) |
 | `pb_heater` | ✅ Bang-bang + full safety cutoffs; SSR confirmed, heat cycle validated on hardware |
 | `pb_fan` | ✅ TRIAC **on/off held-gate** (stock model — the gate is never PWM'd/phase-chopped) |
-| `pb_policy` | 🚧 Authoritative mode/target/lease state machine (API v2 foundation) |
+| `pb_policy` | ✅ Authoritative mode/target/lease state machine |
 | Network core: `pv_wifi` / `pv_evlog` / `pv_moonraker` | ✅ Referenced from OpenVent (submodule); WiFi + Moonraker validated on hardware |
-| Portal / status dashboard / heat LED | ✅ Breath-local; captive-portal provisioning + live dashboard validated |
-| HTTP control API (`pb_httpd`) | ✅ `/status` `/target` `/heartbeat` `/reset`; CSRF-gated mutations |
-| Klipper-side helper (M141 / Fluidd) | ✅ [dragonbreath-klipper](https://github.com/plastikman/dragonbreath-klipper) — HTTP transport, M141/M191, Fluidd chamber card |
+| Portal / status dashboard / heat LED | 🚧 Captive provisioning validated; API v2 dashboard awaits hardware validation |
+| HTTP control API (`pb_httpd`) | 🚧 API v2 JSON command/state + SSE; CSRF-gated mutations |
+| Klipper-side helper (M141 / Fluidd) | 🚧 [dragonbreath-klipper](https://github.com/plastikman/dragonbreath-klipper) must migrate from the removed alpha API to v2 |
 | Flasher (`tools/flash.py`) | ✅ Backs up full stock flash first, then flashes; `--restore` returns to stock |
 | Web OTA update | ✅ Dual-OTA + rollback; upload from the UI, verified on hardware (DragonBreath-only, refused while heating) |
 
@@ -65,14 +65,23 @@ firmware can *guarantee* the absence of a fault; read [`docs/SAFETY.md`](docs/SA
 before touching heater code and supervise the device.
 
 ## Control API & access
-`pb_httpd` exposes a small HTTP API on port 80:
+`pb_httpd` exposes the versioned HTTP/JSON API on port 80:
 
 | Method | Path | Purpose |
 |---|---|---|
-| GET  | `/status` | read-only JSON (temps, target, heating, fault) — **no** side effects |
-| POST | `/target?t=<C>` | set chamber setpoint (0 = off); also counts as liveness |
-| POST | `/heartbeat` | controller liveness only (pet the comms watchdog) |
-| POST | `/reset` | clear a latched safety fault |
+| GET | `/api/v2/info` | device identity, boot identity, firmware and capabilities |
+| GET | `/api/v2/state` | complete authoritative state snapshot — **no** side effects |
+| GET | `/api/v2/events` | SSE stream of state transitions and telemetry snapshots |
+| GET | `/api/v2/health` | uptime, heap, Wi-Fi signal/channel, SSE client count |
+| POST | `/api/v2/command` | revision-aware OFF/POWER_ON/AUTO/DRYING/fault-clear command |
+| POST | `/api/v2/heartbeat` | refresh exactly the device-issued active lease |
+| POST | `/update` | authenticated DragonBreath app-image OTA; refused while heating |
+
+The alpha `/status`, `/target`, `/heartbeat`, and `/reset` routes are removed.
+Remote POWER_ON returns a device-issued lease; only an exact lease heartbeat can
+keep that session alive. Stale revisions cannot overwrite newer control state,
+while OFF is intentionally unconditional. See [`docs/api-v2.md`](docs/api-v2.md)
+for the wire contract.
 
 Every **mutating** endpoint (and the portal's STA-mode `/save`) requires a custom
 `X-DragonBreath-Auth` header. A cross-origin HTML form can't set a custom header and

--- a/components/pb_heater/include/pb_heater.h
+++ b/components/pb_heater/include/pb_heater.h
@@ -35,7 +35,8 @@
 // request heat. Idempotent.
 esp_err_t pb_heater_init(void);
 
-// Set the desired chamber temperature (clamped to [0, PB_HEATER_MAX_TARGET_C]).
+// Set the desired chamber temperature (clamped to the runtime ceiling returned
+// by pb_heater_get_max_target_c(), never above PB_HEATER_ABS_MAX_TARGET_C).
 // 0 (or below) disables heating. Returns:
 //   ESP_OK             - accepted
 //   ESP_ERR_INVALID_ARG   - non-finite (NaN/Inf) target, rejected
@@ -61,7 +62,7 @@ uint32_t  pb_heater_get_comms_timeout_ms(void);
 
 // Feed the comms watchdog: call whenever a live controller link is confirmed
 // (Moonraker connected, or a fresh command). If not called within
-// PB_HEATER_COMMS_TIMEOUT_MS while heating, the heater latches off.
+// pb_heater_get_comms_timeout_ms() while heating, the heater latches off.
 void pb_heater_notify_link_alive(void);
 
 // Periodic control tick (call at ~1-2 Hz). Reads chamber + PTC temps, enforces
@@ -79,10 +80,10 @@ void pb_heater_emergency_off(const char *reason);
 void pb_heater_clear_fault(void);
 
 // PERMANENT inhibit: force the heater off and refuse all heat until reboot. Unlike
-// a latched fault this is NOT clearable by pb_heater_clear_fault()/POST /reset —
+// a latched fault this is NOT clearable by pb_heater_clear_fault()/API clear_fault —
 // only a power cycle lifts it. Use for conditions under which the heater must
 // never run again this boot (e.g. the control-loop watchdog could not be armed,
-// so a hung loop would go undetected). Reports as a fault in /status.
+// so a hung loop would go undetected). Reports as a fault in API v2 state.
 void pb_heater_inhibit(const char *reason);
 
 // True once pb_heater_inhibit() has been called (reboot-only).

--- a/components/pb_heater/pb_heater.c
+++ b/components/pb_heater/pb_heater.c
@@ -93,7 +93,7 @@ esp_err_t pb_heater_set_target_c(float target_c)
     if (r == ESP_OK)
         ESP_LOGI(TAG, "target set to %.1f C", target_c);
     else
-        ESP_LOGW(TAG, "target %.1f rejected: fault latched (POST /reset, then a fresh target)", target_c);
+        ESP_LOGW(TAG, "target %.1f rejected: fault latched (clear fault, then issue a fresh command)", target_c);
     return r;
 }
 

--- a/components/pb_httpd/CMakeLists.txt
+++ b/components/pb_httpd/CMakeLists.txt
@@ -1,5 +1,6 @@
 idf_component_register(
     SRCS "pb_httpd.c"
     INCLUDE_DIRS "include"
-    REQUIRES esp_http_server pb_heater pb_ntc pb_policy json nvs_flash app_update mbedtls
+    REQUIRES esp_http_server pb_heater pb_ntc pb_policy json nvs_flash app_update
+             mbedtls esp_wifi esp_timer esp_system
 )

--- a/components/pb_httpd/include/pb_httpd.h
+++ b/components/pb_httpd/include/pb_httpd.h
@@ -1,21 +1,22 @@
 // SPDX-License-Identifier: MIT
-// pb_httpd — tiny HTTP control API so a Klipper-side helper can surface the
-// chamber in Fluidd (temp + settable target) and map M141/M191 to DragonBreath.
+// pb_httpd — authoritative DragonBreath HTTP/JSON API v2.
 //
-//   GET  /status       -> {temp,ptc,target,heating,fault,max}  READ-ONLY, no side effects
-//   POST /target?t=<C> -> set chamber setpoint in C (0=off); also counts as liveness
-//   POST /heartbeat    -> controller liveness only (pet the comms watchdog)
-//   POST /reset        -> clear a latched safety fault (over-temp / sensor / comms)
+//   GET  /api/v2/info
+//   GET  /api/v2/state
+//   GET  /api/v2/events       Server-Sent Events: state + telemetry snapshots
+//   GET  /api/v2/health
+//   POST /api/v2/command      revision-aware mode/control command
+//   POST /api/v2/heartbeat    refresh exactly one device-issued lease
 //
-// Liveness is explicit: the controller must POST /heartbeat (or /target)
-// regularly while it wants heat; if it stops, the heater comms-watchdog latches
-// off. GET /status never feeds the watchdog. Start after WiFi is up.
+// The alpha /status, /target, /heartbeat, and /reset contract is deliberately
+// removed. Read-only requests have no control side effects. A remote POWER_ON
+// session stays alive only when its exact device-issued lease is heartbeated.
 //
-// CSRF / control gate: every mutating endpoint (/target, /reset, /heartbeat, and
+// CSRF / control gate: every mutating endpoint (command, heartbeat, and
 // the portal's STA-mode /save) requires the custom header "X-DragonBreath-Auth".
 // A cross-origin HTML form cannot set a custom header and we never enable CORS,
 // so an ordinary drive-by page cannot command the heater or rewrite its Wi-Fi
-// config. GET /status stays open (read-only). This is CSRF hardening for a
+// config. Read-only API routes stay open. This is CSRF hardening for a
 // trusted LAN, not transport security.
 #pragma once
 #include "esp_err.h"

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -10,7 +10,11 @@
 #include "nvs.h"
 #include "esp_ota_ops.h"
 #include "esp_app_desc.h"
+#include "esp_mac.h"
+#include "esp_random.h"
 #include "esp_system.h"
+#include "esp_timer.h"
+#include "esp_wifi.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "mbedtls/sha256.h"
@@ -21,6 +25,14 @@
 
 static const char *TAG = "pb_httpd";
 static httpd_handle_t s_server;
+static char s_device_id[32];
+static char s_boot_id[33];
+static portMUX_TYPE s_sse_mux = portMUX_INITIALIZER_UNLOCKED;
+static unsigned s_sse_clients;
+
+#define API_VERSION 2
+#define API_BODY_MAX 1536
+#define SSE_MAX_CLIENTS 2
 
 void pb_httpd_ctl_token(char *out, size_t outsz)
 {
@@ -58,7 +70,9 @@ static bool auth_reject(httpd_req_t *req)
     if (pb_httpd_auth_ok(req)) return false;
     httpd_resp_set_status(req, "403 Forbidden");
     httpd_resp_set_type(req, "application/json");
-    httpd_resp_sendstr(req, "{\"error\":\"missing/invalid " PB_AUTH_HEADER " header\"}");
+    httpd_resp_sendstr(req,
+        "{\"ok\":false,\"error\":\"auth_failed\","
+        "\"message\":\"missing/invalid " PB_AUTH_HEADER " header\"}");
     return true;
 }
 
@@ -82,157 +96,493 @@ static void add_num1(cJSON *o, const char *key, float v)
     cJSON_AddRawToObject(o, key, b);
 }
 
-// Read-only. Deliberately has NO side effects — monitoring (a dashboard, a
-// browser) must never keep the heater alive. Liveness is a separate explicit
-// POST /heartbeat, so losing the controller trips the comms watchdog. Built with
-// cJSON so temps are emitted as JSON null (never the invalid bare token `nan`)
-// when a channel isn't reading OK, alongside explicit per-sensor status.
-static esp_err_t status_get(httpd_req_t *req)
+static const char *fan_reason(const pb_policy_snapshot_t *s)
 {
-    pb_policy_snapshot_t snap;
-    pb_policy_get_snapshot(&snap);
-    pb_ntc_status_t cs = snap.chamber_status;
-    pb_ntc_status_t ps = snap.ptc_status;
+    if (s->fault_latched || s->inhibited) return "fault";
+    if (s->thermal_purge) return "thermal_purge";
+    if (s->heater_demand) return "heater";
+    if (s->effective_fan_percent) return "requested";
+    return "off";
+}
 
+static cJSON *state_json(const pb_policy_snapshot_t *s)
+{
     cJSON *o = cJSON_CreateObject();
-    if (!o) { httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "oom"); return ESP_FAIL; }
+    if (!o) return NULL;
+    cJSON_AddNumberToObject(o, "api_version", API_VERSION);
+    cJSON_AddStringToObject(o, "device_id", s_device_id);
+    cJSON_AddStringToObject(o, "boot_id", s_boot_id);
+    cJSON_AddStringToObject(o, "firmware", esp_app_get_description()->version);
+    cJSON_AddNumberToObject(o, "state_revision", s->state_revision);
+    cJSON_AddStringToObject(o, "mode", pb_policy_mode_str(s->mode));
+    cJSON_AddStringToObject(o, "source", pb_policy_source_str(s->source));
 
-    add_num1(o, "temp", snap.chamber_c);
-    add_num1(o, "ptc", snap.ptc_c);
-    cJSON_AddStringToObject(o, "chamber_status", ntc_status_str(cs));
-    cJSON_AddStringToObject(o, "ptc_status", ntc_status_str(ps));
-    add_num1(o, "target", snap.effective_target_c);
-    cJSON_AddBoolToObject(o, "heating", snap.heater_output);
-    cJSON_AddBoolToObject(o, "fault", snap.fault_latched);
-    if (snap.fault_reason[0])
-        cJSON_AddStringToObject(o, "fault_reason", snap.fault_reason);
-    else    cJSON_AddNullToObject(o, "fault_reason");
-    add_num1(o, "max", pb_heater_get_max_target_c());
-    add_num1(o, "max_abs", PB_HEATER_ABS_MAX_TARGET_C);
-    cJSON_AddNumberToObject(o, "comms_ms", pb_heater_get_comms_timeout_ms());
-    cJSON_AddStringToObject(o, "version", esp_app_get_description()->version);
-    // Transitional visibility while the dashboard/helper still use the alpha
-    // routes. API v2 replaces this entire document with the canonical snapshot.
-    cJSON_AddNumberToObject(o, "revision", snap.state_revision);
-    cJSON_AddStringToObject(o, "mode", pb_policy_mode_str(snap.mode));
-    cJSON_AddStringToObject(o, "source", pb_policy_source_str(snap.source));
-    cJSON_AddBoolToObject(o, "lease_active", snap.lease_active);
+    cJSON *target = cJSON_AddObjectToObject(o, "target");
+    add_num1(target, "requested_c", s->requested_target_c);
+    add_num1(target, "effective_c", s->effective_target_c);
+    add_num1(target, "maximum_c", pb_heater_get_max_target_c());
 
+    cJSON *config = cJSON_AddObjectToObject(o, "config");
+    add_num1(config, "max", pb_heater_get_max_target_c());
+    add_num1(config, "max_abs", PB_HEATER_ABS_MAX_TARGET_C);
+    cJSON_AddNumberToObject(
+        config, "comms_ms", pb_heater_get_comms_timeout_ms());
+
+    cJSON *heater = cJSON_AddObjectToObject(o, "heater");
+    cJSON_AddBoolToObject(heater, "demand", s->heater_demand);
+    cJSON_AddBoolToObject(heater, "output", s->heater_output);
+
+    cJSON *fan = cJSON_AddObjectToObject(o, "fan");
+    cJSON_AddNumberToObject(fan, "requested_percent", s->requested_fan_percent);
+    cJSON_AddNumberToObject(fan, "effective_percent", s->effective_fan_percent);
+    cJSON_AddStringToObject(fan, "reason", fan_reason(s));
+
+    cJSON *sensors = cJSON_AddObjectToObject(o, "sensors");
+    cJSON *chamber = cJSON_AddObjectToObject(sensors, "chamber");
+    add_num1(chamber, "temperature_c", s->chamber_c);
+    cJSON_AddStringToObject(chamber, "status", ntc_status_str(s->chamber_status));
+    cJSON *ptc = cJSON_AddObjectToObject(sensors, "ptc");
+    add_num1(ptc, "temperature_c", s->ptc_c);
+    cJSON_AddStringToObject(ptc, "status", ntc_status_str(s->ptc_status));
+
+    cJSON *environment = cJSON_AddObjectToObject(o, "environment");
+    cJSON_AddBoolToObject(environment, "moonraker_connected", s->moonraker_connected);
+    add_num1(environment, "bed_temperature_c", s->bed_c);
+    cJSON_AddBoolToObject(environment, "auto_engaged", s->auto_engaged);
+    add_num1(environment, "auto_bed_threshold_c", s->auto_bed_threshold_c);
+
+    cJSON *drying = cJSON_AddObjectToObject(o, "drying");
+    cJSON_AddBoolToObject(drying, "active", s->drying);
+    cJSON_AddNumberToObject(drying, "remaining_seconds", s->drying_remaining_s);
+
+    cJSON *control = cJSON_AddObjectToObject(o, "control");
+    cJSON *lease = cJSON_AddObjectToObject(control, "lease");
+    cJSON_AddBoolToObject(lease, "active", s->lease_active);
+    if (s->lease_active) {
+        cJSON_AddStringToObject(lease, "owner", s->lease_owner);
+        cJSON_AddNumberToObject(lease, "expires_in_ms", s->lease_expires_ms);
+    } else {
+        cJSON_AddNullToObject(lease, "owner");
+        cJSON_AddNumberToObject(lease, "expires_in_ms", 0);
+    }
+
+    cJSON *safety = cJSON_AddObjectToObject(o, "safety");
+    cJSON_AddBoolToObject(safety, "fault_latched", s->fault_latched);
+    cJSON_AddBoolToObject(safety, "inhibited", s->inhibited);
+    if (s->fault_reason[0])
+        cJSON_AddStringToObject(safety, "reason", s->fault_reason);
+    else
+        cJSON_AddNullToObject(safety, "reason");
+    return o;
+}
+
+static esp_err_t send_json(httpd_req_t *req, cJSON *o)
+{
     char *out = cJSON_PrintUnformatted(o);
+    if (!out) {
+        cJSON_Delete(o);
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "oom");
+        return ESP_FAIL;
+    }
     httpd_resp_set_type(req, "application/json");
-    esp_err_t r = httpd_resp_sendstr(req, out ? out : "{}");
-    if (out) cJSON_free(out);
+    httpd_resp_set_hdr(req, "Cache-Control", "no-store");
+    esp_err_t r = httpd_resp_sendstr(req, out);
+    cJSON_free(out);
     cJSON_Delete(o);
     return r;
 }
 
-// Explicit controller liveness. The controller must POST this regularly while it
-// wants heat; if it stops, the heater comms-watchdog latches off.
-static esp_err_t heartbeat_post(httpd_req_t *req)
+static esp_err_t api_error(
+    httpd_req_t *req,
+    const char *status,
+    const char *code,
+    const char *message,
+    const char *request_id)
 {
-    if (auth_reject(req)) return ESP_OK;
-    pb_policy_result_t r = pb_policy_heartbeat_legacy();
-    if (r != PB_POLICY_OK) {
-        httpd_resp_set_status(req, "409 Conflict");
-        httpd_resp_set_type(req, "application/json");
-        char b[80];
-        snprintf(b, sizeof b, "{\"error\":\"%s\"}", pb_policy_result_str(r));
-        return httpd_resp_sendstr(req, b);
-    }
-    httpd_resp_set_type(req, "application/json");
-    return httpd_resp_sendstr(req, "{\"ok\":true}");
+    cJSON *o = cJSON_CreateObject();
+    if (!o) return ESP_FAIL;
+    cJSON_AddBoolToObject(o, "ok", false);
+    cJSON_AddStringToObject(o, "error", code);
+    cJSON_AddStringToObject(o, "message", message);
+    if (request_id) cJSON_AddStringToObject(o, "request_id", request_id);
+    pb_policy_snapshot_t snap;
+    pb_policy_get_snapshot(&snap);
+    cJSON_AddItemToObject(o, "state", state_json(&snap));
+    httpd_resp_set_status(req, status);
+    return send_json(req, o);
 }
 
-// Explicit safety-fault reset (over-temp / sensor / comms). POST-only.
-static esp_err_t reset_post(httpd_req_t *req)
+static cJSON *recv_json(httpd_req_t *req)
 {
-    if (auth_reject(req)) return ESP_OK;
-    // A permanent inhibit can't be cleared — say so (409) rather than falsely
-    // reporting a successful clear.
-    if (pb_heater_is_inhibited()) {
-        httpd_resp_set_status(req, "409 Conflict");
-        httpd_resp_set_type(req, "application/json");
-        return httpd_resp_sendstr(req,
-            "{\"error\":\"heater permanently inhibited — reboot required\"}");
+    if (req->content_len <= 0 || req->content_len > API_BODY_MAX) return NULL;
+    char body[API_BODY_MAX + 1];
+    int got = 0;
+    while (got < req->content_len) {
+        int r = httpd_req_recv(req, body + got, req->content_len - got);
+        if (r == HTTPD_SOCK_ERR_TIMEOUT) continue;
+        if (r <= 0) return NULL;
+        got += r;
     }
-    pb_policy_result_t r = pb_policy_clear_fault(PB_SOURCE_WEB);
-    if (r != PB_POLICY_OK) {
-        httpd_resp_set_status(req, "409 Conflict");
-        httpd_resp_set_type(req, "application/json");
-        char b[80];
-        snprintf(b, sizeof b, "{\"error\":\"%s\"}", pb_policy_result_str(r));
-        return httpd_resp_sendstr(req, b);
-    }
-    httpd_resp_set_type(req, "application/json");
-    return httpd_resp_sendstr(req, "{\"ok\":true}");
+    body[got] = '\0';
+    return cJSON_ParseWithLength(body, got);
 }
 
-// Parse a finite decimal temperature. strtof with an end-pointer check rejects
-// junk AND non-finite tokens ("nan"/"inf" -> isfinite() false), which atof would
-// silently accept. Trailing non-whitespace ("45junk", "45 60") is also rejected
-// so a partially-numeric value can never be silently truncated to a target.
-static bool parse_temp(const char *s, float *out)
+static bool json_number(const cJSON *o, const char *key, double *out)
 {
-    if (!s || !*s) return false;
-    char *end = NULL;
-    float v = strtof(s, &end);
-    if (end == s || !isfinite(v)) return false;
-    while (*end == ' ' || *end == '\t' || *end == '\r' || *end == '\n') end++;
-    if (*end != '\0') return false;      // trailing junk after the number
-    *out = v;
+    cJSON *v = cJSON_GetObjectItemCaseSensitive(o, key);
+    if (!cJSON_IsNumber(v) || !isfinite(v->valuedouble)) return false;
+    *out = v->valuedouble;
     return true;
 }
 
-// POST /target?t=<celsius>  (0 = off). POST-only so a stray GET (browser prefetch,
-// crawler, link) can never energize the heater. A target command also counts as
-// liveness. Falls back to a plain-number body if no query.
-static esp_err_t target_set(httpd_req_t *req)
+static esp_err_t info_get(httpd_req_t *req)
 {
-    if (auth_reject(req)) return ESP_OK;
-    float t = 0.0f;
-    bool have = false;
-    char q[48];
-    if (httpd_req_get_url_query_str(req, q, sizeof q) == ESP_OK) {
-        char v[16];
-        if (httpd_query_key_value(q, "t", v, sizeof v) == ESP_OK) have = parse_temp(v, &t);
-    }
-    if (!have) {                                     // try request body ("60" / "60.0")
-        char body[16] = {0};
-        int r = httpd_req_recv(req, body, sizeof body - 1);
-        if (r > 0) { body[r] = '\0'; have = parse_temp(body, &t); }
-    }
-    if (!have) {
-        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "bad/missing target ?t=<finite C>");
-        return ESP_FAIL;
-    }
+    cJSON *o = cJSON_CreateObject();
+    cJSON_AddNumberToObject(o, "api_version", API_VERSION);
+    cJSON_AddStringToObject(o, "device_id", s_device_id);
+    cJSON_AddStringToObject(o, "boot_id", s_boot_id);
+    cJSON_AddStringToObject(o, "firmware", esp_app_get_description()->version);
+    cJSON_AddStringToObject(o, "project", esp_app_get_description()->project_name);
+    cJSON *cap = cJSON_AddArrayToObject(o, "capabilities");
+    cJSON_AddItemToArray(cap, cJSON_CreateString("power_on"));
+    cJSON_AddItemToArray(cap, cJSON_CreateString("auto"));
+    cJSON_AddItemToArray(cap, cJSON_CreateString("drying"));
+    cJSON_AddItemToArray(cap, cJSON_CreateString("lease_heartbeat"));
+    cJSON_AddItemToArray(cap, cJSON_CreateString("sse"));
+    return send_json(req, o);
+}
 
-    pb_policy_result_t pr;
-    pb_policy_lease_t lease = {0};
-    if (t <= 0.0f) {
-        pb_policy_set_mode_off(PB_SOURCE_WEB);
-        pr = PB_POLICY_OK;
-    } else {
-        pr = pb_policy_set_power_on(
-            t, PB_SOURCE_WEB, "legacy-http", PB_POLICY_REVISION_ANY, &lease);
-    }
-    if (pr == PB_POLICY_FAULT_LATCHED || pr == PB_POLICY_INHIBITED) {
-        httpd_resp_set_status(req, "409 Conflict");
-        httpd_resp_set_type(req, "application/json");
-        return httpd_resp_sendstr(req,
-            "{\"error\":\"fault latched — POST /reset, then set a target\"}");
-    }
-    if (pr != PB_POLICY_OK) {
-        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "invalid target");
-        return ESP_FAIL;
-    }
+static esp_err_t state_get(httpd_req_t *req)
+{
     pb_policy_snapshot_t snap;
     pb_policy_get_snapshot(&snap);
-    char buf[160];
-    int n = snprintf(buf, sizeof buf,
-        "{\"target\":%.1f,\"revision\":%lu,\"lease\":\"%s\"}",
-        snap.effective_target_c, (unsigned long)snap.state_revision, lease.id);
+    return send_json(req, state_json(&snap));
+}
+
+typedef struct {
+    char actor_id[PB_POLICY_OWNER_LEN + 1];
+    char request_id[65];
+    uint32_t revision;
+    char response[3072];
+} replay_entry_t;
+
+static replay_entry_t s_replay[2];
+static unsigned s_replay_next;
+
+static replay_entry_t *replay_find(
+    const char *actor_id,
+    const char *request_id)
+{
+    for (size_t i = 0; i < sizeof s_replay / sizeof s_replay[0]; i++)
+        if (s_replay[i].request_id[0]
+                && strcmp(s_replay[i].actor_id, actor_id) == 0
+                && strcmp(s_replay[i].request_id, request_id) == 0)
+            return &s_replay[i];
+    return NULL;
+}
+
+static void replay_store(
+    const char *actor_id,
+    const char *request_id,
+    uint32_t revision,
+    const char *response)
+{
+    replay_entry_t *e = &s_replay[s_replay_next++ % (sizeof s_replay / sizeof s_replay[0])];
+    snprintf(e->actor_id, sizeof e->actor_id, "%s", actor_id);
+    snprintf(e->request_id, sizeof e->request_id, "%s", request_id);
+    e->revision = revision;
+    snprintf(e->response, sizeof e->response, "%s", response);
+}
+
+static esp_err_t send_command_success(
+    httpd_req_t *req,
+    const char *actor_id,
+    const char *request_id,
+    const char *lease_id,
+    bool cache)
+{
+    pb_policy_snapshot_t snap;
+    pb_policy_get_snapshot(&snap);
+    cJSON *o = cJSON_CreateObject();
+    cJSON_AddBoolToObject(o, "ok", true);
+    cJSON_AddStringToObject(o, "request_id", request_id);
+    if (lease_id && lease_id[0])
+        cJSON_AddStringToObject(o, "lease_id", lease_id);
+    cJSON_AddItemToObject(o, "state", state_json(&snap));
+    char *out = cJSON_PrintUnformatted(o);
+    cJSON_Delete(o);
+    if (!out) return api_error(req, "500 Internal Server Error", "internal", "out of memory", request_id);
+    if (cache)
+        replay_store(actor_id, request_id, snap.state_revision, out);
     httpd_resp_set_type(req, "application/json");
-    return httpd_resp_send(req, buf, n);
+    httpd_resp_set_hdr(req, "Cache-Control", "no-store");
+    esp_err_t r = httpd_resp_sendstr(req, out);
+    cJSON_free(out);
+    return r;
+}
+
+static esp_err_t policy_error(
+    httpd_req_t *req,
+    pb_policy_result_t result,
+    const char *request_id)
+{
+    const char *status = result == PB_POLICY_INVALID
+        ? "400 Bad Request" : "409 Conflict";
+    const char *code = result == PB_POLICY_INVALID
+        ? "invalid_command" : pb_policy_result_str(result);
+    return api_error(req, status, code,
+                     "command rejected by authoritative policy", request_id);
+}
+
+static esp_err_t command_post(httpd_req_t *req)
+{
+    if (auth_reject(req)) return ESP_OK;
+    cJSON *root = recv_json(req);
+    if (!root)
+        return api_error(req, "400 Bad Request", "invalid_command", "invalid JSON body", NULL);
+
+    cJSON *version = cJSON_GetObjectItemCaseSensitive(root, "api_version");
+    cJSON *rid = cJSON_GetObjectItemCaseSensitive(root, "request_id");
+    cJSON *actor = cJSON_GetObjectItemCaseSensitive(root, "actor");
+    cJSON *command = cJSON_GetObjectItemCaseSensitive(root, "command");
+    cJSON *kind = cJSON_IsObject(actor)
+        ? cJSON_GetObjectItemCaseSensitive(actor, "kind") : NULL;
+    cJSON *actor_id = cJSON_IsObject(actor)
+        ? cJSON_GetObjectItemCaseSensitive(actor, "id") : NULL;
+    cJSON *name = cJSON_IsObject(command)
+        ? cJSON_GetObjectItemCaseSensitive(command, "name") : NULL;
+
+    char request_id_buf[65] = {0};
+    const char *request_id = NULL;
+    if (cJSON_IsString(rid) && rid->valuestring[0]
+            && strlen(rid->valuestring) <= 64) {
+        snprintf(request_id_buf, sizeof request_id_buf, "%s", rid->valuestring);
+        request_id = request_id_buf;
+    }
+    if (!cJSON_IsNumber(version) || version->valuedouble != API_VERSION) {
+        cJSON_Delete(root);
+        return api_error(req, "400 Bad Request", "unsupported_api_version",
+                         "api_version must be 2", request_id);
+    }
+    if (!request_id
+            || !cJSON_IsString(kind) || !cJSON_IsString(actor_id)
+            || !actor_id->valuestring[0] || strlen(actor_id->valuestring) > PB_POLICY_OWNER_LEN
+            || !cJSON_IsString(name)) {
+        cJSON_Delete(root);
+        return api_error(req, "400 Bad Request", "invalid_command",
+                         "request_id, actor.kind, actor.id, and command.name are required",
+                         request_id);
+    }
+    char actor_id_buf[PB_POLICY_OWNER_LEN + 1];
+    snprintf(actor_id_buf, sizeof actor_id_buf, "%s", actor_id->valuestring);
+    pb_source_t source;
+    if (strcmp(kind->valuestring, "klipper") == 0) source = PB_SOURCE_KLIPPER;
+    else if (strcmp(kind->valuestring, "web") == 0) source = PB_SOURCE_WEB;
+    else {
+        cJSON_Delete(root);
+        return api_error(req, "400 Bad Request", "invalid_command",
+                         "actor.kind must be web or klipper", request_id);
+    }
+
+    const char *cmd = name->valuestring;
+    bool cacheable = strcmp(cmd, "off") != 0
+        && strcmp(cmd, "drying_stop") != 0;
+    replay_entry_t *prior = cacheable
+        ? replay_find(actor_id_buf, request_id) : NULL;
+    if (prior) {
+        pb_policy_snapshot_t snap;
+        pb_policy_get_snapshot(&snap);
+        cJSON_Delete(root);
+        if (snap.state_revision == prior->revision) {
+            httpd_resp_set_type(req, "application/json");
+            httpd_resp_set_hdr(req, "Cache-Control", "no-store");
+            return httpd_resp_sendstr(req, prior->response);
+        }
+        return api_error(req, "409 Conflict", "revision_conflict",
+                         "request_id was already applied to an older state", request_id);
+    }
+
+    cJSON *expected = cJSON_GetObjectItemCaseSensitive(root, "expected_revision");
+    uint32_t revision = PB_POLICY_REVISION_ANY;
+    bool revision_valid = cJSON_IsNumber(expected) && expected->valuedouble >= 0
+            && expected->valuedouble < UINT32_MAX
+            && floor(expected->valuedouble) == expected->valuedouble;
+    if (revision_valid)
+        revision = (uint32_t)expected->valuedouble;
+
+    pb_policy_result_t result = PB_POLICY_INVALID;
+    double target = 0.0, threshold = 0.0, hours = 0.0;
+    pb_policy_lease_t issued_lease = {0};
+    if (strcmp(cmd, "off") == 0) {
+        pb_policy_set_mode_off(source);
+        result = PB_POLICY_OK; // revision intentionally ignored for safer action
+    } else if (!revision_valid) {
+        result = PB_POLICY_INVALID;
+    } else if (strcmp(cmd, "power_on") == 0
+            && json_number(command, "target_c", &target)) {
+        result = pb_policy_set_power_on(
+            (float)target, source, actor_id_buf, revision, &issued_lease);
+    } else if (strcmp(cmd, "auto") == 0
+            && json_number(command, "target_c", &target)
+            && json_number(command, "bed_threshold_c", &threshold)) {
+        result = pb_policy_set_auto(
+            (float)target, (float)threshold, source, revision);
+    } else if (strcmp(cmd, "drying_start") == 0
+            && json_number(command, "target_c", &target)
+            && json_number(command, "hours", &hours)
+            && hours >= 1 && hours <= 12 && floor(hours) == hours) {
+        result = pb_policy_start_drying(
+            (float)target, (uint8_t)hours, source, revision);
+    } else if (strcmp(cmd, "drying_stop") == 0) {
+        pb_policy_stop_drying(source); // safer action, like OFF
+        result = PB_POLICY_OK;
+    } else if (strcmp(cmd, "clear_fault") == 0) {
+        result = pb_policy_clear_fault(source, revision);
+    }
+
+    cJSON_Delete(root);
+    if (result != PB_POLICY_OK) return policy_error(req, result, request_id);
+    return send_command_success(
+        req,
+        actor_id_buf,
+        request_id,
+        issued_lease.id[0] ? issued_lease.id : NULL,
+        cacheable);
+}
+
+static esp_err_t heartbeat_post(httpd_req_t *req)
+{
+    if (auth_reject(req)) return ESP_OK;
+    cJSON *root = recv_json(req);
+    cJSON *version = root ? cJSON_GetObjectItemCaseSensitive(root, "api_version") : NULL;
+    cJSON *lease_id = root ? cJSON_GetObjectItemCaseSensitive(root, "lease_id") : NULL;
+    if (!root || !cJSON_IsNumber(version) || version->valuedouble != API_VERSION
+            || !cJSON_IsString(lease_id)
+            || strlen(lease_id->valuestring) != PB_POLICY_LEASE_ID_LEN) {
+        if (root) cJSON_Delete(root);
+        return api_error(req, "400 Bad Request", "invalid_command",
+                         "api_version 2 and exact lease_id are required", NULL);
+    }
+    pb_policy_lease_t lease = {0};
+    memcpy(lease.id, lease_id->valuestring, PB_POLICY_LEASE_ID_LEN);
+    cJSON_Delete(root);
+    pb_policy_result_t result = pb_policy_heartbeat(&lease);
+    if (result != PB_POLICY_OK) return policy_error(req, result, NULL);
+
+    pb_policy_snapshot_t snap;
+    pb_policy_get_snapshot(&snap);
+    cJSON *o = cJSON_CreateObject();
+    cJSON_AddBoolToObject(o, "ok", true);
+    cJSON_AddNumberToObject(o, "expires_in_ms", snap.lease_expires_ms);
+    cJSON_AddNumberToObject(o, "state_revision", snap.state_revision);
+    return send_json(req, o);
+}
+
+static esp_err_t health_get(httpd_req_t *req)
+{
+    wifi_ap_record_t ap = {0};
+    cJSON *o = cJSON_CreateObject();
+    cJSON_AddNumberToObject(o, "api_version", API_VERSION);
+    cJSON_AddStringToObject(o, "boot_id", s_boot_id);
+    cJSON_AddNumberToObject(o, "uptime_ms", esp_timer_get_time() / 1000);
+    cJSON_AddNumberToObject(o, "free_heap_bytes", esp_get_free_heap_size());
+    cJSON_AddNumberToObject(o, "minimum_free_heap_bytes", esp_get_minimum_free_heap_size());
+    if (esp_wifi_sta_get_ap_info(&ap) == ESP_OK) {
+        cJSON_AddNumberToObject(o, "wifi_rssi_dbm", ap.rssi);
+        cJSON_AddNumberToObject(o, "wifi_channel", ap.primary);
+    } else {
+        cJSON_AddNullToObject(o, "wifi_rssi_dbm");
+        cJSON_AddNullToObject(o, "wifi_channel");
+    }
+    portENTER_CRITICAL(&s_sse_mux);
+    unsigned clients = s_sse_clients;
+    portEXIT_CRITICAL(&s_sse_mux);
+    cJSON_AddNumberToObject(o, "sse_clients", clients);
+    return send_json(req, o);
+}
+
+static esp_err_t sse_send(
+    httpd_req_t *req,
+    const char *event,
+    uint32_t id,
+    const pb_policy_snapshot_t *snap)
+{
+    cJSON *o = state_json(snap);
+    if (!o) return ESP_ERR_NO_MEM;
+    char *json = cJSON_PrintUnformatted(o);
+    cJSON_Delete(o);
+    if (!json) return ESP_ERR_NO_MEM;
+    char head[64];
+    int n = id == UINT32_MAX
+        ? snprintf(head, sizeof head, "event: %s\n", event)
+        : snprintf(head, sizeof head, "event: %s\nid: %lu\n", event, (unsigned long)id);
+    esp_err_t r = httpd_resp_send_chunk(req, head, n);
+    if (r == ESP_OK) r = httpd_resp_send_chunk(req, "data: ", 6);
+    if (r == ESP_OK) r = httpd_resp_send_chunk(req, json, strlen(json));
+    if (r == ESP_OK) r = httpd_resp_send_chunk(req, "\n\n", 2);
+    cJSON_free(json);
+    return r;
+}
+
+static void sse_task(void *arg)
+{
+    httpd_req_t *req = arg;
+    uint32_t last_revision = UINT32_MAX;
+    int64_t last_telemetry_us = 0;
+    for (;;) {
+        pb_policy_snapshot_t snap;
+        pb_policy_get_snapshot(&snap);
+        int64_t now = esp_timer_get_time();
+        esp_err_t r = ESP_OK;
+        if (snap.state_revision != last_revision) {
+            r = sse_send(req, "state", snap.state_revision, &snap);
+            last_revision = snap.state_revision;
+            last_telemetry_us = now;
+        } else if (now - last_telemetry_us >= 2000000) {
+            r = sse_send(req, "telemetry", UINT32_MAX, &snap);
+            last_telemetry_us = now;
+        }
+        if (r != ESP_OK) break;
+        vTaskDelay(pdMS_TO_TICKS(250));
+    }
+    httpd_req_async_handler_complete(req);
+    portENTER_CRITICAL(&s_sse_mux);
+    s_sse_clients--;
+    portEXIT_CRITICAL(&s_sse_mux);
+    vTaskDelete(NULL);
+}
+
+static esp_err_t events_get(httpd_req_t *req)
+{
+    portENTER_CRITICAL(&s_sse_mux);
+    bool full = s_sse_clients >= SSE_MAX_CLIENTS;
+    if (!full) s_sse_clients++;
+    portEXIT_CRITICAL(&s_sse_mux);
+    if (full)
+        return api_error(req, "503 Service Unavailable", "busy",
+                         "event stream client limit reached", NULL);
+
+    httpd_req_t *async_req = NULL;
+    if (httpd_req_async_handler_begin(req, &async_req) != ESP_OK) {
+        portENTER_CRITICAL(&s_sse_mux);
+        s_sse_clients--;
+        portEXIT_CRITICAL(&s_sse_mux);
+        return api_error(req, "503 Service Unavailable", "busy",
+                         "cannot start event stream", NULL);
+    }
+    httpd_resp_set_type(async_req, "text/event-stream");
+    httpd_resp_set_hdr(async_req, "Cache-Control", "no-cache");
+    httpd_resp_set_hdr(async_req, "Connection", "keep-alive");
+    if (xTaskCreate(sse_task, "db_sse", 6144, async_req, 3, NULL) != pdPASS) {
+        api_error(async_req, "503 Service Unavailable", "busy",
+                  "cannot start event stream task", NULL);
+        httpd_req_async_handler_complete(async_req);
+        portENTER_CRITICAL(&s_sse_mux);
+        s_sse_clients--;
+        portEXIT_CRITICAL(&s_sse_mux);
+        return ESP_OK;
+    }
+    return ESP_OK;
 }
 
 // Emit the current settings + their bounds as JSON (shared by GET /settings and
@@ -258,6 +608,20 @@ static esp_err_t settings_send(httpd_req_t *req)
 static esp_err_t settings_get(httpd_req_t *req)
 {
     return settings_send(req);
+}
+
+// Parse a finite decimal temperature. Trailing non-whitespace is rejected so a
+// partially numeric value can never silently become a safety setting.
+static bool parse_temp(const char *s, float *out)
+{
+    if (!s || !*s) return false;
+    char *end = NULL;
+    float v = strtof(s, &end);
+    if (end == s || !isfinite(v)) return false;
+    while (*end == ' ' || *end == '\t' || *end == '\r' || *end == '\n') end++;
+    if (*end != '\0') return false;
+    *out = v;
+    return true;
 }
 
 // Parse an unsigned integer (no sign, no junk, no overflow past u32).
@@ -416,7 +780,7 @@ esp_err_t pb_httpd_start(void)
     httpd_config_t cfg = HTTPD_DEFAULT_CONFIG();
     cfg.lru_purge_enable = true;
     cfg.uri_match_fn = httpd_uri_match_wildcard;   // lets pb_portal add a "/*" captive catch-all
-    cfg.max_uri_handlers = 14;                     // control API + settings + portal + captive
+    cfg.max_uri_handlers = 16;                     // 15 used + 1 spare
     // The OTA handler hashes the image (mbedtls) with a 1 KB read buffer + the
     // app descriptor on-stack, which overflows the 4 KB default httpd task stack
     // (stack-protection panic). Give it headroom.
@@ -424,21 +788,33 @@ esp_err_t pb_httpd_start(void)
     esp_err_t err = httpd_start(&s_server, &cfg);
     if (err != ESP_OK) return err;
 
-    httpd_uri_t status = { .uri = "/status",    .method = HTTP_GET,  .handler = status_get };
-    httpd_uri_t tgt    = { .uri = "/target",    .method = HTTP_POST, .handler = target_set };
-    httpd_uri_t hb     = { .uri = "/heartbeat", .method = HTTP_POST, .handler = heartbeat_post };
-    httpd_uri_t rst    = { .uri = "/reset",     .method = HTTP_POST, .handler = reset_post };
-    httpd_uri_t upd    = { .uri = "/update",    .method = HTTP_POST, .handler = update_post };
-    httpd_uri_t setg   = { .uri = "/settings",  .method = HTTP_GET,  .handler = settings_get };
-    httpd_uri_t setp   = { .uri = "/settings",  .method = HTTP_POST, .handler = settings_post };
-    httpd_register_uri_handler(s_server, &status);
-    httpd_register_uri_handler(s_server, &tgt);
+    uint8_t mac[6];
+    esp_read_mac(mac, ESP_MAC_WIFI_STA);
+    snprintf(s_device_id, sizeof s_device_id, "dragonbreath-%02x%02x%02x",
+             mac[3], mac[4], mac[5]);
+    snprintf(s_boot_id, sizeof s_boot_id, "%08lx%08lx%08lx%08lx",
+             (unsigned long)esp_random(), (unsigned long)esp_random(),
+             (unsigned long)esp_random(), (unsigned long)esp_random());
+
+    httpd_uri_t info   = { .uri = "/api/v2/info",      .method = HTTP_GET,  .handler = info_get };
+    httpd_uri_t state  = { .uri = "/api/v2/state",     .method = HTTP_GET,  .handler = state_get };
+    httpd_uri_t cmd    = { .uri = "/api/v2/command",   .method = HTTP_POST, .handler = command_post };
+    httpd_uri_t hb     = { .uri = "/api/v2/heartbeat", .method = HTTP_POST, .handler = heartbeat_post };
+    httpd_uri_t events = { .uri = "/api/v2/events",    .method = HTTP_GET,  .handler = events_get };
+    httpd_uri_t health = { .uri = "/api/v2/health",    .method = HTTP_GET,  .handler = health_get };
+    httpd_uri_t upd    = { .uri = "/update",           .method = HTTP_POST, .handler = update_post };
+    httpd_uri_t setg   = { .uri = "/settings",         .method = HTTP_GET,  .handler = settings_get };
+    httpd_uri_t setp   = { .uri = "/settings",         .method = HTTP_POST, .handler = settings_post };
+    httpd_register_uri_handler(s_server, &info);
+    httpd_register_uri_handler(s_server, &state);
+    httpd_register_uri_handler(s_server, &cmd);
     httpd_register_uri_handler(s_server, &hb);
-    httpd_register_uri_handler(s_server, &rst);
+    httpd_register_uri_handler(s_server, &events);
+    httpd_register_uri_handler(s_server, &health);
     httpd_register_uri_handler(s_server, &upd);
     httpd_register_uri_handler(s_server, &setg);
     httpd_register_uri_handler(s_server, &setp);
-    ESP_LOGI(TAG, "HTTP API up :80 (GET /status,/settings; POST /target?t=<C>, /heartbeat, /reset, /update, /settings)");
+    ESP_LOGI(TAG, "HTTP API v2 up :80 (info/state/events/health; command/heartbeat; settings; OTA /update)");
     return ESP_OK;
 }
 

--- a/components/pb_policy/include/pb_policy.h
+++ b/components/pb_policy/include/pb_policy.h
@@ -121,11 +121,15 @@ void pb_policy_stop_drying(pb_source_t source);
 void pb_policy_set_env(float bed_c, bool moonraker_connected);
 
 // Refresh exactly the active lease.  A stale/superseded lease cannot keep heat
-// alive.  The legacy helper exists only until API v2 replaces the alpha routes.
+// alive.
 pb_policy_result_t pb_policy_heartbeat(const pb_policy_lease_t *lease);
-pb_policy_result_t pb_policy_heartbeat_legacy(void);
 
-pb_policy_result_t pb_policy_clear_fault(pb_source_t source);
+// Clearing a fault changes authoritative state and therefore requires the
+// caller's observed revision. Unlike OFF, stale state must not clear a newer
+// fault or safety transition.
+pb_policy_result_t pb_policy_clear_fault(
+    pb_source_t source,
+    uint32_t expected_revision);
 
 // Periodic control tick (call at ~1-2 Hz).  Computes the effective target,
 // applies the heater/fan outputs, enforces deadlines, and synchronizes safety

--- a/components/pb_policy/pb_policy.c
+++ b/components/pb_policy/pb_policy.c
@@ -306,38 +306,16 @@ pb_policy_result_t pb_policy_heartbeat(const pb_policy_lease_t *lease)
     return PB_POLICY_OK;
 }
 
-pb_policy_result_t pb_policy_heartbeat_legacy(void)
-{
-    // Transitional adapter for the alpha /heartbeat route.  API v2 removes this
-    // capability and requires the device-issued lease ID on every heartbeat.
-    if (!s_lock) return PB_POLICY_STALE_LEASE;
-    xSemaphoreTake(s_lock, portMAX_DELAY);
-    // The deployed alpha helper heartbeats even while idle. Keep that harmless
-    // during the v1->v2 transition, but never let it revive a missing/expired
-    // POWER_ON lease.
-    if (s.mode != PB_MODE_POWER_ON) {
-        xSemaphoreGive(s_lock);
-        return PB_POLICY_OK;
-    }
-    if (!s.lease_active) {
-        xSemaphoreGive(s_lock);
-        return PB_POLICY_STALE_LEASE;
-    }
-    int64_t now = esp_timer_get_time();
-    if (now >= s.lease_deadline_us) {
-        xSemaphoreGive(s_lock);
-        return PB_POLICY_STALE_LEASE;
-    }
-    s.lease_deadline_us = now + remote_lease_ttl_us();
-    pb_heater_notify_link_alive();
-    xSemaphoreGive(s_lock);
-    return PB_POLICY_OK;
-}
-
-pb_policy_result_t pb_policy_clear_fault(pb_source_t source)
+pb_policy_result_t pb_policy_clear_fault(
+    pb_source_t source,
+    uint32_t expected_revision)
 {
     if (!s_lock) return PB_POLICY_INHIBITED;
     xSemaphoreTake(s_lock, portMAX_DELAY);
+    if (!revision_matches_locked(expected_revision)) {
+        xSemaphoreGive(s_lock);
+        return PB_POLICY_REVISION_CONFLICT;
+    }
     if (pb_heater_is_inhibited()) {
         xSemaphoreGive(s_lock);
         return PB_POLICY_INHIBITED;

--- a/components/pb_portal/pb_portal.c
+++ b/components/pb_portal/pb_portal.c
@@ -146,8 +146,9 @@ static const char CONFIG_WIFI[] =
     "<button type=button id=eye onclick='togglePw()' aria-label='show password'>\xF0\x9F\x91\x81</button></div>"
     "<button type=button class=sec onclick='rescan()'>Rescan networks</button></div>";
 
-// Live status dashboard (STA root). Polls /status every 2s; can set the target,
-// turn off, and clear a fault. Links to /setup for Wi-Fi/printer config.
+// Live status dashboard (STA root). API v2 state arrives over SSE; a serialized,
+// backoff-controlled poll is used only when an event stream cannot be held.
+// This tab heartbeats only the exact lease returned by its own POWER_ON command.
 static const char STATUS_BODY[] =
     "<div id=fault class=card style='display:none;background:#5a1f1f;color:#ffd7d7'></div>"
     "<div class=card style='text-align:center'>"
@@ -155,14 +156,25 @@ static const char STATUS_BODY[] =
     "<div id=temp style='font-size:3rem;font-weight:700;color:var(--accent);line-height:1.15'>--</div>"
     "<div id=cstat style='font-size:.75rem;color:#8a8a8a'></div></div>"
     "<div class=card>"
+    "<div class=srow><span>Mode</span><b id=mode>--</b></div>"
     "<div class=srow><span>Target</span><b id=target>--</b></div>"
     "<div class=srow><span>Heating</span><b id=heating>--</b></div>"
-    "<div class=srow><span>Element (PTC)</span><b id=ptc>--</b></div></div>"
-    "<div class=card><label>Set chamber target (&deg;C, 0 = off)</label>"
-    "<div class=pw><input id=tin type=number min=0 max=70 step=1 value=45>"
-    "<button type=button class=go style='width:auto;margin:0;padding:12px 18px' onclick='setT()'>Set</button></div>"
+    "<div class=srow><span>Fan</span><b id=fan>--</b></div>"
+    "<div class=srow><span>Element (PTC)</span><b id=ptc>--</b></div>"
+    "<div class=srow><span>Controller</span><b id=owner>--</b></div>"
+    "<div class=srow><span>Link</span><b id=link>--</b></div></div>"
+    "<div class=card><h2>Manual heat</h2><label>Chamber target (&deg;C)</label>"
+    "<div class=pw><input id=tin type=number min=0 step=1 value=45>"
+    "<button type=button class=go style='width:auto;margin:0;padding:12px 18px' onclick='powerOn()'>Start</button></div>"
     "<button type=button id=off class=sec onclick='setOff()' disabled>Turn heater off</button>"
     "<button type=button class=sec id=rst style='display:none' onclick='doReset()'>Clear fault</button></div>"
+    "<div class=card><h2>Automatic</h2><label>Bed threshold (&deg;C)</label>"
+    "<input id=bed type=number min=0 max=150 step=1 value=60>"
+    "<button type=button class=sec onclick='setAuto()'>Follow printer bed</button></div>"
+    "<div class=card><h2>Filament drying</h2><label>Duration (hours)</label>"
+    "<input id=hours type=number min=1 max=12 step=1 value=4>"
+    "<button type=button class=sec onclick='dryStart()'>Start drying</button>"
+    "<button type=button class=sec onclick='dryStop()'>Stop drying</button></div>"
     "<div class=card><h2>Advanced / Safety</h2>"
     "<label>Max target ceiling (&deg;C)</label><input id=smax type=number step=1>"
     "<label>Comms watchdog (s) &mdash; heater latches off if the controller goes silent</label>"
@@ -177,43 +189,70 @@ static const char STATUS_BODY[] =
     "<div id=ver style='text-align:center;color:#5a5a5a;font-size:.72rem;margin-top:2px'></div></div>"
     "<script>" DB_AUTH_JS
     "if(window.DB_VER)document.getElementById('ver').textContent='DragonBreath '+window.DB_VER;"
-    // iOwn: did THIS tab start the current heat? We heartbeat ONLY then, so a
-    // passive or freshly-reloaded dashboard (iOwn=false) never pets the comms
-    // watchdog and therefore can't mask a Klippy/controller failure.
-    "var iOwn=false;"
+    "var rev=0,lease=null,last=null,polling=false,pollDelay=2000;"
+    "var actor=sessionStorage.getItem('db_actor');"
+    "if(!actor){actor='web-'+Math.random().toString(16).slice(2);sessionStorage.setItem('db_actor',actor);}"
+    "function rid(){return self.crypto&&crypto.randomUUID?crypto.randomUUID():Date.now()+'-'+Math.random();}"
     "function u(i,v){document.getElementById(i).textContent=v;}"
-    "function refresh(){fetch('/status').then(function(r){return r.json();}).then(function(s){"
-    "u('temp',s.temp==null?'--':s.temp.toFixed(1)+'\\u00b0C');"
-    "u('ptc',s.ptc==null?'--':s.ptc.toFixed(1)+'\\u00b0C'+(s.ptc_status!='ok'?' ('+s.ptc_status+')':''));"
-    "u('target',s.target?s.target.toFixed(0)+'\\u00b0C':'off');"
-    // Reflect the live target (e.g. one set by Klipper) in the set-temp box, but
-    // never while the user is typing in it. Keep the last value when off.
+    "function deg(v){return v==null?'--':Number(v).toFixed(1)+'\\u00b0C';}"
+    "function apply(s){if(!s||s.api_version!==2)return;"
+    "if(last&&s.boot_id===last.boot_id&&s.state_revision<rev)return;"
+    "if(last&&s.boot_id!==last.boot_id)lease=null;last=s;rev=s.state_revision;"
+    "var c=s.sensors.chamber,p=s.sensors.ptc,l=s.control.lease;"
+    "u('temp',deg(c.temperature_c));u('cstat',c.status==='ok'?'':'sensor: '+c.status);"
+    "u('ptc',deg(p.temperature_c)+(p.status==='ok'?'':' ('+p.status+')'));"
+    "u('mode',s.mode);u('target',s.target.effective_c>0?deg(s.target.effective_c):'off');"
+    "u('heating',s.heater.output?'ON':(s.heater.demand?'waiting':'off'));"
+    "u('fan',s.fan.effective_percent+'% ('+s.fan.reason+')');"
+    "u('owner',l.active?(l.owner||'remote'):(s.source||'--'));"
+    "u('link',s.environment.moonraker_connected?'Moonraker online':'Moonraker offline');"
     "var tin=document.getElementById('tin');"
-    "if(s.max)tin.max=Math.round(s.max);"          // slider ceiling tracks the configured max
-    "if(document.activeElement!==tin&&s.target>0){tin.value=Math.round(s.target);}"
-    "u('heating',s.heating?'ON':'off');"
-    "var ob=document.getElementById('off');var on=s.target>0;ob.disabled=!on;"
+    "if(s.target.maximum_c!=null)tin.max=Math.round(s.target.maximum_c);"
+    "if(document.activeElement!==tin&&s.target.requested_c>0)tin.value=Math.round(s.target.requested_c);"
+    "var ob=document.getElementById('off'),on=s.mode!=='off';ob.disabled=!on;"
     "ob.style.background=on?'var(--accent)':'';ob.style.color=on?'#fff':'';ob.style.borderColor=on?'var(--accent)':'';"
-    "u('cstat',s.chamber_status=='ok'?'':'sensor: '+s.chamber_status);"
-    "if(!(s.target>0))iOwn=false;"          // heat is off -> nobody's lease, incl. ours
-    // Heartbeat lease — only for heat THIS tab started. Close the tab (or never
-    // having started it) lets the 5-min watchdog latch the heater off (fail-safe).
-    "if(iOwn&&s.target>0){fetch('/heartbeat',{method:'POST',headers:hdr()}).catch(function(){});}"
     "var f=document.getElementById('fault'),rb=document.getElementById('rst');"
-    "if(s.fault){f.style.display='block';f.textContent='\\u26a0 Fault: '+(s.fault_reason||'')+' (fix, then Clear fault)';rb.style.display='block';}"
+    "if(s.safety.fault_latched||s.safety.inhibited){f.style.display='block';"
+    "f.textContent='\\u26a0 '+(s.safety.inhibited?'Inhibited: ':'Fault: ')+(s.safety.reason||'unknown');"
+    "rb.style.display=s.safety.inhibited?'none':'block';}"
     "else{f.style.display='none';rb.style.display='none';}"
-    "}).catch(function(){});}"
-    // Take ownership ONLY after the device accepts a positive target (HTTP ok).
-    // A rejected/failed request must NOT leave this tab thinking it owns heat, or
-    // it could later heartbeat a target another controller set.
-    "function setT(){var v=document.getElementById('tin').value;var pos=parseFloat(v)>0;"
-    "post('/target?t='+encodeURIComponent(v)).then(function(r){iOwn=!!(r&&r.ok&&pos);refresh();})"
-    ".catch(function(){iOwn=false;refresh();});}"
-    "function setOff(){iOwn=false;post('/target?t=0').then(refresh);}"
-    "function doReset(){post('/reset').then(refresh);}"
-    // Advanced/Safety: load current settings + their bounds from /settings, and
-    // save edits back. The device clamps everything (ceiling <= 70 C, timeout
-    // 10s-5min), so out-of-range entries come back corrected.
+    // A passive/reloaded tab has lease=null. If another controller supersedes
+    // our lease, the next authoritative snapshot immediately stops heartbeats.
+    "if(!l.active||!lease||l.owner!==actor)lease=null;"
+    "}"
+    "function request(path,body){var h=hdr();h['Content-Type']='application/json';"
+    "return fetch(path,{method:'POST',headers:h,body:JSON.stringify(body)}).then(function(r){"
+    "return r.json().catch(function(){return{};}).then(function(j){"
+    "if(r.status===403){localStorage.removeItem('db_tok');alert('Control token rejected.');}"
+    "if(j.state)apply(j.state);if(!r.ok)throw j;return j;});});}"
+    "function command(name,fields){var b={api_version:2,request_id:rid(),expected_revision:rev,"
+    "actor:{kind:'web',id:actor},command:{name:name}};"
+    "Object.keys(fields||{}).forEach(function(k){b.command[k]=fields[k];});"
+    "return request('/api/v2/command',b);}"
+    "function powerOn(){lease=null;command('power_on',{target_c:+document.getElementById('tin').value})"
+    ".then(function(r){lease=r.lease_id||null;if(r.state)apply(r.state);})"
+    ".catch(function(){lease=null;});}"
+    "function setOff(){lease=null;command('off',{}).catch(function(){});}"
+    "function setAuto(){lease=null;command('auto',{target_c:+document.getElementById('tin').value,"
+    "bed_threshold_c:+document.getElementById('bed').value}).catch(function(){});}"
+    "function dryStart(){lease=null;command('drying_start',{target_c:+document.getElementById('tin').value,"
+    "hours:+document.getElementById('hours').value}).catch(function(){});}"
+    "function dryStop(){lease=null;command('drying_stop',{}).catch(function(){});}"
+    "function doReset(){lease=null;command('clear_fault',{}).catch(function(){});}"
+    "function heartbeat(){if(!lease||!last||last.mode!=='power_on')return;"
+    "request('/api/v2/heartbeat',{api_version:2,lease_id:lease}).catch(function(){lease=null;});}"
+    // Polling fallback is serialized: schedule the next request only after the
+    // current request settles, with bounded backoff on failure.
+    "function poll(){if(polling)return;polling=true;fetch('/api/v2/state',{cache:'no-store'})"
+    ".then(function(r){if(!r.ok)throw 0;return r.json();}).then(function(s){apply(s);pollDelay=2000;})"
+    ".catch(function(){pollDelay=Math.min(10000,Math.round(pollDelay*1.6));})"
+    ".finally(function(){polling=false;setTimeout(poll,pollDelay+Math.random()*250);});}"
+    "function events(){var es=new EventSource('/api/v2/events');var seen=false;"
+    "function ev(e){seen=true;try{apply(JSON.parse(e.data));}catch(_){}}"
+    "es.addEventListener('state',ev);es.addEventListener('telemetry',ev);"
+    "es.onerror=function(){es.close();if(!seen)poll();else setTimeout(poll,1000);};}"
+    // Advanced/Safety remains the persisted configuration surface until a
+    // dedicated v2 settings route is introduced.
     "function loadSettings(){fetch('/settings').then(function(r){return r.json();}).then(function(s){"
     "var mx=document.getElementById('smax');mx.min=s.max_min;mx.max=s.max_abs;"
     "if(document.activeElement!==mx)mx.value=Math.round(s.max);"
@@ -227,10 +266,10 @@ static const char STATUS_BODY[] =
     ".then(function(r){return r.json().then(function(j){return{s:r.status,j:j};})"
     ".catch(function(){return{s:r.status,j:{}};});})"
     ".then(function(x){if(x.s==200){m.innerHTML='<small>Saved \\u2713 (max '+x.j.max+'\\u00b0C, timeout '"
-    "+Math.round(x.j.comms_ms/1000)+'s)</small>';loadSettings();refresh();}"
+    "+Math.round(x.j.comms_ms/1000)+'s)</small>';loadSettings();}"
     "else{m.innerHTML='<small>Save failed: '+((x.j&&x.j.error)||('HTTP '+x.s))+'</small>';}})"
     ".catch(function(){m.innerHTML='<small>Save failed (connection).</small>';});}"
-    "refresh();setInterval(refresh,2000);loadSettings();"
+    "events();setInterval(heartbeat,30000);loadSettings();"
     "</script></body></html>";
 
 // Dedicated firmware-update page (GET /fw) — DragonBreath OTA only, its own page so

--- a/docs/api-v2.md
+++ b/docs/api-v2.md
@@ -1,0 +1,154 @@
+# DragonBreath API v2
+
+API v2 is the sole device control contract. It replaces the alpha `/status`,
+`/target`, `/heartbeat`, and `/reset` routes; clients must not probe for or fall
+back to those routes.
+
+All bodies are JSON. Read-only routes are open on the trusted LAN. Mutating
+routes require `X-DragonBreath-Auth`; the device does not enable CORS.
+
+## Read-only routes
+
+- `GET /api/v2/info` — API version, stable device ID, per-boot ID, firmware and
+  capabilities.
+- `GET /api/v2/state` — full authoritative snapshot. Reading never refreshes a
+  lease or otherwise changes device state.
+- `GET /api/v2/events` — Server-Sent Events. A `state` event is sent on connect
+  and when `state_revision` changes. A full `telemetry` snapshot is sent every
+  two seconds between transitions. At most two streams are held concurrently.
+- `GET /api/v2/health` — uptime, heap, Wi-Fi RSSI/channel and SSE client count.
+
+The complete snapshot, not locally remembered intent, is the source of truth:
+
+```json
+{
+  "api_version": 2,
+  "device_id": "dragonbreath-a1b2c3",
+  "boot_id": "4f7f00004f7f00004f7f00004f7f0000",
+  "firmware": "0.3.0",
+  "state_revision": 12,
+  "mode": "power_on",
+  "source": "klipper",
+  "target": {
+    "requested_c": 45.0,
+    "effective_c": 45.0,
+    "maximum_c": 70.0
+  },
+  "config": {
+    "max": 70.0,
+    "max_abs": 70.0,
+    "comms_ms": 300000
+  },
+  "heater": {"demand": true, "output": true},
+  "fan": {
+    "requested_percent": 100,
+    "effective_percent": 100,
+    "reason": "heater"
+  },
+  "sensors": {
+    "chamber": {"temperature_c": 36.2, "status": "ok"},
+    "ptc": {"temperature_c": 73.1, "status": "ok"}
+  },
+  "environment": {
+    "moonraker_connected": true,
+    "bed_temperature_c": 100.0,
+    "auto_engaged": false,
+    "auto_bed_threshold_c": 0.0
+  },
+  "drying": {"active": false, "remaining_seconds": 0},
+  "control": {
+    "lease": {
+      "active": true,
+      "owner": "u1-klippy",
+      "expires_in_ms": 299500
+    }
+  },
+  "safety": {
+    "fault_latched": false,
+    "inhibited": false,
+    "reason": null
+  }
+}
+```
+
+Temperatures are JSON `null` when their sensor status is not `ok`. Public
+state and SSE snapshots intentionally omit the raw lease ID; only the
+authenticated response that creates a POWER_ON lease returns it.
+`state_revision` changes only for control, mode, lease, fault, and safety
+transitions; ordinary temperature samples and successful heartbeats do not
+increment it.
+
+## Commands
+
+`POST /api/v2/command` takes a request ID, the revision observed by the caller,
+actor identity, and one command:
+
+```json
+{
+  "api_version": 2,
+  "request_id": "client-generated-unique-id",
+  "expected_revision": 12,
+  "actor": {"kind": "klipper", "id": "u1-klippy"},
+  "command": {"name": "power_on", "target_c": 45}
+}
+```
+
+Supported commands:
+
+- `{"name":"off"}` — unconditional. A missing or stale revision never blocks a
+  safer OFF.
+- `{"name":"power_on","target_c":45}` — creates a new device-issued remote
+  lease and invalidates any previous lease.
+- `{"name":"auto","target_c":45,"bed_threshold_c":60}` — device policy follows
+  the observed Moonraker bed state.
+- `{"name":"drying_start","target_c":50,"hours":4}` — bounded to 1–12 hours.
+- `{"name":"drying_stop"}` — unconditional safer stop.
+- `{"name":"clear_fault"}` — clears a recoverable fault only at the expected
+  revision. Permanent inhibits require correcting the condition and rebooting.
+
+`actor.kind` is `web` or `klipper`; `actor.id` is at most 31 characters.
+Successful responses contain `ok`, the `request_id`, and the complete new
+`state`. A successful `power_on` response also contains a top-level `lease_id`.
+Clients must take a POWER_ON lease only from that authenticated response, never
+from public state/events and never invent or reuse one.
+
+The device keeps a small replay cache keyed by `(actor.id, request_id)`.
+Repeating the same request while its resulting revision is still current
+returns the original response. Reusing it after state changed returns
+`revision_conflict`. Safer `off` and `drying_stop` commands are never cached and
+always execute.
+
+## Lease heartbeat
+
+```http
+POST /api/v2/heartbeat
+X-DragonBreath-Auth: ...
+Content-Type: application/json
+
+{"api_version":2,"lease_id":"exact 32-character device-issued ID"}
+```
+
+Only the currently active lease is accepted. A stale, superseded, expired, or
+invented ID returns HTTP 409 `stale_lease`. Heartbeats extend the lease deadline
+but do not change `state_revision`. Passive dashboards and reconnected clients
+must not heartbeat a lease they did not receive from their own accepted
+POWER_ON response.
+
+## Errors
+
+Errors are machine-readable and normally include the current authoritative
+state:
+
+```json
+{
+  "ok": false,
+  "error": "revision_conflict",
+  "message": "command rejected by authoritative policy",
+  "request_id": "...",
+  "state": {}
+}
+```
+
+Defined error codes include `invalid_command`, `unsupported_api_version`,
+`auth_failed`, `revision_conflict`, `stale_lease`, `fault_latched`,
+`inhibited`, and `busy`.

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -160,7 +160,7 @@ static void control_task(void *arg)
     if (!wdt_armed) {
         // Fail closed: without watchdog coverage a hung control loop could leave
         // the SSR energized undetected, so refuse to heat for the rest of this
-        // boot. This is a PERMANENT inhibit — POST /reset cannot clear it (unlike
+        // boot. This is a PERMANENT inhibit — API clear_fault cannot clear it (unlike
         // a normal fault); only a power cycle (which re-attempts enrollment) can.
         ESP_LOGE(TAG, "task WDT subscribe FAILED — inhibiting heat (reboot required)");
         pb_heater_inhibit("task watchdog unavailable");

--- a/plans/iteration-2-stock-parity-and-config.md
+++ b/plans/iteration-2-stock-parity-and-config.md
@@ -187,14 +187,15 @@ restores its inhibited state, never its prior target.
 **B7. API v2 (breaking alpha change).**
 - Introduce an explicit API version and structured JSON state/command documents.
   Exact paths may be finalized during implementation, but provide equivalents
-  of `GET state`, `POST command`, `POST heartbeat`, and `GET events`.
+  of `GET state`, `POST command`, `POST heartbeat`, and `GET events`. The
+  finalized routes and schemas are documented in `docs/api-v2.md`.
 - Command responses return the resulting authoritative snapshot/revision, not
   only `{"ok":true}`. Rejections include machine-readable fault, inhibit,
   version, validation, or stale-lease reasons.
 - Provide a device-originated SSE or WebSocket event stream; polling remains a
   recovery fallback.
 - `"set target" > 0` maps to POWER_ON and zero maps to OFF.
-- Update firmware, dashboard, and openbreath-klipper together. Require a
+- Update firmware, dashboard, and dragonbreath-klipper together. Require a
   firmware/helper version handshake and fail clearly on incompatibility. There
   is no obligation to preserve the current query-parameter alpha API.
 - User-facing precedence may remain last-writer-wins, but a stale writer must
@@ -243,7 +244,7 @@ panic-off is live ASAP. `pb_policy` REQUIRES += `pb_buttons pv_evlog`.
 3. K3 polarity end-to-end (idle 1 / pressed 0; else flip `active_low`).
 4. LEDs light on **high**; toggling GPIO4/5 does **not** perturb chamber/PTC temps, the ZCD count, or the GPIO2 read; GPIO6 heat LED still works after ownership moved to pb_leds.
 5. Press detection: exactly one SHORT on release; one LONG at threshold, no trailing short.
-6. Safety regression while heating: button/LED activity causes no spurious sensor-fault trips, ZCD keeps counting; long-press drops the SSR ≤1 tick and latches (`fault:true` in `/status`).
+6. Safety regression while heating: button/LED activity causes no spurious sensor-fault trips, ZCD keeps counting; long-press drops the SSR ≤1 tick and latches (`safety.fault_latched:true` in `/api/v2/state`).
 7. Remote-control regression: while heating from dashboard/Klipper, a K3 action invalidates the lease, updates both observers, and stale heartbeats/reconnects do not restore heat.
 8. Persistent-fault regression: power-cycle after a latched fault → heater OFF, fan ON, commands rejected until a deliberate valid clear.
 

--- a/tests/check_api_v2_contract.sh
+++ b/tests/check_api_v2_contract.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+httpd="$root/components/pb_httpd/pb_httpd.c"
+portal="$root/components/pb_portal/pb_portal.c"
+
+for route in info state command heartbeat events health; do
+    grep -q "\"/api/v2/$route\"" "$httpd" || {
+        echo "missing API v2 route: $route" >&2
+        exit 1
+    }
+done
+
+if grep -Eq '\.uri = "/(status|target|heartbeat|reset)"' "$httpd"; then
+    echo "alpha API route was reintroduced" >&2
+    exit 1
+fi
+
+grep -q "EventSource('/api/v2/events')" "$portal"
+grep -q "if(polling)return" "$portal"
+grep -q "lease_id:lease" "$portal"
+grep -q "lease=r.lease_id" "$portal"
+grep -q "l.owner!==actor" "$portal"
+grep -q "s.target.maximum_c" "$portal"
+grep -q 'strcmp(s_replay\[i\].actor_id, actor_id)' "$httpd"
+grep -q 'expected->valuedouble < UINT32_MAX' "$httpd"
+
+if grep -q 'cJSON_AddStringToObject(lease, "id"' "$httpd"; then
+    echo "unauthenticated state exposes raw lease id" >&2
+    exit 1
+fi
+
+echo "api v2 static contract checks: PASS"

--- a/tests/check_dashboard_js.mjs
+++ b/tests/check_dashboard_js.mjs
@@ -1,0 +1,20 @@
+import fs from "node:fs";
+
+const source = fs.readFileSync(
+  new URL("../components/pb_portal/pb_portal.c", import.meta.url),
+  "utf8",
+);
+const start = source.indexOf("static const char STATUS_BODY[]");
+const end = source.indexOf("// Dedicated firmware-update page", start);
+if (start < 0 || end < 0) throw new Error("STATUS_BODY not found");
+
+const block = source.slice(start, end);
+const tokens = block.match(/"(?:\\.|[^"\\])*"/gs) ?? [];
+const html = tokens.map((token) => Function(`return ${token}`)()).join("");
+const script = html.match(/<script>([\s\S]*)<\/script>/)?.[1];
+if (!script) throw new Error("dashboard script not found");
+
+// DB_AUTH_JS is a C macro between string tokens, so its helpers are absent from
+// the extracted text. They are runtime dependencies, not syntax dependencies.
+Function("tok", "hdr", script);
+console.log("dashboard JavaScript syntax: PASS");

--- a/tests/pb_policy_host_test.c
+++ b/tests/pb_policy_host_test.c
@@ -284,14 +284,6 @@ static void test_runtime_limits_drive_auto_and_remote_lease(void)
     CHECK(snapshot().fault_latched);
 }
 
-static void test_legacy_idle_heartbeat_is_benign(void)
-{
-    reset_fixture();
-    CHECK(pb_policy_heartbeat_legacy() == PB_POLICY_OK);
-    CHECK(heater_link_pets == 0);
-    CHECK(snapshot().mode == PB_MODE_OFF);
-}
-
 static void test_local_power_limit_expires_off_without_fault(void)
 {
     reset_fixture();
@@ -341,12 +333,30 @@ static void test_external_fault_sync_off_and_clear(void)
     CHECK(snap.effective_target_c == 0.0f);
     CHECK(snap.fault_latched);
 
-    CHECK(pb_policy_clear_fault(PB_SOURCE_WEB) == PB_POLICY_OK);
+    uint32_t clear_revision = snap.state_revision;
+    CHECK(pb_policy_clear_fault(
+        PB_SOURCE_WEB, clear_revision + 1) == PB_POLICY_REVISION_CONFLICT);
+    CHECK(pb_policy_clear_fault(
+        PB_SOURCE_WEB, clear_revision) == PB_POLICY_OK);
     snap = snapshot();
     CHECK(snap.mode == PB_MODE_OFF);
     CHECK(snap.source == PB_SOURCE_WEB);
     CHECK(!snap.fault_latched);
     CHECK(snap.effective_target_c == 0.0f);
+}
+
+static void test_fault_clear_requires_current_revision(void)
+{
+    reset_fixture();
+    heater_fault = true;
+    heater_reason = "test fault";
+    pb_policy_snapshot_t snap = snapshot();
+    CHECK(pb_policy_clear_fault(
+        PB_SOURCE_WEB, snap.state_revision + 1) == PB_POLICY_REVISION_CONFLICT);
+    CHECK(heater_fault);
+    CHECK(pb_policy_clear_fault(
+        PB_SOURCE_WEB, snap.state_revision) == PB_POLICY_OK);
+    CHECK(!heater_fault);
 }
 
 int main(void)
@@ -358,9 +368,9 @@ int main(void)
     test_auto_requires_live_moonraker_and_uses_hysteresis();
     test_drying_is_bounded_and_expires_off();
     test_runtime_limits_drive_auto_and_remote_lease();
-    test_legacy_idle_heartbeat_is_benign();
     test_local_power_limit_expires_off_without_fault();
     test_external_fault_sync_off_and_clear();
+    test_fault_clear_requires_current_revision();
     puts("pb_policy host tests: PASS");
     return 0;
 }


### PR DESCRIPTION
## What

This is the second, stacked firmware change for the control rewrite. It builds on #9 and replaces the alpha HTTP contract with the authoritative DragonBreath API v2:

- removes `/status`, `/target`, `/heartbeat`, and `/reset`
- adds versioned info, state, command, heartbeat, health, and SSE event routes
- returns the complete authoritative state after accepted commands and most rejections
- makes control commands revision-aware while keeping OFF and drying-stop unconditionally safe
- requires the exact device-issued lease ID for POWER_ON heartbeats
- adds a small request-ID replay cache so a lost response can be retried without creating a second lease
- revision-guards fault clear inside `pb_policy`
- migrates the embedded dashboard to API v2, exact lease ownership, asynchronous SSE, and one-in-flight polling fallback
- adds the API contract document and CI checks for route removal, dashboard ownership, and embedded JavaScript syntax

## Why

The alpha API split state across ad-hoc endpoints and let clients infer ownership from their own requests. That made physical controls, another UI, a reconnect, or a slow/failed HTTP response difficult to reconcile safely. Polling also overlapped under slow Wi-Fi and contributed to the observed unresponsive UI.

API v2 makes the device snapshot authoritative. Clients consume the device's mode, source, revision, lease, output, sensors, environment, and fault state rather than assuming their last command still owns the heater.

## Protocol highlights

- `GET /api/v2/info`
- `GET /api/v2/state`
- `GET /api/v2/events` (SSE; max two asynchronous streams)
- `GET /api/v2/health`
- `POST /api/v2/command`
- `POST /api/v2/heartbeat`

The full contract and examples are in `docs/api-v2.md`.

The event task serializes the same snapshot used for its SSE ID, so an intervening state transition cannot produce an event whose ID and body disagree. Dashboard snapshots from the same boot are monotonic by revision; a new boot ID resets local ownership.

## Compatibility / impact

This is intentionally breaking alpha firmware. The existing `dragonbreath-klipper` helper will not control this branch until its separate API v2 migration lands. OTA and provisioning routes are preserved.

The dashboard and API v2 still need live hardware exercise before either stacked PR is merged.

## Checks

- `sh tests/run_policy_host_test.sh`
- `sh tests/check_api_v2_contract.sh`
- `node tests/check_dashboard_js.mjs`
- `git diff --check`
- full `espressif/idf:v5.3` ESP32-C3 build
  - `dragonbreath.bin`: `0xfa3d0`
  - smallest app partition free: `0xd5c30` (46%)
