### PR TITLE
Add safe serial HIL harness and devboard target

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -10,6 +10,8 @@ on:
       - 'CMakeLists.txt'
       - 'partitions.csv'
       - 'sdkconfig.defaults'
+      - 'sdkconfig.hil-*'
+      - 'tools/hil.py'
       - '.github/workflows/firmware-build.yml'
   pull_request:
     paths:
@@ -19,6 +21,8 @@ on:
       - 'CMakeLists.txt'
       - 'partitions.csv'
       - 'sdkconfig.defaults'
+      - 'sdkconfig.hil-*'
+      - 'tools/hil.py'
   workflow_dispatch:
 
 # Least-privilege GITHUB_TOKEN: the build only needs to read code and upload
@@ -44,6 +48,9 @@ jobs:
       - name: Test authoritative policy state machine
         run: sh tests/run_policy_host_test.sh
 
+      - name: Test HIL scenario runner
+        run: python3 -m unittest tests/test_hil_runner.py
+
       - name: Check API v2 contract and dashboard ownership
         run: |
           sh tests/check_api_v2_contract.sh
@@ -56,6 +63,24 @@ jobs:
           target: esp32c3
           path: '.'
 
+      - name: Build safe dev-board HIL profile (ESP-IDF v5.3)
+        uses: espressif/esp-idf-ci-action@9d38657f3d789ca759b2b37aaf5ceffbc42c4f0d # v1
+        with:
+          esp_idf_version: v5.3
+          target: esp32c3
+          path: '.'
+          command: |
+            idf.py -B build-hil-devboard \
+              -DSDKCONFIG="$PWD/build-hil-devboard/sdkconfig.profile" \
+              -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.hil-devboard" \
+              build
+            sh tests/check_hil_compileout.sh build-hil-devboard
+            idf.py -B build-hil-devboard-uart \
+              -DSDKCONFIG="$PWD/build-hil-devboard-uart/sdkconfig.profile" \
+              -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.hil-devboard-uart" \
+              build
+            sh tests/check_hil_compileout.sh build-hil-devboard-uart
+
       - name: Upload firmware artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -64,4 +89,6 @@ jobs:
             build/dragonbreath.bin
             build/bootloader/bootloader.bin
             build/partition_table/partition-table.bin
+            build-hil-devboard/dragonbreath.bin
+            build-hil-devboard-uart/dragonbreath.bin
           if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # ESP-IDF build artifacts
 build/
+build-*/
 sdkconfig
 sdkconfig.old
 managed_components/
@@ -21,3 +22,6 @@ main/dev_config.h.local
 
 # stock flash backups written by tools/flash.py
 backups/
+
+# Serial HIL transcripts and reports
+hil-results/

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ OEM parity → [`docs/OEM_PARITY.md`](docs/OEM_PARITY.md) · hardware →
 | Auto (follow-bed) / filament-dry modes | 🚧 Shipped in the state machine + UI (v0.3.0); end-to-end hardware soak in progress |
 | Flasher (`tools/flash.py`) | ✅ Backs up full stock flash first, then flashes; `--restore` returns to stock |
 | Web OTA update | ✅ Dual-OTA + rollback; upload from the UI, verified on hardware (DragonBreath-only, refused while heating) |
-| HIL (`pb_hil` / `tools/hil.py`) | 🚧 Dev-board native-USB/UART + real-Panda UART profiles implemented; CH341 dev-board suite qualified on hardware, real-Panda matrix pending |
+| HIL (`pb_hil` / `tools/hil.py`) | ✅ CH341 devboard suite and non-heating real-Panda UART build/flash/no-flash workflows qualified on hardware; native-USB runtime pending on the tested devboard |
 
 **Shared-core boundary:** board-agnostic infrastructure (WiFi, event log, Moonraker
 client) is referenced from the [OpenVent](https://github.com/justinh-rahb/OpenVent)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ re-implemented.
 **Docs:** full feature set → [`docs/FEATURES.md`](docs/FEATURES.md) · control API →
 [`docs/api-v2.md`](docs/api-v2.md) · safety model → [`docs/SAFETY.md`](docs/SAFETY.md) ·
 OEM parity → [`docs/OEM_PARITY.md`](docs/OEM_PARITY.md) · hardware →
-[`docs/HARDWARE.md`](docs/HARDWARE.md).
+[`docs/HARDWARE.md`](docs/HARDWARE.md) · hardware-in-loop testing →
+[`docs/HIL.md`](docs/HIL.md).
 
 ## Status
 | Component | State |
@@ -39,6 +40,7 @@ OEM parity → [`docs/OEM_PARITY.md`](docs/OEM_PARITY.md) · hardware →
 | Auto (follow-bed) / filament-dry modes | 🚧 Shipped in the state machine + UI (v0.3.0); end-to-end hardware soak in progress |
 | Flasher (`tools/flash.py`) | ✅ Backs up full stock flash first, then flashes; `--restore` returns to stock |
 | Web OTA update | ✅ Dual-OTA + rollback; upload from the UI, verified on hardware (DragonBreath-only, refused while heating) |
+| HIL (`pb_hil` / `tools/hil.py`) | 🚧 Dev-board native-USB/UART + real-Panda UART profiles implemented; CH341 dev-board suite qualified on hardware, real-Panda matrix pending |
 
 **Shared-core boundary:** board-agnostic infrastructure (WiFi, event log, Moonraker
 client) is referenced from the [OpenVent](https://github.com/justinh-rahb/OpenVent)
@@ -164,10 +166,11 @@ components/
   pb_heater/   SSR control + safety cutoffs + comms watchdog
   pb_fan/      TRIAC on/off held-gate blower control (never PWM)
   pb_policy/   authoritative control state, modes, leases -> actuators
+  pb_hil/      JSON serial HIL console + safe dev-board injection
   pb_httpd/    HTTP control API (CSRF-gated mutations)
   pb_portal/   captive-portal provisioning + live status dashboard
 main/          app_main: safety-first init + control loop
-docs/          hardware map, safety model, NTC RE report
+docs/          hardware map, safety model, HIL guide, NTC RE report
 ```
 
 ## Credits

--- a/components/pb_board/pb_board.c
+++ b/components/pb_board/pb_board.c
@@ -6,6 +6,9 @@ static const char *TAG = "pb_board";
 
 void pb_board_init(void)
 {
+#ifdef CONFIG_PB_HIL_DEVBOARD
+    ESP_LOGW(TAG, "HIL dev-board target: production board GPIO init compiled out");
+#else
     const gpio_config_t leds = {
         .pin_bit_mask = (1ULL << PB_GPIO_LED_K1) |
                         (1ULL << PB_GPIO_LED_K2) |
@@ -20,10 +23,14 @@ void pb_board_init(void)
     gpio_set_level(PB_GPIO_LED_K2, 0);
     gpio_set_level(PB_GPIO_LED_K3, 0);
     ESP_LOGI(TAG, "board init: LEDs off; heater/fan owned by their components");
+#endif
 }
 
 int pb_board_rref_kohm(void)
 {
+#ifdef CONFIG_PB_HIL_DEVBOARD
+    return 82;
+#else
     const gpio_config_t strap = {
         .pin_bit_mask = (1ULL << PB_GPIO_RREF_STRAP),
         .mode = GPIO_MODE_INPUT,
@@ -36,4 +43,5 @@ int pb_board_rref_kohm(void)
     int rref = (level == 0) ? 82 : 33;
     ESP_LOGI(TAG, "Rref strap (GPIO19)=%d -> %d kOhm", level, rref);
     return rref;
+#endif
 }

--- a/components/pb_fan/include/pb_fan.h
+++ b/components/pb_fan/include/pb_fan.h
@@ -23,3 +23,8 @@ uint8_t pb_fan_get_level(void);
 // the last two edges (mains cycle period). interval 0 = no zero-cross seen yet
 // (ZCD not working / no mains) — lets us verify the detector without firing.
 void pb_fan_zc_diag(uint32_t *count_out, uint32_t *interval_us_out);
+
+#ifdef CONFIG_PB_HIL_DEVBOARD
+// Inject one or more zero-cross events into the dev-board backend.
+void pb_fan_hil_zero_cross(uint32_t count, uint32_t interval_us);
+#endif

--- a/components/pb_fan/pb_fan.c
+++ b/components/pb_fan/pb_fan.c
@@ -25,6 +25,7 @@ static volatile uint32_t s_zc_count;
 static volatile uint32_t s_zc_interval_us;
 static volatile uint64_t s_zc_last_us;
 
+#ifndef CONFIG_PB_HIL_DEVBOARD
 static void IRAM_ATTR zcd_isr(void *arg)
 {
     uint64_t now = esp_timer_get_time();
@@ -38,9 +39,19 @@ static void IRAM_ATTR zcd_isr(void *arg)
         s_applied = on;
     }
 }
+#endif
 
 esp_err_t pb_fan_init(void)
 {
+#ifdef CONFIG_PB_HIL_DEVBOARD
+    s_want_on = false;
+    s_applied = false;
+    s_zc_count = 0;
+    s_zc_interval_us = 0;
+    s_zc_last_us = 0;
+    ESP_LOGW(TAG, "HIL dev-board backend: fan gate and ZCD GPIOs compiled out");
+    return ESP_OK;
+#else
     const gpio_config_t gate = {
         .pin_bit_mask = (1ULL << PB_GPIO_FAN_GATE),
         .mode = GPIO_MODE_OUTPUT,
@@ -69,6 +80,7 @@ esp_err_t pb_fan_init(void)
     ESP_LOGI(TAG, "init: ON/OFF held-gate (stock model), gate GPIO%d, ZCD GPIO%d; never PWM'd",
              PB_GPIO_FAN_GATE, PB_GPIO_ZERO_CROSS);
     return ESP_OK;
+#endif
 }
 
 void pb_fan_set_level(uint8_t percent)
@@ -76,7 +88,9 @@ void pb_fan_set_level(uint8_t percent)
     bool on = (percent > 0);
     s_want_on = on;
     if (!on) {                                     // turn OFF immediately (don't wait for a ZC)
+#ifndef CONFIG_PB_HIL_DEVBOARD
         gpio_set_level(PB_GPIO_FAN_GATE, 0);
+#endif
         s_applied = false;
     }
     // ON is applied at the next zero cross by the ISR (clean AC switching).
@@ -89,3 +103,13 @@ void pb_fan_zc_diag(uint32_t *count_out, uint32_t *interval_us_out)
     if (count_out) *count_out = s_zc_count;
     if (interval_us_out) *interval_us_out = s_zc_interval_us;
 }
+
+#ifdef CONFIG_PB_HIL_DEVBOARD
+void pb_fan_hil_zero_cross(uint32_t count, uint32_t interval_us)
+{
+    if (count == 0) return;
+    s_zc_count += count;
+    s_zc_interval_us = interval_us;
+    s_applied = s_want_on;
+}
+#endif

--- a/components/pb_heater/pb_heater.c
+++ b/components/pb_heater/pb_heater.c
@@ -42,12 +42,15 @@ static uint32_t c_to_centi(float c)
 
 static void ssr_set(bool on)        // control-task context only
 {
+#ifndef CONFIG_PB_HIL_DEVBOARD
     gpio_set_level(PB_GPIO_RELAY, on ? 1 : 0);
+#endif
     s_on = on;
 }
 
 esp_err_t pb_heater_init(void)
 {
+#ifndef CONFIG_PB_HIL_DEVBOARD
     const gpio_config_t io = {
         .pin_bit_mask = (1ULL << PB_GPIO_RELAY),
         .mode = GPIO_MODE_OUTPUT,
@@ -57,6 +60,7 @@ esp_err_t pb_heater_init(void)
     };
     esp_err_t err = gpio_config(&io);
     if (err != ESP_OK) return err;
+#endif
     ssr_set(false);                  // guaranteed OFF before any request
     taskENTER_CRITICAL(&s_mux);
     s_target_c = 0.0f;
@@ -68,7 +72,11 @@ esp_err_t pb_heater_init(void)
     s_max_target_c = PB_HEATER_MAX_TARGET_C_DEFAULT;
     s_comms_timeout_us = (int64_t)PB_HEATER_COMMS_TIMEOUT_MS_DEFAULT * 1000;
     taskEXIT_CRITICAL(&s_mux);
+#ifdef CONFIG_PB_HIL_DEVBOARD
+    ESP_LOGW(TAG, "HIL dev-board backend: relay GPIO compiled out");
+#else
     ESP_LOGI(TAG, "init: SSR forced OFF");
+#endif
     return ESP_OK;
 }
 

--- a/components/pb_hil/CMakeLists.txt
+++ b/components/pb_hil/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "pb_hil.c"
+    INCLUDE_DIRS "include"
+    REQUIRES driver esp_driver_usb_serial_jtag json pb_fan pb_leds pb_ntc pb_policy
+)

--- a/components/pb_hil/Kconfig.projbuild
+++ b/components/pb_hil/Kconfig.projbuild
@@ -1,0 +1,20 @@
+menu "DragonBreath hardware-in-loop"
+
+config PB_HIL_CONSOLE
+    bool "Enable the serial HIL command console"
+    default n
+    help
+        Accept line-delimited JSON commands on the configured console UART and
+        emit machine-readable DBHIL responses alongside normal ESP-IDF logs.
+        This is intended for development and qualification images only.
+
+config PB_HIL_DEVBOARD
+    bool "Build for a safe ESP32-C3 development board"
+    depends on PB_HIL_CONSOLE
+    default n
+    help
+        Compile out every Panda mains GPIO write. Thermistors, zero-cross, and
+        network state are supplied by the HIL console. Heater and fan outputs
+        remain logical state only, so this image cannot energize Panda hardware.
+
+endmenu

--- a/components/pb_hil/include/pb_hil.h
+++ b/components/pb_hil/include/pb_hil.h
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Line-delimited JSON hardware-in-loop console.
+#pragma once
+
+#include "esp_err.h"
+
+esp_err_t pb_hil_start(void);

--- a/components/pb_hil/pb_hil.c
+++ b/components/pb_hil/pb_hil.c
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: MIT
+#include "pb_hil.h"
+
+#ifdef CONFIG_PB_HIL_CONSOLE
+
+#include "pb_fan.h"
+#include "pb_leds.h"
+#include "pb_ntc.h"
+#include "pb_policy.h"
+
+#include "cJSON.h"
+#ifdef CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#include "driver/usb_serial_jtag.h"
+#include "driver/usb_serial_jtag_vfs.h"
+#else
+#include "driver/uart.h"
+#include "driver/uart_vfs.h"
+#endif
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+static const char *TAG = "pb_hil";
+
+#define HIL_LINE_MAX   768
+#define HIL_TASK_STACK 6144
+
+static int console_read_byte(uint8_t *byte)
+{
+#ifdef CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+    return usb_serial_jtag_read_bytes(byte, 1, portMAX_DELAY);
+#else
+    return uart_read_bytes(CONFIG_ESP_CONSOLE_UART_NUM, byte, 1, portMAX_DELAY);
+#endif
+}
+
+static const char *ntc_status_str(pb_ntc_status_t status)
+{
+    switch (status) {
+        case PB_NTC_OK: return "ok";
+        case PB_NTC_SHORT: return "short";
+        case PB_NTC_OPEN: return "open";
+        case PB_NTC_UNINIT:
+        default: return "uninit";
+    }
+}
+
+static const char *led_pattern_str(pb_led_pattern_t pattern)
+{
+    switch (pattern) {
+        case PB_LED_SOLID: return "solid";
+        case PB_LED_BLINK: return "blink";
+        case PB_LED_BLINK_SLOW: return "blink_slow";
+        case PB_LED_CODE: return "code";
+        case PB_LED_OFF:
+        default: return "off";
+    }
+}
+
+static cJSON *state_json(void)
+{
+    pb_policy_snapshot_t snap;
+    pb_policy_get_snapshot(&snap);
+
+    cJSON *state = cJSON_CreateObject();
+    cJSON_AddNumberToObject(state, "revision", snap.state_revision);
+    cJSON_AddStringToObject(state, "mode", pb_policy_mode_str(snap.mode));
+    cJSON_AddStringToObject(state, "source", pb_policy_source_str(snap.source));
+    cJSON_AddNumberToObject(state, "requested_target_c", snap.requested_target_c);
+    cJSON_AddNumberToObject(state, "effective_target_c", snap.effective_target_c);
+    cJSON_AddBoolToObject(state, "heater_demand", snap.heater_demand);
+    cJSON_AddBoolToObject(state, "heater_output", snap.heater_output);
+    cJSON_AddNumberToObject(state, "fan_percent", snap.effective_fan_percent);
+    cJSON_AddBoolToObject(state, "thermal_purge", snap.thermal_purge);
+    cJSON_AddBoolToObject(state, "fault_latched", snap.fault_latched);
+    cJSON_AddBoolToObject(state, "inhibited", snap.inhibited);
+    cJSON_AddStringToObject(state, "fault_reason", snap.fault_reason);
+    cJSON_AddBoolToObject(state, "moonraker_connected", snap.moonraker_connected);
+    cJSON_AddNumberToObject(state, "bed_c", snap.bed_c);
+    cJSON_AddBoolToObject(state, "auto_engaged", snap.auto_engaged);
+    cJSON_AddBoolToObject(state, "lease_active", snap.lease_active);
+    if (snap.lease_active) {
+        cJSON_AddStringToObject(state, "lease_id", snap.lease_id);
+        cJSON_AddNumberToObject(state, "lease_expires_ms", snap.lease_expires_ms);
+    } else {
+        cJSON_AddNullToObject(state, "lease_id");
+        cJSON_AddNumberToObject(state, "lease_expires_ms", 0);
+    }
+
+    cJSON *sensors = cJSON_AddObjectToObject(state, "sensors");
+    cJSON *chamber = cJSON_AddObjectToObject(sensors, "chamber");
+    cJSON_AddStringToObject(chamber, "status", ntc_status_str(snap.chamber_status));
+    if (snap.chamber_status == PB_NTC_OK && isfinite(snap.chamber_c))
+        cJSON_AddNumberToObject(chamber, "temp_c", snap.chamber_c);
+    else
+        cJSON_AddNullToObject(chamber, "temp_c");
+    cJSON *ptc = cJSON_AddObjectToObject(sensors, "ptc");
+    cJSON_AddStringToObject(ptc, "status", ntc_status_str(snap.ptc_status));
+    if (snap.ptc_status == PB_NTC_OK && isfinite(snap.ptc_c))
+        cJSON_AddNumberToObject(ptc, "temp_c", snap.ptc_c);
+    else
+        cJSON_AddNullToObject(ptc, "temp_c");
+
+    uint32_t zc_count = 0;
+    uint32_t zc_interval_us = 0;
+    pb_fan_zc_diag(&zc_count, &zc_interval_us);
+    cJSON *io = cJSON_AddObjectToObject(state, "io");
+#ifdef CONFIG_PB_HIL_DEVBOARD
+    cJSON_AddStringToObject(io, "target", "devboard");
+    cJSON_AddBoolToObject(io, "mains_gpio_compiled_out", true);
+#else
+    cJSON_AddStringToObject(io, "target", "panda");
+    cJSON_AddBoolToObject(io, "mains_gpio_compiled_out", false);
+#endif
+    cJSON_AddNumberToObject(io, "zero_cross_count", zc_count);
+    cJSON_AddNumberToObject(io, "zero_cross_interval_us", zc_interval_us);
+    cJSON *leds = cJSON_AddObjectToObject(io, "leds");
+    cJSON_AddStringToObject(leds, "power", led_pattern_str(pb_leds_get(PB_LED_POWER)));
+    cJSON_AddStringToObject(leds, "auto", led_pattern_str(pb_leds_get(PB_LED_AUTO)));
+    cJSON_AddStringToObject(leds, "on", led_pattern_str(pb_leds_get(PB_LED_ON)));
+    cJSON_AddStringToObject(leds, "dry", led_pattern_str(pb_leds_get(PB_LED_DRY)));
+    return state;
+}
+
+static void emit(cJSON *response)
+{
+    char *json = cJSON_PrintUnformatted(response);
+    if (json) {
+        printf("DBHIL %s\n", json);
+        fflush(stdout);
+        cJSON_free(json);
+    }
+    cJSON_Delete(response);
+}
+
+static cJSON *response_new(const cJSON *request)
+{
+    cJSON *response = cJSON_CreateObject();
+    const cJSON *id = cJSON_GetObjectItemCaseSensitive(request, "id");
+    if (id) cJSON_AddItemToObject(response, "id", cJSON_Duplicate(id, true));
+    return response;
+}
+
+static void response_error(cJSON *response, const char *error)
+{
+    cJSON_AddBoolToObject(response, "ok", false);
+    cJSON_AddStringToObject(response, "error", error);
+    cJSON_AddItemToObject(response, "state", state_json());
+}
+
+static bool json_number(const cJSON *root, const char *key, double *out)
+{
+    const cJSON *item = cJSON_GetObjectItemCaseSensitive(root, key);
+    if (!cJSON_IsNumber(item) || !isfinite(item->valuedouble)) return false;
+    *out = item->valuedouble;
+    return true;
+}
+
+#ifdef CONFIG_PB_HIL_DEVBOARD
+static bool parse_ntc_status(const char *name, pb_ntc_status_t *status)
+{
+    if (strcmp(name, "ok") == 0) *status = PB_NTC_OK;
+    else if (strcmp(name, "open") == 0) *status = PB_NTC_OPEN;
+    else if (strcmp(name, "short") == 0) *status = PB_NTC_SHORT;
+    else if (strcmp(name, "uninit") == 0) *status = PB_NTC_UNINIT;
+    else return false;
+    return true;
+}
+#endif
+
+static pb_policy_result_t run_mode_command(
+    const cJSON *request, pb_policy_lease_t *lease)
+{
+    const cJSON *mode = cJSON_GetObjectItemCaseSensitive(request, "mode");
+    if (!cJSON_IsString(mode)) return PB_POLICY_INVALID;
+    if (strcmp(mode->valuestring, "off") == 0) {
+        pb_policy_set_mode_off(PB_SOURCE_WEB);
+        return PB_POLICY_OK;
+    }
+
+    double target = 0.0;
+    if (!json_number(request, "target_c", &target)) return PB_POLICY_INVALID;
+    if (strcmp(mode->valuestring, "power_on") == 0) {
+        return pb_policy_set_power_on(
+            (float)target, PB_SOURCE_WEB, "hil-serial",
+            PB_POLICY_REVISION_ANY, lease);
+    }
+    if (strcmp(mode->valuestring, "auto") == 0) {
+        double threshold = 0.0;
+        if (!json_number(request, "bed_threshold_c", &threshold))
+            return PB_POLICY_INVALID;
+        return pb_policy_set_auto(
+            (float)target, (float)threshold, PB_SOURCE_WEB,
+            PB_POLICY_REVISION_ANY);
+    }
+    if (strcmp(mode->valuestring, "drying") == 0) {
+        double hours = 0.0;
+        if (!json_number(request, "hours", &hours)
+                || hours < 1.0 || hours > 12.0 || floor(hours) != hours)
+            return PB_POLICY_INVALID;
+        return pb_policy_start_drying(
+            (float)target, (uint8_t)hours, PB_SOURCE_WEB,
+            PB_POLICY_REVISION_ANY);
+    }
+    return PB_POLICY_INVALID;
+}
+
+static void handle_request(const cJSON *request)
+{
+    cJSON *response = response_new(request);
+    const cJSON *cmd = cJSON_GetObjectItemCaseSensitive(request, "cmd");
+    if (!cJSON_IsString(cmd)) {
+        response_error(response, "missing_cmd");
+        emit(response);
+        return;
+    }
+
+    if (strcmp(cmd->valuestring, "ping") == 0
+            || strcmp(cmd->valuestring, "state") == 0) {
+        cJSON_AddBoolToObject(response, "ok", true);
+    } else if (strcmp(cmd->valuestring, "off") == 0) {
+        pb_policy_set_mode_off(PB_SOURCE_WEB);
+        cJSON_AddBoolToObject(response, "ok", true);
+    } else if (strcmp(cmd->valuestring, "mode") == 0) {
+        pb_policy_lease_t lease = {0};
+        pb_policy_result_t result = run_mode_command(request, &lease);
+        cJSON_AddBoolToObject(response, "ok", result == PB_POLICY_OK);
+        cJSON_AddStringToObject(response, "result", pb_policy_result_str(result));
+        if (lease.id[0]) cJSON_AddStringToObject(response, "lease_id", lease.id);
+    } else if (strcmp(cmd->valuestring, "heartbeat") == 0) {
+        const cJSON *id = cJSON_GetObjectItemCaseSensitive(request, "lease_id");
+        pb_policy_lease_t lease = {0};
+        if (cJSON_IsString(id))
+            snprintf(lease.id, sizeof lease.id, "%s", id->valuestring);
+        pb_policy_result_t result = pb_policy_heartbeat(&lease);
+        cJSON_AddBoolToObject(response, "ok", result == PB_POLICY_OK);
+        cJSON_AddStringToObject(response, "result", pb_policy_result_str(result));
+    } else if (strcmp(cmd->valuestring, "clear_fault") == 0) {
+        pb_policy_snapshot_t snap;
+        pb_policy_get_snapshot(&snap);
+        pb_policy_result_t result =
+            pb_policy_clear_fault(PB_SOURCE_WEB, snap.state_revision);
+        cJSON_AddBoolToObject(response, "ok", result == PB_POLICY_OK);
+        cJSON_AddStringToObject(response, "result", pb_policy_result_str(result));
+#ifdef CONFIG_PB_HIL_DEVBOARD
+    } else if (strcmp(cmd->valuestring, "sensor") == 0) {
+        const cJSON *channel = cJSON_GetObjectItemCaseSensitive(request, "channel");
+        const cJSON *status_item = cJSON_GetObjectItemCaseSensitive(request, "status");
+        pb_ntc_status_t status = PB_NTC_UNINIT;
+        double temp_c = 25.0;
+        bool valid = cJSON_IsString(channel) && cJSON_IsString(status_item)
+            && parse_ntc_status(status_item->valuestring, &status);
+        if (status == PB_NTC_OK)
+            valid = valid && json_number(request, "temp_c", &temp_c);
+        pb_ntc_channel_t ch = PB_NTC_CHAMBER;
+        if (valid && strcmp(channel->valuestring, "ptc") == 0)
+            ch = PB_NTC_PTC;
+        else if (!valid || strcmp(channel->valuestring, "chamber") != 0)
+            valid = false;
+        if (valid) {
+            pb_ntc_hil_set(ch, status, (float)temp_c);
+            cJSON_AddBoolToObject(response, "ok", true);
+        } else {
+            response_error(response, "invalid_sensor");
+            emit(response);
+            return;
+        }
+    } else if (strcmp(cmd->valuestring, "env") == 0) {
+        const cJSON *connected =
+            cJSON_GetObjectItemCaseSensitive(request, "connected");
+        double bed_c = 0.0;
+        if (!cJSON_IsBool(connected) || !json_number(request, "bed_c", &bed_c)) {
+            response_error(response, "invalid_env");
+            emit(response);
+            return;
+        }
+        pb_policy_set_env((float)bed_c, cJSON_IsTrue(connected));
+        cJSON_AddBoolToObject(response, "ok", true);
+    } else if (strcmp(cmd->valuestring, "zero_cross") == 0) {
+        double count = 1.0;
+        double interval_us = 10000.0;
+        const cJSON *count_item =
+            cJSON_GetObjectItemCaseSensitive(request, "count");
+        if (count_item && !json_number(request, "count", &count)) count = 0.0;
+        const cJSON *interval_item =
+            cJSON_GetObjectItemCaseSensitive(request, "interval_us");
+        if (interval_item && !json_number(request, "interval_us", &interval_us))
+            interval_us = 0.0;
+        if (count < 1.0 || count > UINT32_MAX || floor(count) != count
+                || interval_us < 0.0 || interval_us > UINT32_MAX) {
+            response_error(response, "invalid_zero_cross");
+            emit(response);
+            return;
+        }
+        pb_fan_hil_zero_cross((uint32_t)count, (uint32_t)interval_us);
+        cJSON_AddBoolToObject(response, "ok", true);
+#endif
+    } else {
+        response_error(response, "unsupported_cmd");
+        emit(response);
+        return;
+    }
+
+    cJSON_AddItemToObject(response, "state", state_json());
+    emit(response);
+}
+
+static void hil_task(void *arg)
+{
+    (void)arg;
+    char line[HIL_LINE_MAX];
+    size_t used = 0;
+
+    for (;;) {
+        uint8_t byte = 0;
+        int got = console_read_byte(&byte);
+        if (got != 1) continue;
+        if (byte == '\r') continue;
+        if (byte != '\n') {
+            if (used + 1 < sizeof line) line[used++] = (char)byte;
+            else used = 0;
+            continue;
+        }
+        line[used] = '\0';
+        used = 0;
+        if (!line[0]) continue;
+        cJSON *request = cJSON_Parse(line);
+        if (!request || !cJSON_IsObject(request)) {
+            cJSON *response = cJSON_CreateObject();
+            response_error(response, "invalid_json");
+            emit(response);
+            cJSON_Delete(request);
+            continue;
+        }
+        handle_request(request);
+        cJSON_Delete(request);
+    }
+}
+
+esp_err_t pb_hil_start(void)
+{
+#ifdef CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+    usb_serial_jtag_driver_config_t config = {
+        .tx_buffer_size = 2048,
+        .rx_buffer_size = 2048,
+    };
+    esp_err_t err = usb_serial_jtag_driver_install(&config);
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) return err;
+    usb_serial_jtag_vfs_use_driver();
+#else
+    esp_err_t err = uart_driver_install(
+        CONFIG_ESP_CONSOLE_UART_NUM, 2048, 0, 0, NULL, 0);
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) return err;
+    uart_vfs_dev_use_driver(CONFIG_ESP_CONSOLE_UART_NUM);
+#endif
+    if (xTaskCreate(hil_task, "pb_hil", HIL_TASK_STACK, NULL, 8, NULL) != pdPASS)
+        return ESP_ERR_NO_MEM;
+#ifdef CONFIG_PB_HIL_DEVBOARD
+    ESP_LOGW(TAG, "serial HIL ready (devboard; mains GPIO compiled out)");
+#else
+    ESP_LOGW(TAG, "serial HIL ready (Panda hardware active)");
+#endif
+    return ESP_OK;
+}
+
+#else
+
+esp_err_t pb_hil_start(void)
+{
+    return ESP_ERR_NOT_SUPPORTED;
+}
+
+#endif

--- a/components/pb_leds/include/pb_leds.h
+++ b/components/pb_leds/include/pb_leds.h
@@ -43,3 +43,6 @@ void pb_leds_set(pb_led_id_t id, pb_led_pattern_t pattern);
 
 // Set a LED to the CODE pattern blinking `pulses` short pulses per cycle.
 void pb_leds_set_code(pb_led_id_t id, uint8_t pulses);
+
+// Current logical pattern, including when dev-board HIL compiles GPIO out.
+pb_led_pattern_t pb_leds_get(pb_led_id_t id);

--- a/components/pb_leds/pb_leds.c
+++ b/components/pb_leds/pb_leds.c
@@ -19,9 +19,11 @@ static const char *TAG = "pb_leds";
 #define CODE_OFF_TICKS     3    // 150 ms between pulses within a burst
 #define CODE_GAP_TICKS    16    // 800 ms quiet gap after each burst
 
+#ifndef CONFIG_PB_HIL_DEVBOARD
 static const gpio_num_t s_gpio[PB_LED_COUNT] = {
     PB_GPIO_LED_K1, PB_GPIO_LED_K2, PB_GPIO_LED_K3, PB_GPIO_LED_POWER,
 };
+#endif
 
 // The "Power" LED (index 3 / GPIO21) shares the UART0 console TX pin, so it is
 // only claimed + driven when CONFIG_PB_POWER_LED is set (release builds). When
@@ -85,7 +87,11 @@ static void led_task(void *arg)
                 cs[i].sub = 0;
                 break;
             }
+#ifndef CONFIG_PB_HIL_DEVBOARD
             gpio_set_level(s_gpio[i], on ? 1 : 0);
+#else
+            (void)on;
+#endif
         }
         tick++;
         vTaskDelay(pdMS_TO_TICKS(TICK_MS));
@@ -96,6 +102,7 @@ esp_err_t pb_leds_start(void)
 {
     if (s_task) return ESP_ERR_INVALID_STATE;
 
+#ifndef CONFIG_PB_HIL_DEVBOARD
     uint64_t mask = 0;
     for (int i = 0; i < PB_LED_COUNT; i++)
         if (PB_LED_DRIVEN(i)) mask |= 1ULL << s_gpio[i];   // skip GPIO21 unless enabled
@@ -108,17 +115,24 @@ esp_err_t pb_leds_start(void)
     };
     esp_err_t err = gpio_config(&cfg);
     if (err != ESP_OK) return err;
+#endif
     for (int i = 0; i < PB_LED_COUNT; i++) {
         atomic_store(&s_pat[i], PB_LED_OFF);
         atomic_store(&s_code[i], 0);
+#ifndef CONFIG_PB_HIL_DEVBOARD
         if (PB_LED_DRIVEN(i)) gpio_set_level(s_gpio[i], 0);
+#endif
     }
 
     if (xTaskCreate(led_task, "pb_leds", 2048, NULL, 3, &s_task) != pdPASS) {
         s_task = NULL;
         return ESP_ERR_NO_MEM;
     }
+#ifdef CONFIG_PB_HIL_DEVBOARD
+    ESP_LOGW(TAG, "HIL dev-board backend: LED GPIO writes compiled out");
+#else
     ESP_LOGI(TAG, "started");
+#endif
     return ESP_OK;
 }
 
@@ -133,4 +147,10 @@ void pb_leds_set_code(pb_led_id_t id, uint8_t pulses)
     if (id < 0 || id >= PB_LED_COUNT) return;
     atomic_store(&s_code[id], pulses);
     atomic_store(&s_pat[id], PB_LED_CODE);
+}
+
+pb_led_pattern_t pb_leds_get(pb_led_id_t id)
+{
+    if (id < 0 || id >= PB_LED_COUNT) return PB_LED_OFF;
+    return atomic_load(&s_pat[id]);
 }

--- a/components/pb_ntc/include/pb_ntc.h
+++ b/components/pb_ntc/include/pb_ntc.h
@@ -40,3 +40,9 @@ pb_ntc_status_t pb_ntc_last_status(pb_ntc_channel_t ch);
 // Latest smoothed temperature (5-sample moving average, for display/telemetry).
 // NAN if no valid reading yet. Fed by pb_ntc_read on each OK sample.
 float pb_ntc_smoothed_c(pb_ntc_channel_t ch);
+
+#ifdef CONFIG_PB_HIL_DEVBOARD
+// Dev-board HIL backend. Production builds do not expose or compile this API.
+void pb_ntc_hil_set(pb_ntc_channel_t ch, pb_ntc_status_t status, float temp_c);
+void pb_ntc_hil_reset(void);
+#endif

--- a/components/pb_ntc/pb_ntc.c
+++ b/components/pb_ntc/pb_ntc.c
@@ -6,11 +6,87 @@
 #include <math.h>
 #include <string.h>
 #include "esp_log.h"
+#ifdef CONFIG_PB_HIL_DEVBOARD
+#include "freertos/FreeRTOS.h"
+#else
 #include "esp_adc/adc_oneshot.h"
 #include "esp_adc/adc_cali.h"
 #include "esp_adc/adc_cali_scheme.h"
+#endif
 
 static const char *TAG = "pb_ntc";
+
+#ifdef CONFIG_PB_HIL_DEVBOARD
+
+static portMUX_TYPE s_hil_mux = portMUX_INITIALIZER_UNLOCKED;
+static float s_hil_temp[2];
+static pb_ntc_status_t s_hil_status[2];
+static pb_ntc_status_t s_last_status[2];
+static bool s_ready;
+
+void pb_ntc_hil_reset(void)
+{
+    taskENTER_CRITICAL(&s_hil_mux);
+    for (int i = 0; i < 2; ++i) {
+        s_hil_temp[i] = 25.0f;
+        s_hil_status[i] = PB_NTC_OK;
+        s_last_status[i] = PB_NTC_OK;
+    }
+    taskEXIT_CRITICAL(&s_hil_mux);
+}
+
+void pb_ntc_hil_set(pb_ntc_channel_t ch, pb_ntc_status_t status, float temp_c)
+{
+    if (ch < PB_NTC_CHAMBER || ch > PB_NTC_PTC) return;
+    taskENTER_CRITICAL(&s_hil_mux);
+    s_hil_status[ch] = status;
+    s_hil_temp[ch] = temp_c;
+    s_last_status[ch] = status;
+    taskEXIT_CRITICAL(&s_hil_mux);
+}
+
+esp_err_t pb_ntc_init(void)
+{
+    pb_ntc_hil_reset();
+    s_ready = true;
+    ESP_LOGW(TAG, "HIL dev-board backend: ADC disabled; temperatures are injected");
+    return ESP_OK;
+}
+
+pb_ntc_status_t pb_ntc_read(pb_ntc_channel_t ch, float *out_c)
+{
+    if (!s_ready || ch < PB_NTC_CHAMBER || ch > PB_NTC_PTC) {
+        if (out_c) *out_c = NAN;
+        return PB_NTC_UNINIT;
+    }
+    taskENTER_CRITICAL(&s_hil_mux);
+    pb_ntc_status_t status = s_hil_status[ch];
+    float temp_c = status == PB_NTC_OK ? s_hil_temp[ch] : NAN;
+    s_last_status[ch] = status;
+    taskEXIT_CRITICAL(&s_hil_mux);
+    if (out_c) *out_c = temp_c;
+    return status;
+}
+
+pb_ntc_status_t pb_ntc_last_status(pb_ntc_channel_t ch)
+{
+    if (ch < PB_NTC_CHAMBER || ch > PB_NTC_PTC) return PB_NTC_UNINIT;
+    taskENTER_CRITICAL(&s_hil_mux);
+    pb_ntc_status_t status = s_last_status[ch];
+    taskEXIT_CRITICAL(&s_hil_mux);
+    return status;
+}
+
+float pb_ntc_smoothed_c(pb_ntc_channel_t ch)
+{
+    if (!s_ready || ch < PB_NTC_CHAMBER || ch > PB_NTC_PTC) return NAN;
+    taskENTER_CRITICAL(&s_hil_mux);
+    float temp_c = s_hil_status[ch] == PB_NTC_OK ? s_hil_temp[ch] : NAN;
+    taskEXIT_CRITICAL(&s_hil_mux);
+    return temp_c;
+}
+
+#else
 
 // Low-side NTC divider supply K in Rntc = Rref*V/(K-V) = the ~3.3 V rail.
 // (The RE report's 0.1 V was wrong; on hardware the pin sits ~1.6 V at ambient.)
@@ -162,3 +238,5 @@ float pb_ntc_smoothed_c(pb_ntc_channel_t ch)
     for (int i = 0; i < s_win_cnt[ch]; i++) sum += s_win[ch][i];
     return sum / (float)s_win_cnt[ch];
 }
+
+#endif

--- a/docs/HIL.md
+++ b/docs/HIL.md
@@ -15,8 +15,8 @@ As of 2026-07-23:
 - Both devboard transports pass the compile-time GPIO/ADC exclusion audit.
 - The native-USB image builds and flashes, but this board's application-side
   native USB serial endpoint did not respond during qualification.
-- The non-heating real-Panda smoke scenario is implemented; the physical
-  real-Panda release matrix remains pending.
+- The real-Panda UART profile passes the non-heating smoke scenario on physical
+  hardware, both as a guarded build/flash run and as an already-flashed run.
 
 ## Safety boundaries
 
@@ -241,6 +241,35 @@ python tools/hil.py \
 
 Add `--allow-heater` only for a supervised scenario that intentionally requests
 a positive temperature. The provided Panda smoke scenario never requests heat.
+
+### Reference hardware result
+
+The real-Panda workflow was qualified on 2026-07-23 using commit `7883dda`, an
+ESP32-C3 revision 1.1 Panda connected to a generic Linux SSH device host through
+its on-board QinHeng `1a86:7522` UART bridge, and ESP-IDF 5.3.1 on the build
+machine.
+
+Before flashing, the complete 4 MiB device flash was read and its local and
+remote SHA-256 digests were compared. The guarded run then:
+
+1. built the `sdkconfig.hil-panda` profile;
+2. transferred the manifest and images to the device host;
+3. flashed and reset the Panda with remote esptool;
+4. ran `panda-smoke.json`; and
+5. retrieved `report.json` and `serial.jsonl`.
+
+The same scenario passed again without `--flash`, proving the normal attach and
+test path against an already-running unit. Both runs reported:
+
+- `target: "panda"` over the `uart` transport;
+- `mains_gpio_compiled_out: false`, confirming the real hardware profile;
+- valid chamber/PTC readings and live zero-cross counts;
+- successful `state` and unconditional `off` commands; and
+- final mode `off` with `heater_demand: false` and `heater_output: false`.
+
+The build profile contained `CONFIG_PB_HIL_CONSOLE=y`,
+`CONFIG_ESP_CONSOLE_UART_DEFAULT=y`, and no `CONFIG_PB_POWER_LED`. Neither run
+used `--allow-heater`, so the harness could not issue a positive heat request.
 
 ## Manual builds
 

--- a/docs/HIL.md
+++ b/docs/HIL.md
@@ -1,0 +1,455 @@
+# Hardware-in-the-loop testing
+
+DragonBreath HIL runs the production policy state machine on either a GPIO-safe
+ESP32-C3 development board or a real Panda Breath. `tools/hil.py` builds the
+selected profile, optionally flashes it, drives line-delimited JSON commands,
+captures the complete serial console, evaluates scripted assertions, and writes
+a machine-readable report.
+
+## Qualification status
+
+As of 2026-07-23:
+
+- The complete devboard suite passes on a dual-USB-C ESP32-C3 board through its
+  CH341-family UART bridge.
+- Both devboard transports pass the compile-time GPIO/ADC exclusion audit.
+- The native-USB image builds and flashes, but this board's application-side
+  native USB serial endpoint did not respond during qualification.
+- The non-heating real-Panda smoke scenario is implemented; the physical
+  real-Panda release matrix remains pending.
+
+## Safety boundaries
+
+The two HIL targets intentionally have different hardware behavior.
+
+### Devboard target
+
+`CONFIG_PB_HIL_DEVBOARD` replaces or removes every Panda-specific physical
+backend used by the test path:
+
+- relay output
+- fan TRIAC gate and zero-cross GPIO
+- chamber and PTC ADC
+- Panda indicator LEDs
+- board-strap input
+
+Heater demand, heater output, fan percentage, LED patterns, and zero-cross
+diagnostics still update as logical state. Every response identifies this target
+with:
+
+```json
+{
+  "state": {
+    "io": {
+      "target": "devboard",
+      "mains_gpio_compiled_out": true
+    }
+  }
+}
+```
+
+`tests/check_hil_compileout.sh` inspects the built component archives and fails
+if a devboard backend references the excluded GPIO or ADC APIs.
+
+### Real-Panda target
+
+The Panda profile uses real sensors and actuators. The runner provides two
+independent host-side acknowledgements:
+
+- `--allow-panda-flash` authorizes replacing firmware on a real unit.
+- `--allow-heater` authorizes positive-target `power_on`, `auto`, or `drying`
+  commands.
+
+These checks protect runner-driven workflows; they are not authentication in
+the firmware protocol. A different serial writer can send commands directly.
+Real-unit HIL must therefore be supervised with the normal electrical and
+thermal precautions.
+
+The Panda power LED must remain disabled in this profile. GPIO21 is both the
+optional power LED and UART0 TX:
+
+```text
+# CONFIG_PB_POWER_LED is not set
+CONFIG_ESP_CONSOLE_UART_DEFAULT=y
+```
+
+## Profiles
+
+| Target | Transport | Overlay | Typical port | Physical I/O |
+|---|---|---|---|---|
+| Devboard | Native USB Serial/JTAG | `sdkconfig.hil-devboard` | `/dev/ttyACM0` | Panda I/O compiled out |
+| Devboard | USB-to-UART bridge | `sdkconfig.hil-devboard-uart` | `/dev/ttyUSB0` | Panda I/O compiled out |
+| Panda | On-board UART bridge | `sdkconfig.hil-panda` | `/dev/ttyUSB0` | Real hardware active |
+
+When `--transport` is omitted, the runner infers `native` from `/dev/ttyACM*`
+and `uart` from `/dev/ttyUSB*`. Pass it explicitly for other device naming
+schemes.
+
+Each profile uses a separate generated `sdkconfig.profile` inside its build
+directory. This prevents HIL symbols or console choices from leaking into the
+normal firmware build.
+
+## Prerequisites
+
+On the build machine:
+
+- this repository and its submodules
+- ESP-IDF 5.3
+- Python from the ESP-IDF environment
+- `pyserial` for local serial I/O
+- `ssh` and `scp` for remote operation
+
+On a remote device host:
+
+- SSH access
+- Python 3.9 or newer
+- `pyserial`
+- an esptool installation when using `--flash`
+- permission to open the serial device, normally through the `dialout` group
+
+Activate ESP-IDF before a build or any `--flash` invocation:
+
+```bash
+source ~/esp/esp-idf/export.sh
+idf.py --version
+python -c 'import serial; print(serial.__version__)'
+```
+
+## Local operation
+
+Run all scenarios compatible with a bridge-connected devboard:
+
+```bash
+python tools/hil.py \
+  --target devboard \
+  --port /dev/ttyUSB0 \
+  --flash \
+  --suite
+```
+
+Run one scenario without rebuilding or flashing:
+
+```bash
+python tools/hil.py \
+  --target devboard \
+  --port /dev/ttyUSB0 \
+  --scenario tests/hil/scenarios/devboard-safety.json
+```
+
+Use native USB explicitly:
+
+```bash
+python tools/hil.py \
+  --target devboard \
+  --transport native \
+  --port /dev/ttyACM0 \
+  --flash \
+  --suite
+```
+
+Drive the console interactively by entering one JSON object per line:
+
+```bash
+python tools/hil.py \
+  --target devboard \
+  --port /dev/ttyUSB0 \
+  --interactive
+```
+
+Example interactive input:
+
+```json
+{"cmd":"sensor","channel":"chamber","status":"ok","temp_c":25}
+{"cmd":"sensor","channel":"ptc","status":"ok","temp_c":25}
+{"cmd":"mode","mode":"power_on","target_c":50}
+{"cmd":"state"}
+{"cmd":"off"}
+```
+
+## Remote device-host operation
+
+Use `--host` when ESP-IDF and the repository are on the workstation but the
+serial device is attached to another machine. The runner:
+
+1. builds locally when `--flash` is present;
+2. reads ESP-IDF's generated `flasher_args.json`;
+3. creates an isolated directory on the remote host;
+4. transfers the exact flash images, runner, and scenarios;
+5. flashes and runs beside the serial device;
+6. copies `report.json` and `serial.jsonl` back to the local output directory.
+
+For a bridge-connected board on a Linux device host:
+
+```bash
+python tools/hil.py \
+  --host tester@hil-host \
+  --target devboard \
+  --port /dev/ttyUSB0 \
+  --remote-esptool /home/tester/hil-tools/.venv/bin/esptool.py \
+  --flash \
+  --suite \
+  --verbose
+```
+
+To rerun the suite against the already-flashed firmware:
+
+```bash
+python tools/hil.py \
+  --host tester@hil-host \
+  --target devboard \
+  --port /dev/ttyUSB0 \
+  --suite
+```
+
+Useful remote options:
+
+| Option | Default | Purpose |
+|---|---|---|
+| `--remote-python` | `python3` | Python interpreter containing `pyserial` |
+| `--remote-esptool` | `esptool.py` | Remote esptool executable |
+| `--remote-dir` | `/tmp/dragonbreath-hil` | Remote staging root |
+| `--flash-baud` | `460800` | Esptool transfer baud |
+| `--output-dir` | timestamped `hil-results/` | Local report destination |
+
+Remote operation requires an explicit `--port`; local auto-detection is not
+used for a different machine.
+
+## Real-Panda qualification
+
+Run the non-heating smoke scenario against an already-flashed unit:
+
+```bash
+python tools/hil.py \
+  --host tester@hil-host \
+  --target panda \
+  --port /dev/ttyUSB0 \
+  --scenario tests/hil/scenarios/panda-smoke.json
+```
+
+Authorize a real-unit flash separately:
+
+```bash
+python tools/hil.py \
+  --host tester@hil-host \
+  --target panda \
+  --port /dev/ttyUSB0 \
+  --remote-esptool /home/tester/hil-tools/.venv/bin/esptool.py \
+  --flash \
+  --allow-panda-flash \
+  --scenario tests/hil/scenarios/panda-smoke.json
+```
+
+Add `--allow-heater` only for a supervised scenario that intentionally requests
+a positive temperature. The provided Panda smoke scenario never requests heat.
+
+## Manual builds
+
+The runner performs these isolated builds when `--flash` is supplied. They can
+also be run directly:
+
+```bash
+idf.py -B build-hil-devboard \
+  -DSDKCONFIG="$PWD/build-hil-devboard/sdkconfig.profile" \
+  -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.hil-devboard" \
+  build
+
+idf.py -B build-hil-devboard-uart \
+  -DSDKCONFIG="$PWD/build-hil-devboard-uart/sdkconfig.profile" \
+  -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.hil-devboard-uart" \
+  build
+
+idf.py -B build-hil-panda \
+  -DSDKCONFIG="$PWD/build-hil-panda/sdkconfig.profile" \
+  -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.hil-panda" \
+  build
+```
+
+Audit either devboard build:
+
+```bash
+sh tests/check_hil_compileout.sh build-hil-devboard
+sh tests/check_hil_compileout.sh build-hil-devboard-uart
+```
+
+## Scenario format
+
+Scenarios are JSON objects stored under `tests/hil/scenarios/`:
+
+```json
+{
+  "name": "example",
+  "targets": ["devboard"],
+  "steps": [
+    {
+      "name": "inject a nominal sensor",
+      "send": {
+        "cmd": "sensor",
+        "channel": "chamber",
+        "status": "ok",
+        "temp_c": 25
+      },
+      "expect": {
+        "ok": true,
+        "state.sensors.chamber.status": "ok"
+      }
+    },
+    {
+      "name": "request heat and save the lease",
+      "send": {"cmd": "mode", "mode": "power_on", "target_c": 50},
+      "save": {"lease": "lease_id"}
+    },
+    {"name": "allow one control tick", "wait_s": 0.7},
+    {
+      "name": "renew ownership",
+      "send": {"cmd": "heartbeat", "lease_id": "$lease"},
+      "expect": {"ok": true, "state.lease_active": true}
+    }
+  ]
+}
+```
+
+Step fields:
+
+| Field | Meaning |
+|---|---|
+| `name` | Human-readable step label |
+| `send` | JSON request object; the runner adds `id` |
+| `wait_s` | Delay-only step, mutually exclusive with `send` |
+| `timeout_s` | Response timeout override, default 4 seconds |
+| `expect` | Dotted response paths and expected values |
+| `save` | Variable name to dotted response path |
+
+A string beginning with `$` substitutes a saved variable recursively in later
+requests. Assertions accept exact values or one operator:
+
+```json
+{
+  "state.io.zero_cross_count": {"gte": 12},
+  "state.mode": {"ne": "drying"},
+  "state.fault_reason": {"contains": "sensor"}
+}
+```
+
+Supported operators are `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, and `contains`.
+`--suite` loads only scenarios whose `targets` include the selected target.
+
+## Serial protocol
+
+Requests are one UTF-8 JSON object per line. Firmware emits exactly one
+correlated response prefixed with `DBHIL `:
+
+```text
+{"cmd":"state","id":7}
+DBHIL {"id":7,"ok":true,"state":{...}}
+```
+
+Other serial lines are treated as ordinary ESP-IDF console logs and retained in
+the transcript.
+
+Commands available on both targets:
+
+| Command | Required fields | Effect |
+|---|---|---|
+| `ping` | none | Return current state |
+| `state` | none | Return current state |
+| `off` | none | Request authoritative OFF |
+| `mode` | `mode` and mode-specific values | Select `off`, `power_on`, `auto`, or `drying` |
+| `heartbeat` | `lease_id` | Renew active remote ownership |
+| `clear_fault` | none | Clear a recoverable fault and remain OFF |
+
+Devboard-only injection:
+
+| Command | Fields | Effect |
+|---|---|---|
+| `sensor` | `channel`, `status`, optional `temp_c` | Inject chamber/PTC value or `open`, `short`, `uninit` |
+| `env` | `connected`, `bed_c` | Inject Moonraker connection and bed temperature |
+| `zero_cross` | optional `count`, `interval_us` | Inject fan zero-cross diagnostics |
+
+Every response includes the authoritative policy snapshot: mode, source,
+revision, targets, heater demand/output, fan percentage, fault/inhibit state,
+lease state, sensors, printer environment, logical LEDs, target identity, and
+zero-cross diagnostics.
+
+## Results
+
+Each scripted run writes:
+
+- `report.json`: target, transport, port, overall result, scenario results,
+  per-step duration, response snapshots, and failures.
+- `serial.jsonl`: timestamped `tx` and `rx` records containing every command,
+  response, and console log line.
+
+The default local location is `hil-results/YYYYMMDD-HHMMSS/`. This directory is
+gitignored. With `--host`, results are generated remotely and then copied to the
+same local structure. The downloaded report records the SSH host and rewrites
+its transcript path to the local copy. Missing remote artifacts fail the run
+instead of being ignored.
+
+## CI coverage
+
+The firmware workflow:
+
+- runs the policy, API, dashboard, and HIL runner tests;
+- builds normal firmware with ESP-IDF 5.3;
+- builds native-USB and UART devboard HIL images;
+- runs the compile-out audit against both images;
+- uploads both devboard application binaries.
+
+Physical HIL remains a deliberate lab qualification rather than a GitHub-hosted
+runner job.
+
+## Troubleshooting
+
+### No serial device
+
+Inspect USB enumeration and persistent names:
+
+```bash
+lsusb
+ls -l /dev/serial/by-id
+ls -l /dev/ttyACM* /dev/ttyUSB*
+dmesg --ctime | tail -30
+```
+
+Native ESP USB normally appears as `/dev/ttyACM*`; CH341/CH340 bridges normally
+appear as `/dev/ttyUSB*`.
+
+### Permission denied
+
+Check the device group and current memberships:
+
+```bash
+ls -l /dev/ttyUSB0
+id
+```
+
+Add the device-host user to `dialout`, then start a new login session.
+
+### Port opens but requests time out
+
+- Confirm the firmware transport matches the connector.
+- Confirm no monitor or other process owns the port with
+  `fuser -v /dev/ttyUSB0`.
+- Reset the board and inspect the captured ESP-IDF logs.
+- If using native USB, try the bridge/UART profile; native application serial
+  remains unqualified on the current dual-USB-C board.
+
+The runner explicitly releases DTR/RTS after opening the port and bounds serial
+writes so an unresponsive native USB endpoint cannot wedge the test process.
+
+### Board remains in the ROM loader
+
+Use the connector matching the selected profile and reset without holding BOOT.
+For remote flashing, verify that `--remote-esptool` names the intended
+installation and that the user can open the selected port.
+
+### Wrong configuration appears in a build
+
+Do not share the repository-root generated `sdkconfig` between profiles. Use the
+documented `-DSDKCONFIG=.../sdkconfig.profile` commands or let the runner select
+the isolated build directory.
+
+### Real Panda UART output is missing
+
+Verify `CONFIG_PB_POWER_LED` is disabled. Enabling it claims GPIO21 and conflicts
+with UART0 TX.

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(
     SRCS "app_main.c"
     INCLUDE_DIRS "."
-    REQUIRES pb_board pb_ntc pb_heater pb_fan pb_policy pb_leds pb_httpd pb_portal
+    REQUIRES pb_board pb_ntc pb_heater pb_fan pb_policy pb_leds pb_hil pb_httpd pb_portal
              pv_wifi pv_moonraker nvs_flash esp_wifi esp_netif mdns app_update
 )

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -25,6 +25,7 @@
 #include "pb_fan.h"
 #include "pb_policy.h"
 #include "pb_leds.h"
+#include "pb_hil.h"
 
 #include "esp_wifi.h"
 #include "esp_mac.h"
@@ -62,6 +63,7 @@ static volatile bool s_mk_up = false;
 // default (pre-DragonBreath rebrand) so an already-provisioned device adopts the new
 // name, while preserving any user-customized SSID. (mDNS hostname is overridden
 // separately in brand_hostname().)
+#ifndef CONFIG_PB_HIL_DEVBOARD
 static void brand_ap(void)
 {
     nvs_handle_t h;
@@ -104,6 +106,7 @@ static void brand_hostname(void)
     mdns_service_instance_name_set("_http", "_tcp", HN);
     ESP_LOGI(TAG, "mDNS hostname override: %s.local", HN);
 }
+#endif
 
 static void nvs_init(void)
 {
@@ -168,9 +171,11 @@ static void control_task(void *arg)
 
     for (;;) {
         pv_moonraker_status_t st = {0};
+#ifndef CONFIG_PB_HIL_DEVBOARD
         if (s_net_up && s_mk_up) pv_moonraker_get_status(&st);
         bool mk_connected = s_mk_up && st.state == PV_MK_SUBSCRIBED;
         pb_policy_set_env(st.bed_temp, mk_connected);
+#endif
 
         // Safety/control loop: enforces every heater cutoff + fan-follows-heater.
         // pb_policy is the sole mode/target writer. Network clients and local
@@ -210,6 +215,9 @@ void app_main(void)
     ESP_ERROR_CHECK(pb_fan_init());
     ESP_ERROR_CHECK(pb_policy_init());
     ESP_ERROR_CHECK(pb_leds_start());       // indicator LEDs (pb_policy drives them)
+#ifdef CONFIG_PB_HIL_CONSOLE
+    ESP_ERROR_CHECK(pb_hil_start());
+#endif
 
     // Start the safety/telemetry loop FIRST — it must run regardless of the
     // network coming up (a blocking/hung network stack must never stop it).
@@ -220,6 +228,7 @@ void app_main(void)
     // loop above is already running, so safety + telemetry continue.
     nvs_init();
     pb_heater_load_config();                 // apply persisted max-target + comms timeout (NVS is up now)
+#ifndef CONFIG_PB_HIL_DEVBOARD
     brand_ap();                              // AP name = DragonBreath_XXXX
 #if defined(DB_WIFI_SSID) || defined(DB_MOONRAKER_HOST)
     seed_dev_config();
@@ -246,6 +255,9 @@ void app_main(void)
 
     s_net_up = true;
     ESP_LOGI(TAG, "network bring-up done (wifi + moonraker + http api + portal, best-effort)");
+#else
+    ESP_LOGW(TAG, "HIL dev-board target: network stack skipped; inject env over serial");
+#endif
 
     // OTA rollback confirm: we reached a healthy state (safety loop running, init
     // complete), so mark this image valid and cancel the pending-verify rollback.

--- a/plans/iteration-2-stock-parity-and-config.md
+++ b/plans/iteration-2-stock-parity-and-config.md
@@ -21,8 +21,8 @@ Decisions locked with the user: **phased plan**, **all four buttons usable**
 > in v0.3.0 & hardware-validated — **except B2** (thermal-purge + NVS-persisted fault
 > latch), deferred · Phase C ⬜ not started (buttons — all 4 pins mapped, ready to build) · Phase D 🟡 partial (v2 dashboard
 > covers D2/D3; D4 parity matrix documented; D1 shell open) · Phase E 🟡 partial (release/build CI +
-> host tests; broader static-analysis/sim/dev-board target open). **Next candidates:** B2
-> safety hardening, Phase C button, or Phase D1/D4 dashboard polish.
+> host tests + UART dev-board HIL qualified; broader static-analysis/sim and real-Panda matrix open). **Next candidates:** B2
+> safety hardening, Phase C button, or Phase D1 dashboard polish.
 
 Not covered / explicitly out of scope: stock OEM WebSocket protocol + web UI,
 Bambu binding, and the stock `filtertemp`/`heater_temp` auto parameters
@@ -344,10 +344,15 @@ enhancement, not required parity until OEM behavior confirms it.
 
 > 🟡 **Partial.** **E1** in progress: firmware-build + release CI (SHA-pinned actions,
 > least-privilege perms) and host-side tests exist (`pb_policy` host test, `check_api_v2_contract.sh`,
-> dashboard JS check). **Open:** the fuller **E1** gate (warnings-as-errors, formatting,
+> dashboard JS check, HIL runner tests). **E3/E4 tooling is implemented:** isolated
+> native-USB/UART dev-board and UART Panda profiles, compile-time no-op Panda mains backends,
+> JSON serial injection/state, scripted suites, console capture, and JSON reports.
+> The full dev-board suite is hardware-qualified over its CH341-family UART bridge;
+> native-USB runtime diagnosis and the real-Panda release matrix remain open.
+> **Open:** the fuller **E1** gate (warnings-as-errors, formatting,
 > static analysis, dependency validation on every PR), **E2** broad host/sim fault coverage
-> (sensor faults, corrupt NVS, reconnect storms, stale leases, malformed API, OTA rollback),
-> and **E3** the ESP32-C3 dev-board target with heater output compile-time disabled.
+> (corrupt NVS, reconnect storms, malformed API, OTA rollback), native-USB runtime
+> qualification, and real-Panda physical HIL sign-off.
 
 **E1. CI/static analysis.** Run warnings-as-errors, formatting, static analysis,
 dependency validation, host-side unit tests, frontend validation, and API/schema

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -9,9 +9,10 @@ CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
 # Size-optimize (the app slot is ~1.8MB; stock image is ~1.3MB)
 CONFIG_COMPILER_OPTIMIZATION_SIZE=y
 
-# Console on UART0 (CH340K USB-C bridge, GPIO21/20). The C3 native USB-Serial-JTAG
-# is NOT usable here: its D-/D+ pads are GPIO18/19 and GPIO18 drives the heater SSR.
-CONFIG_ESP_CONSOLE_UART_DEFAULT=y
+# Kconfig defaults production images to UART0 (CH340K USB-C bridge, GPIO21/20).
+# Do not pin the choice here: the safe dev-board HIL overlay deliberately selects
+# native USB Serial/JTAG. Native USB is NOT usable on Panda hardware because its
+# D-/D+ pads are GPIO18/19 and GPIO18 drives the heater SSR.
 
 # Task watchdog on — a hung control loop must not leave the heater energized.
 # (pb_control subscribes via esp_task_wdt_add and pets it each loop.)

--- a/sdkconfig.hil-devboard
+++ b/sdkconfig.hil-devboard
@@ -1,0 +1,13 @@
+# ESP32-C3 development-board HIL overlay.
+# Build with:
+#   idf.py -B build-hil-devboard \
+#     -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.hil-devboard" build
+CONFIG_PB_HIL_CONSOLE=y
+CONFIG_PB_HIL_DEVBOARD=y
+
+# This dual-USB-C dev board is connected through the ESP32-C3 native USB port.
+# Use the built-in USB Serial/JTAG device for flashing, commands, and log capture.
+# Never combine this profile with sdkconfig.release.
+# CONFIG_PB_POWER_LED is not set
+# CONFIG_ESP_CONSOLE_UART_DEFAULT is not set
+CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y

--- a/sdkconfig.hil-devboard-uart
+++ b/sdkconfig.hil-devboard-uart
@@ -1,0 +1,12 @@
+# ESP32-C3 development-board HIL overlay using its USB-to-UART bridge.
+# Build with:
+#   idf.py -B build-hil-devboard-uart \
+#     -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.hil-devboard-uart" build
+CONFIG_PB_HIL_CONSOLE=y
+CONFIG_PB_HIL_DEVBOARD=y
+
+# Match Panda hardware transport while retaining the GPIO-free devboard backend.
+# GPIO21 is UART0 TX, so the optional Panda power LED must remain disabled.
+# CONFIG_PB_POWER_LED is not set
+CONFIG_ESP_CONSOLE_UART_DEFAULT=y
+# CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG is not set

--- a/sdkconfig.hil-panda
+++ b/sdkconfig.hil-panda
@@ -1,0 +1,8 @@
+# Real Panda Breath HIL overlay. Hardware sensors and actuators remain active;
+# only the serial command/observation console is added.
+CONFIG_PB_HIL_CONSOLE=y
+# CONFIG_PB_HIL_DEVBOARD is not set
+
+# Keep UART0 available. Never combine this profile with sdkconfig.release.
+# CONFIG_PB_POWER_LED is not set
+CONFIG_ESP_CONSOLE_UART_DEFAULT=y

--- a/tests/check_hil_compileout.sh
+++ b/tests/check_hil_compileout.sh
@@ -5,6 +5,15 @@ build_dir="${1:-build-hil-devboard}"
 config="$build_dir/config/sdkconfig.h"
 nm_tool="${CROSS_COMPILE:-riscv32-esp-elf-}nm"
 
+if ! command -v "$nm_tool" >/dev/null 2>&1; then
+    echo "HIL compile-out check requires $nm_tool in PATH" >&2
+    exit 1
+fi
+if [ ! -f "$config" ]; then
+    echo "missing HIL build config: $config" >&2
+    exit 1
+fi
+
 grep -q '^#define CONFIG_PB_HIL_CONSOLE 1$' "$config"
 grep -q '^#define CONFIG_PB_HIL_DEVBOARD 1$' "$config"
 if ! grep -Eq \
@@ -19,7 +28,15 @@ fi
 
 for component in pb_board pb_heater pb_fan pb_leds; do
     archive="$build_dir/esp-idf/$component/lib$component.a"
-    if "$nm_tool" -u "$archive" | grep -Eq \
+    if [ ! -f "$archive" ]; then
+        echo "missing HIL component archive: $archive" >&2
+        exit 1
+    fi
+    if ! undefined_symbols=$("$nm_tool" -u "$archive"); then
+        echo "$nm_tool failed to inspect $archive" >&2
+        exit 1
+    fi
+    if printf '%s\n' "$undefined_symbols" | grep -Eq \
         'gpio_(config|set_level|get_level|install_isr_service|isr_handler_add)'; then
         echo "$component still references physical GPIO in dev-board HIL" >&2
         exit 1
@@ -27,7 +44,15 @@ for component in pb_board pb_heater pb_fan pb_leds; do
 done
 
 archive="$build_dir/esp-idf/pb_ntc/libpb_ntc.a"
-if "$nm_tool" -u "$archive" | grep -Eq 'adc_(oneshot|cali)'; then
+if [ ! -f "$archive" ]; then
+    echo "missing HIL component archive: $archive" >&2
+    exit 1
+fi
+if ! undefined_symbols=$("$nm_tool" -u "$archive"); then
+    echo "$nm_tool failed to inspect $archive" >&2
+    exit 1
+fi
+if printf '%s\n' "$undefined_symbols" | grep -Eq 'adc_(oneshot|cali)'; then
     echo "pb_ntc still references the ADC backend in dev-board HIL" >&2
     exit 1
 fi

--- a/tests/check_hil_compileout.sh
+++ b/tests/check_hil_compileout.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -eu
+
+build_dir="${1:-build-hil-devboard}"
+config="$build_dir/config/sdkconfig.h"
+nm_tool="${CROSS_COMPILE:-riscv32-esp-elf-}nm"
+
+grep -q '^#define CONFIG_PB_HIL_CONSOLE 1$' "$config"
+grep -q '^#define CONFIG_PB_HIL_DEVBOARD 1$' "$config"
+if ! grep -Eq \
+    '^#define CONFIG_ESP_CONSOLE_(USB_SERIAL_JTAG|UART_DEFAULT) 1$' "$config"; then
+    echo "dev-board HIL requires a supported serial console" >&2
+    exit 1
+fi
+if grep -q '^#define CONFIG_PB_POWER_LED 1$' "$config"; then
+    echo "dev-board HIL must not claim the Panda Power LED" >&2
+    exit 1
+fi
+
+for component in pb_board pb_heater pb_fan pb_leds; do
+    archive="$build_dir/esp-idf/$component/lib$component.a"
+    if "$nm_tool" -u "$archive" | grep -Eq \
+        'gpio_(config|set_level|get_level|install_isr_service|isr_handler_add)'; then
+        echo "$component still references physical GPIO in dev-board HIL" >&2
+        exit 1
+    fi
+done
+
+archive="$build_dir/esp-idf/pb_ntc/libpb_ntc.a"
+if "$nm_tool" -u "$archive" | grep -Eq 'adc_(oneshot|cali)'; then
+    echo "pb_ntc still references the ADC backend in dev-board HIL" >&2
+    exit 1
+fi
+
+echo "HIL compile-out check: PASS"

--- a/tests/hil/scenarios/devboard-auto.json
+++ b/tests/hil/scenarios/devboard-auto.json
@@ -1,0 +1,70 @@
+{
+  "name": "devboard AUTO environment injection",
+  "targets": ["devboard"],
+  "steps": [
+    {"name": "start safe", "send": {"cmd": "off"}},
+    {
+      "name": "nominal chamber",
+      "send": {"cmd": "sensor", "channel": "chamber", "status": "ok", "temp_c": 25}
+    },
+    {
+      "name": "nominal PTC",
+      "send": {"cmd": "sensor", "channel": "ptc", "status": "ok", "temp_c": 25}
+    },
+    {
+      "name": "select AUTO",
+      "send": {
+        "cmd": "mode",
+        "mode": "auto",
+        "target_c": 55,
+        "bed_threshold_c": 100
+      }
+    },
+    {
+      "name": "disconnected printer cannot engage",
+      "send": {"cmd": "env", "connected": false, "bed_c": 110}
+    },
+    {"name": "allow disconnected tick", "wait_s": 0.7},
+    {
+      "name": "AUTO remains cold while disconnected",
+      "send": {"cmd": "state"},
+      "expect": {
+        "ok": true,
+        "state.mode": "auto",
+        "state.auto_engaged": false,
+        "state.heater_output": false
+      }
+    },
+    {
+      "name": "connect at threshold",
+      "send": {"cmd": "env", "connected": true, "bed_c": 100}
+    },
+    {"name": "allow engaged tick", "wait_s": 0.7},
+    {
+      "name": "AUTO engages",
+      "send": {"cmd": "state"},
+      "expect": {
+        "ok": true,
+        "state.auto_engaged": true,
+        "state.heater_output": true
+      }
+    },
+    {
+      "name": "disconnect live printer",
+      "send": {"cmd": "env", "connected": false, "bed_c": 100}
+    },
+    {"name": "allow fail-closed tick", "wait_s": 0.7},
+    {
+      "name": "AUTO drops heat without latching a sensor fault",
+      "send": {"cmd": "state"},
+      "expect": {
+        "ok": true,
+        "state.mode": "auto",
+        "state.auto_engaged": false,
+        "state.heater_output": false,
+        "state.fault_latched": false
+      }
+    },
+    {"name": "finish off", "send": {"cmd": "off"}}
+  ]
+}

--- a/tests/hil/scenarios/devboard-safety.json
+++ b/tests/hil/scenarios/devboard-safety.json
@@ -1,0 +1,140 @@
+{
+  "name": "devboard safety and ownership",
+  "targets": ["devboard"],
+  "steps": [
+    {
+      "name": "boot is safe and mains GPIO is absent",
+      "send": {"cmd": "state"},
+      "expect": {
+        "ok": true,
+        "state.mode": "off",
+        "state.heater_output": false,
+        "state.io.target": "devboard",
+        "state.io.mains_gpio_compiled_out": true
+      }
+    },
+    {
+      "name": "inject nominal chamber sensor",
+      "send": {
+        "cmd": "sensor",
+        "channel": "chamber",
+        "status": "ok",
+        "temp_c": 25
+      }
+    },
+    {
+      "name": "inject nominal PTC sensor",
+      "send": {
+        "cmd": "sensor",
+        "channel": "ptc",
+        "status": "ok",
+        "temp_c": 25
+      }
+    },
+    {
+      "name": "request remote heat and capture lease",
+      "send": {"cmd": "mode", "mode": "power_on", "target_c": 50},
+      "expect": {
+        "ok": true,
+        "state.mode": "power_on",
+        "state.lease_active": true
+      },
+      "save": {"lease": "lease_id"}
+    },
+    {"name": "allow control tick", "wait_s": 0.7},
+    {
+      "name": "logical heater turns on without a mains GPIO",
+      "send": {"cmd": "state"},
+      "expect": {
+        "ok": true,
+        "state.heater_demand": true,
+        "state.heater_output": true,
+        "state.io.mains_gpio_compiled_out": true
+      }
+    },
+    {
+      "name": "active lease heartbeat succeeds",
+      "send": {"cmd": "heartbeat", "lease_id": "$lease"},
+      "expect": {"ok": true, "result": "ok"}
+    },
+    {
+      "name": "chamber open circuit is injected",
+      "send": {"cmd": "sensor", "channel": "chamber", "status": "open"}
+    },
+    {"name": "allow safety tick", "wait_s": 0.7},
+    {
+      "name": "sensor fault latches off and forces airflow",
+      "send": {"cmd": "state"},
+      "expect": {
+        "ok": true,
+        "state.mode": "off",
+        "state.heater_output": false,
+        "state.fault_latched": true,
+        "state.fault_reason": "chamber sensor fault",
+        "state.fan_percent": 100
+      }
+    },
+    {
+      "name": "fault invalidates the old lease",
+      "send": {"cmd": "heartbeat", "lease_id": "$lease"},
+      "expect": {"ok": false, "result": "stale_lease"}
+    },
+    {
+      "name": "restore chamber sensor",
+      "send": {
+        "cmd": "sensor",
+        "channel": "chamber",
+        "status": "ok",
+        "temp_c": 25
+      }
+    },
+    {
+      "name": "explicit clear returns to off",
+      "send": {"cmd": "clear_fault"},
+      "expect": {
+        "ok": true,
+        "state.mode": "off",
+        "state.fault_latched": false,
+        "state.heater_output": false
+      }
+    },
+    {
+      "name": "PTC over-temperature setup",
+      "send": {"cmd": "mode", "mode": "power_on", "target_c": 50}
+    },
+    {
+      "name": "inject PTC over-temperature",
+      "send": {
+        "cmd": "sensor",
+        "channel": "ptc",
+        "status": "ok",
+        "temp_c": 106
+      }
+    },
+    {"name": "allow over-temperature tick", "wait_s": 0.7},
+    {
+      "name": "fixed PTC cutoff latches off",
+      "send": {"cmd": "state"},
+      "expect": {
+        "ok": true,
+        "state.fault_latched": true,
+        "state.fault_reason": "PTC element over-temp",
+        "state.heater_output": false
+      }
+    },
+    {
+      "name": "restore PTC sensor",
+      "send": {"cmd": "sensor", "channel": "ptc", "status": "ok", "temp_c": 25}
+    },
+    {"name": "clear PTC fault", "send": {"cmd": "clear_fault"}},
+    {
+      "name": "inject zero-cross events",
+      "send": {"cmd": "zero_cross", "count": 12, "interval_us": 10000},
+      "expect": {
+        "ok": true,
+        "state.io.zero_cross_count": {"gte": 12},
+        "state.io.zero_cross_interval_us": 10000
+      }
+    }
+  ]
+}

--- a/tests/hil/scenarios/panda-smoke.json
+++ b/tests/hil/scenarios/panda-smoke.json
@@ -1,0 +1,24 @@
+{
+  "name": "Panda non-heating smoke qualification",
+  "targets": ["panda"],
+  "steps": [
+    {
+      "name": "identify real hardware target",
+      "send": {"cmd": "state"},
+      "expect": {
+        "ok": true,
+        "state.io.target": "panda",
+        "state.io.mains_gpio_compiled_out": false
+      }
+    },
+    {
+      "name": "physical OFF is always accepted",
+      "send": {"cmd": "off"},
+      "expect": {
+        "ok": true,
+        "state.mode": "off",
+        "state.heater_output": false
+      }
+    }
+  ]
+}

--- a/tests/test_hil_runner.py
+++ b/tests/test_hil_runner.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+import importlib.util
+import io
+import json
+import pathlib
+import sys
+import tempfile
+import types
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("dragonbreath_hil", ROOT / "tools" / "hil.py")
+hil = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(hil)
+
+
+class HilRunnerTest(unittest.TestCase):
+    def test_dotted_expectations_and_operators(self):
+        response = {"ok": True, "state": {"mode": "off", "count": 3}}
+        hil.check_expectations(
+            response,
+            {
+                "ok": True,
+                "state.mode": "off",
+                "state.count": {"gte": 2},
+            },
+        )
+
+    def test_failed_expectation_is_descriptive(self):
+        with self.assertRaisesRegex(hil.HilError, "expected 'off', got 'auto'"):
+            hil.check_expectations(
+                {"state": {"mode": "auto"}}, {"state.mode": "off"}
+            )
+
+    def test_variable_substitution(self):
+        value = hil.substitute(
+            {"cmd": "heartbeat", "lease_id": "$lease"}, {"lease": "abc"}
+        )
+        self.assertEqual(value["lease_id"], "abc")
+
+    def test_heat_detection(self):
+        self.assertTrue(
+            hil.requests_heat(
+                {"cmd": "mode", "mode": "power_on", "target_c": 50}
+            )
+        )
+        self.assertFalse(hil.requests_heat({"cmd": "off"}))
+        self.assertFalse(
+            hil.requests_heat({"cmd": "mode", "mode": "off", "target_c": 50})
+        )
+
+    def test_all_scenarios_parse_for_a_supported_target(self):
+        for path in sorted(hil.SCENARIO_DIR.glob("*.json")):
+            raw = __import__("json").loads(path.read_text(encoding="utf-8"))
+            target = raw.get("targets", ["devboard", "panda"])[0]
+            loaded = hil.load_scenario(path, target)
+            self.assertTrue(loaded["steps"], path)
+
+    def test_suite_only_loads_scenarios_for_target(self):
+        scenarios = hil.load_suite_scenarios("devboard")
+        self.assertTrue(scenarios)
+        self.assertTrue(
+            all("devboard" in scenario["targets"] for _, scenario in scenarios)
+        )
+        self.assertNotIn(
+            "panda-smoke.json", {path.name for path, _ in scenarios}
+        )
+
+    def test_serial_open_releases_reset_lines(self):
+        class FakeSerial:
+            def __init__(self, **kwargs):
+                self.port = kwargs["port"]
+                self.write_timeout = kwargs["write_timeout"]
+                self.rts = None
+                self.dtr = None
+                self.open_state = None
+
+            def open(self):
+                self.open_state = (self.rts, self.dtr)
+
+        serial_module = types.SimpleNamespace(Serial=FakeSerial)
+        with mock.patch.dict(sys.modules, {"serial": serial_module}):
+            transport = hil.SerialTransport("/dev/test", 115200, io.StringIO())
+
+        self.assertEqual(transport.serial.open_state, (True, True))
+        self.assertEqual((transport.serial.rts, transport.serial.dtr), (False, False))
+        self.assertEqual(transport.serial.write_timeout, 1.0)
+
+    def test_transport_is_inferred_from_linux_port(self):
+        self.assertEqual(
+            hil.resolve_transport("devboard", None, "/dev/ttyACM0"), "native"
+        )
+        self.assertEqual(
+            hil.resolve_transport("devboard", None, "/dev/ttyUSB0"), "uart"
+        )
+        self.assertEqual(
+            hil.resolve_transport("devboard", "uart", "/dev/ttyACM0"), "uart"
+        )
+
+    def test_panda_rejects_native_usb_transport(self):
+        with self.assertRaisesRegex(hil.HilError, "Panda HIL uses UART"):
+            hil.resolve_transport("panda", "native", "/dev/ttyACM0")
+
+    def test_uart_devboard_uses_dedicated_profile(self):
+        args = SimpleNamespace(
+            target="devboard", transport="uart", build_dir=None
+        )
+        overlay, build_dir = hil.profile_paths(args)
+        self.assertEqual(overlay.name, "sdkconfig.hil-devboard-uart")
+        self.assertEqual(build_dir.name, "build-hil-devboard-uart")
+
+    def test_remote_flash_command_uses_generated_manifest(self):
+        with tempfile.TemporaryDirectory() as temp:
+            build_dir = pathlib.Path(temp)
+            (build_dir / "bootloader").mkdir()
+            (build_dir / "bootloader" / "bootloader.bin").write_bytes(b"boot")
+            (build_dir / "dragonbreath.bin").write_bytes(b"app")
+            manifest = {
+                "write_flash_args": ["--flash_mode", "dio"],
+                "flash_files": {
+                    "0x20000": "dragonbreath.bin",
+                    "0x0": "bootloader/bootloader.bin",
+                },
+                "extra_esptool_args": {
+                    "chip": "esp32c3",
+                    "before": "default_reset",
+                    "after": "hard_reset",
+                    "stub": False,
+                },
+            }
+            (build_dir / "flasher_args.json").write_text(
+                json.dumps(manifest), encoding="utf-8"
+            )
+            args = SimpleNamespace(
+                remote_esptool="/venv/bin/esptool.py",
+                port="/dev/ttyACM0",
+                flash_baud=460800,
+            )
+
+            command, sources = hil.remote_flash_command(
+                args, build_dir, "/tmp/hil/firmware"
+            )
+
+        self.assertIn("--no-stub", command)
+        self.assertLess(command.index("0x0"), command.index("0x20000"))
+        self.assertIn("/tmp/hil/firmware/dragonbreath.bin", command)
+        self.assertEqual(
+            {path.name for path in sources},
+            {"bootloader.bin", "dragonbreath.bin"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/hil.py
+++ b/tools/hil.py
@@ -1,0 +1,662 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Build, flash, drive, and report DragonBreath serial HIL scenarios."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import datetime as dt
+import json
+import pathlib
+import posixpath
+import shlex
+import subprocess
+import sys
+import time
+from typing import Any, Optional
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCENARIO_DIR = ROOT / "tests" / "hil" / "scenarios"
+RESPONSE_PREFIX = "DBHIL "
+
+
+class HilError(RuntimeError):
+    pass
+
+
+def dotted_get(value: Any, path: str) -> Any:
+    current = value
+    for part in path.split("."):
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        else:
+            raise HilError(f"response has no field {path!r}")
+    return current
+
+
+def check_expectations(response: dict[str, Any], expected: dict[str, Any]) -> None:
+    for path, wanted in expected.items():
+        actual = dotted_get(response, path)
+        if isinstance(wanted, dict):
+            if len(wanted) != 1:
+                raise HilError(f"{path}: assertion must contain exactly one operator")
+            operator, operand = next(iter(wanted.items()))
+            operations = {
+                "eq": lambda: actual == operand,
+                "ne": lambda: actual != operand,
+                "gt": lambda: actual > operand,
+                "gte": lambda: actual >= operand,
+                "lt": lambda: actual < operand,
+                "lte": lambda: actual <= operand,
+                "contains": lambda: operand in actual,
+            }
+            if operator not in operations:
+                raise HilError(f"{path}: unknown assertion operator {operator!r}")
+            passed = operations[operator]()
+        else:
+            passed = actual == wanted
+        if not passed:
+            raise HilError(f"{path}: expected {wanted!r}, got {actual!r}")
+
+
+def substitute(value: Any, variables: dict[str, Any]) -> Any:
+    if isinstance(value, str) and value.startswith("$"):
+        name = value[1:]
+        if name not in variables:
+            raise HilError(f"unknown scenario variable {value}")
+        return variables[name]
+    if isinstance(value, dict):
+        return {key: substitute(item, variables) for key, item in value.items()}
+    if isinstance(value, list):
+        return [substitute(item, variables) for item in value]
+    return value
+
+
+def requests_heat(command: dict[str, Any]) -> bool:
+    if command.get("cmd") != "mode":
+        return False
+    return command.get("mode") in {"power_on", "auto", "drying"} and (
+        float(command.get("target_c", 0)) > 0
+    )
+
+
+def load_scenario(
+    path: pathlib.Path, target: Optional[str] = None
+) -> dict[str, Any]:
+    try:
+        scenario = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise HilError(f"cannot load scenario {path}: {exc}") from exc
+    if not isinstance(scenario, dict) or not isinstance(scenario.get("steps"), list):
+        raise HilError(f"{path}: scenario must be an object with a steps array")
+    targets = scenario.get("targets", ["devboard", "panda"])
+    if target is not None and target not in targets:
+        raise HilError(f"{path}: scenario does not support target {target!r}")
+    return scenario
+
+
+def load_suite_scenarios(target: str) -> list[tuple[pathlib.Path, dict[str, Any]]]:
+    scenarios = []
+    for path in sorted(SCENARIO_DIR.glob("*.json")):
+        scenario = load_scenario(path)
+        if target in scenario.get("targets", ["devboard", "panda"]):
+            scenarios.append((path, scenario))
+    if not scenarios:
+        raise HilError(f"no suite scenarios support target {target!r}")
+    return scenarios
+
+
+class SerialTransport:
+    def __init__(
+        self,
+        port: str,
+        baud: int,
+        transcript,
+        verbose: bool = False,
+    ) -> None:
+        try:
+            import serial
+        except ImportError as exc:
+            raise HilError(
+                "pyserial is required for HIL I/O; run from the ESP-IDF 5.3 "
+                "environment (source ~/esp/esp-idf/export.sh)"
+            ) from exc
+        self.serial = serial.Serial(
+            port=None, baudrate=baud, timeout=0.2, write_timeout=1.0
+        )
+        # Match ESP-IDF Monitor: establish known levels before opening, then
+        # release both lines so native USB does not hold the C3 in reset.
+        self.serial.rts = True
+        self.serial.dtr = True
+        self.serial.port = port
+        self.serial.open()
+        self.serial.rts = False
+        self.serial.dtr = False
+        self.transcript = transcript
+        self.verbose = verbose
+        self.next_id = 1
+
+    def close(self) -> None:
+        if sys.platform == "linux" and getattr(self.serial, "is_open", False):
+            try:
+                import fcntl
+                import struct
+                import termios
+
+                layout = "iiIiiiiiHcciHHPHIL"
+                packed = fcntl.ioctl(
+                    self.serial.fd,
+                    termios.TIOCGSERIAL,
+                    bytes(struct.calcsize(layout)),
+                )
+                fields = list(struct.unpack(layout, packed))
+                fields[12] = 0xFFFF  # ASYNC_CLOSING_WAIT_NONE
+                fcntl.ioctl(
+                    self.serial.fd, termios.TIOCSSERIAL,
+                    struct.pack(layout, *fields),
+                )
+            except (AttributeError, OSError):
+                pass
+        try:
+            self.serial.cancel_write()
+        except (AttributeError, OSError):
+            pass
+        try:
+            self.serial.reset_output_buffer()
+        except (AttributeError, OSError):
+            pass
+        self.serial.close()
+
+    def drain(self, seconds: float) -> None:
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            self._read_line()
+
+    def _read_line(self) -> Optional[str]:
+        raw = self.serial.readline()
+        if not raw:
+            return None
+        line = raw.decode("utf-8", errors="replace").rstrip("\r\n")
+        self.transcript.write(
+            json.dumps(
+                {"at": dt.datetime.now(dt.timezone.utc).isoformat(), "rx": line}
+            )
+            + "\n"
+        )
+        self.transcript.flush()
+        if self.verbose or not line.startswith(RESPONSE_PREFIX):
+            print(f"< {line}")
+        return line
+
+    def request(
+        self, command: dict[str, Any], timeout_s: float = 4.0
+    ) -> dict[str, Any]:
+        request = copy.deepcopy(command)
+        request_id = self.next_id
+        self.next_id += 1
+        request["id"] = request_id
+        wire = json.dumps(request, separators=(",", ":"))
+        self.transcript.write(
+            json.dumps(
+                {"at": dt.datetime.now(dt.timezone.utc).isoformat(), "tx": wire}
+            )
+            + "\n"
+        )
+        self.transcript.flush()
+        if self.verbose:
+            print(f"> {wire}")
+        self.serial.write((wire + "\n").encode())
+
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            line = self._read_line()
+            if not line or not line.startswith(RESPONSE_PREFIX):
+                continue
+            try:
+                response = json.loads(line[len(RESPONSE_PREFIX) :])
+            except json.JSONDecodeError:
+                continue
+            if response.get("id") == request_id:
+                return response
+        raise HilError(f"timeout waiting for response to request {request_id}")
+
+
+def resolve_port(requested: Optional[str]) -> str:
+    if requested:
+        return requested
+    try:
+        from serial.tools import list_ports
+    except ImportError as exc:
+        raise HilError("pyserial is required to auto-detect a serial port") from exc
+    ports = [item.device for item in list_ports.comports()]
+    if len(ports) != 1:
+        joined = ", ".join(ports) if ports else "none"
+        raise HilError(f"pass --port; auto-detection found {len(ports)} ports: {joined}")
+    return ports[0]
+
+
+def resolve_transport(target: str, requested: Optional[str], port: str) -> str:
+    if target == "panda":
+        if requested == "native":
+            raise HilError("Panda HIL uses UART; native USB is not available")
+        return "uart"
+    if requested:
+        return requested
+    device_name = pathlib.Path(port).resolve().name
+    return "uart" if device_name.startswith("ttyUSB") else "native"
+
+
+def profile_paths(args) -> tuple[pathlib.Path, pathlib.Path]:
+    profile = f"hil-{args.target}"
+    if args.target == "devboard" and args.transport == "uart":
+        profile += "-uart"
+    overlay = ROOT / f"sdkconfig.{profile}"
+    build_dir = pathlib.Path(args.build_dir or ROOT / f"build-{profile}")
+    return overlay, build_dir
+
+
+def build_profile(args) -> pathlib.Path:
+    overlay, build_dir = profile_paths(args)
+    sdkconfig = build_dir / "sdkconfig.profile"
+    defaults = f"{ROOT / 'sdkconfig.defaults'};{overlay}"
+    command = [
+        args.idf,
+        "-B",
+        str(build_dir),
+        f"-DSDKCONFIG={sdkconfig}",
+        f"-DSDKCONFIG_DEFAULTS={defaults}",
+        "build",
+    ]
+    print("$ " + " ".join(command), flush=True)
+    subprocess.run(command, cwd=ROOT, check=True)
+    return build_dir
+
+
+def build_and_flash(args, port: str) -> None:
+    if args.target == "panda" and not args.allow_panda_flash:
+        raise HilError("Panda flashing requires --allow-panda-flash")
+    overlay, build_dir = profile_paths(args)
+    sdkconfig = build_dir / "sdkconfig.profile"
+    defaults = f"{ROOT / 'sdkconfig.defaults'};{overlay}"
+    command = [
+        args.idf,
+        "-B",
+        str(build_dir),
+        f"-DSDKCONFIG={sdkconfig}",
+        f"-DSDKCONFIG_DEFAULTS={defaults}",
+        "-p",
+        port,
+        "build",
+        "flash",
+    ]
+    print("$ " + " ".join(command), flush=True)
+    subprocess.run(command, cwd=ROOT, check=True)
+
+
+def remote_flash_command(
+    args, build_dir: pathlib.Path, remote_firmware_dir: str
+) -> tuple[list[str], list[pathlib.Path]]:
+    manifest_path = build_dir / "flasher_args.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise HilError(f"cannot load flash manifest {manifest_path}: {exc}") from exc
+
+    extra = manifest.get("extra_esptool_args", {})
+    command = [
+        args.remote_esptool,
+        "--chip",
+        str(extra.get("chip", "esp32c3")),
+        "--port",
+        args.port,
+        "--baud",
+        str(args.flash_baud),
+        "--before",
+        str(extra.get("before", "default_reset")),
+        "--after",
+        str(extra.get("after", "hard_reset")),
+    ]
+    if extra.get("stub") is False:
+        command.append("--no-stub")
+    command.extend(["write_flash", *manifest.get("write_flash_args", [])])
+
+    sources = []
+    flash_files = manifest.get("flash_files")
+    if not isinstance(flash_files, dict) or not flash_files:
+        raise HilError(f"{manifest_path}: flash_files is missing or empty")
+    for offset, relative in sorted(
+        flash_files.items(), key=lambda item: int(item[0], 0)
+    ):
+        source = build_dir / relative
+        if not source.is_file():
+            raise HilError(f"flash image is missing: {source}")
+        sources.append(source)
+        command.extend(
+            [offset, posixpath.join(remote_firmware_dir, source.name)]
+        )
+    return command, sources
+
+
+def run_remote(args) -> int:
+    if not args.port:
+        raise HilError("--host requires an explicit --port on the remote machine")
+    args.transport = resolve_transport(args.target, args.transport, args.port)
+    if args.target == "panda" and args.flash and not args.allow_panda_flash:
+        raise HilError("Panda flashing requires --allow-panda-flash")
+
+    stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+    output_dir = args.output_dir or ROOT / "hil-results" / stamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    remote_root = args.remote_dir.rstrip("/")
+    if not remote_root:
+        raise HilError("--remote-dir must not be empty")
+    remote_tools = posixpath.join(remote_root, "tools")
+    remote_scenarios = posixpath.join(remote_root, "tests", "hil", "scenarios")
+    remote_firmware = posixpath.join(remote_root, "firmware")
+    remote_results = posixpath.join(remote_root, "results", stamp)
+    mkdir_command = [
+        "mkdir",
+        "-p",
+        remote_tools,
+        remote_scenarios,
+        remote_firmware,
+        remote_results,
+    ]
+    subprocess.run(
+        ["ssh", args.host, shlex.join(mkdir_command)],
+        cwd=ROOT,
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            "scp",
+            str(pathlib.Path(__file__).resolve()),
+            f"{args.host}:{remote_tools}/hil.py",
+        ],
+        cwd=ROOT,
+        check=True,
+    )
+    scenario_paths = sorted(SCENARIO_DIR.glob("*.json"))
+    if args.scenario:
+        scenario = load_scenario(args.scenario, args.target)
+        selected_path = args.scenario.resolve()
+        scenario_paths = [
+            path for path in scenario_paths if path.name != selected_path.name
+        ]
+        scenario_paths.append(selected_path)
+        if not scenario["steps"]:
+            raise HilError(f"{args.scenario}: scenario has no steps")
+    subprocess.run(
+        [
+            "scp",
+            *(str(path) for path in scenario_paths),
+            f"{args.host}:{remote_scenarios}/",
+        ],
+        cwd=ROOT,
+        check=True,
+    )
+
+    if args.flash:
+        build_dir = build_profile(args)
+        flash_command, sources = remote_flash_command(
+            args, build_dir, remote_firmware
+        )
+        subprocess.run(
+            [
+                "scp",
+                *(str(path) for path in sources),
+                f"{args.host}:{remote_firmware}/",
+            ],
+            cwd=ROOT,
+            check=True,
+        )
+        subprocess.run(
+            ["ssh", args.host, shlex.join(flash_command)],
+            cwd=ROOT,
+            check=True,
+        )
+        time.sleep(1.0)
+
+    remote_runner = [
+        args.remote_python,
+        posixpath.join(remote_tools, "hil.py"),
+        "--target",
+        args.target,
+        "--transport",
+        args.transport,
+        "--port",
+        args.port,
+        "--baud",
+        str(args.baud),
+        "--output-dir",
+        remote_results,
+    ]
+    if args.suite:
+        remote_runner.append("--suite")
+    elif args.interactive:
+        remote_runner.append("--interactive")
+    else:
+        remote_runner.extend(
+            [
+                "--scenario",
+                posixpath.join(remote_scenarios, args.scenario.name),
+            ]
+        )
+    if args.allow_heater:
+        remote_runner.append("--allow-heater")
+    if args.verbose:
+        remote_runner.append("--verbose")
+
+    result = subprocess.run(
+        ["ssh", args.host, shlex.join(remote_runner)],
+        cwd=ROOT,
+        check=False,
+    )
+    expected_results = (
+        ("serial.jsonl",) if args.interactive else ("report.json", "serial.jsonl")
+    )
+    missing_results = []
+    for name in expected_results:
+        copied = subprocess.run(
+            [
+                "scp",
+                f"{args.host}:{posixpath.join(remote_results, name)}",
+                str(output_dir / name),
+            ],
+            cwd=ROOT,
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if copied.returncode != 0:
+            missing_results.append(name)
+    if missing_results:
+        joined = ", ".join(missing_results)
+        raise HilError(f"remote run did not return expected results: {joined}")
+
+    report_path = output_dir / "report.json"
+    if report_path.is_file():
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        report["host"] = args.host
+        report["transcript"] = str(output_dir / "serial.jsonl")
+        report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(f"local results: {output_dir}", flush=True)
+    return result.returncode
+
+
+def run_scenario(
+    transport: SerialTransport,
+    scenario: dict[str, Any],
+    target: str,
+    allow_heater: bool,
+) -> dict[str, Any]:
+    variables: dict[str, Any] = {}
+    steps_report: list[dict[str, Any]] = []
+    name = scenario.get("name", "unnamed")
+    print(f"\n{name}")
+
+    for index, step in enumerate(scenario["steps"], start=1):
+        step_name = step.get("name", f"step {index}")
+        started = time.monotonic()
+        report: dict[str, Any] = {"name": step_name, "passed": False}
+        try:
+            if "wait_s" in step:
+                time.sleep(float(step["wait_s"]))
+                response: Optional[dict[str, Any]] = None
+            else:
+                command = substitute(step.get("send"), variables)
+                if not isinstance(command, dict):
+                    raise HilError("step requires send object or wait_s")
+                if target == "panda" and requests_heat(command) and not allow_heater:
+                    raise HilError(
+                        "positive-heat command refused on Panda; pass --allow-heater"
+                    )
+                response = transport.request(
+                    command, timeout_s=float(step.get("timeout_s", 4.0))
+                )
+                check_expectations(response, step.get("expect", {"ok": True}))
+                for variable, path in step.get("save", {}).items():
+                    variables[variable] = dotted_get(response, path)
+                report["response"] = response
+            report["passed"] = True
+            print(f"  PASS  {step_name}")
+        except Exception as exc:
+            report["error"] = str(exc)
+            print(f"  FAIL  {step_name}: {exc}")
+            steps_report.append(report)
+            return {"name": name, "passed": False, "steps": steps_report}
+        finally:
+            report["duration_s"] = round(time.monotonic() - started, 3)
+        steps_report.append(report)
+    return {"name": name, "passed": True, "steps": steps_report}
+
+
+def interactive(transport: SerialTransport, target: str, allow_heater: bool) -> int:
+    print("Enter one JSON command per line; Ctrl-D exits.")
+    for line in sys.stdin:
+        try:
+            command = json.loads(line)
+            if not isinstance(command, dict):
+                raise HilError("command must be a JSON object")
+            if target == "panda" and requests_heat(command) and not allow_heater:
+                raise HilError("positive heat refused; restart with --allow-heater")
+            print(json.dumps(transport.request(command), indent=2, sort_keys=True))
+        except Exception as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+    return 0
+
+
+def parse_args(argv: Optional[list[str]] = None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", help="serial device; auto-detected if exactly one")
+    parser.add_argument("--baud", type=int, default=115200, help="HIL console baud")
+    parser.add_argument("--target", choices=("devboard", "panda"), default="devboard")
+    parser.add_argument(
+        "--transport",
+        choices=("native", "uart"),
+        help="console transport; inferred from ttyACM/ttyUSB when omitted",
+    )
+    parser.add_argument("--scenario", type=pathlib.Path, help="run one scenario JSON file")
+    parser.add_argument("--suite", action="store_true", help="run all scenarios for target")
+    parser.add_argument("--interactive", action="store_true", help="read JSON commands from stdin")
+    parser.add_argument("--flash", action="store_true", help="build and flash before testing")
+    parser.add_argument("--build-dir", help="override the isolated profile build directory")
+    parser.add_argument("--idf", default="idf.py", help="ESP-IDF idf.py executable")
+    parser.add_argument("--host", help="run flash and HIL I/O on an SSH host")
+    parser.add_argument(
+        "--remote-python", default="python3", help="remote Python with pyserial"
+    )
+    parser.add_argument(
+        "--remote-esptool", default="esptool.py", help="remote esptool executable"
+    )
+    parser.add_argument(
+        "--remote-dir", default="/tmp/dragonbreath-hil", help="remote staging root"
+    )
+    parser.add_argument(
+        "--flash-baud", type=int, default=460800, help="esptool transfer baud"
+    )
+    parser.add_argument(
+        "--allow-heater",
+        action="store_true",
+        help="allow positive-target commands on a real Panda",
+    )
+    parser.add_argument(
+        "--allow-panda-flash",
+        action="store_true",
+        help="allow replacing firmware on a real Panda",
+    )
+    parser.add_argument("--output-dir", type=pathlib.Path, help="local result directory")
+    parser.add_argument("--verbose", action="store_true", help="print protocol traffic")
+    args = parser.parse_args(argv)
+    selected = sum((bool(args.scenario), args.suite, args.interactive))
+    if selected != 1:
+        parser.error("select exactly one of --scenario, --suite, or --interactive")
+    return args
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+    try:
+        if args.host:
+            return run_remote(args)
+        port = resolve_port(args.port)
+        args.transport = resolve_transport(args.target, args.transport, port)
+        if args.flash:
+            build_and_flash(args, port)
+            time.sleep(1.0)
+
+        stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+        output_dir = args.output_dir or ROOT / "hil-results" / stamp
+        output_dir.mkdir(parents=True, exist_ok=True)
+        transcript_path = output_dir / "serial.jsonl"
+        report_path = output_dir / "report.json"
+
+        with transcript_path.open("w", encoding="utf-8") as transcript:
+            transport = SerialTransport(port, args.baud, transcript, args.verbose)
+            try:
+                transport.drain(1.0)
+                if args.interactive:
+                    result = interactive(transport, args.target, args.allow_heater)
+                    print(f"serial: {transcript_path}")
+                    return result
+
+                scenarios = (
+                    load_suite_scenarios(args.target)
+                    if args.suite
+                    else [(args.scenario, load_scenario(args.scenario, args.target))]
+                )
+                results = []
+                for _, scenario in scenarios:
+                    results.append(
+                        run_scenario(
+                            transport, scenario, args.target, args.allow_heater
+                        )
+                    )
+                    if not results[-1]["passed"]:
+                        break
+            finally:
+                transport.close()
+
+        report = {
+            "target": args.target,
+            "transport": args.transport,
+            "port": port,
+            "passed": bool(results) and all(item["passed"] for item in results),
+            "scenarios": results,
+            "transcript": str(transcript_path),
+        }
+        report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+        print(f"\n{'PASS' if report['passed'] else 'FAIL'}")
+        print(f"report: {report_path}")
+        print(f"serial: {transcript_path}")
+        return 0 if report["passed"] else 1
+    except (HilError, OSError, subprocess.CalledProcessError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a line-delimited JSON HIL console for scripted and interactive serial control
- add ESP32-C3 devboard profiles for native USB and CH341-style UART bridges, plus a real-Panda UART profile
- compile Panda relay, fan/ZCD, ADC, board LED, and strap GPIO access out of the devboard target
- add injectable chamber/PTC sensors, printer environment state, and zero-cross events with authoritative state snapshots
- add local and SSH device-host orchestration for build, manifest-driven transfer/flash, scenario execution, console capture, and result retrieval
- add AUTO, ownership/fault, and real-Panda smoke scenarios, CI builds, compile-out audits, and a complete HIL lab runbook

## Why

Phase E calls for a devboard target that is structurally unable to energize Panda mains hardware and a shared harness that can exercise either that target or a real Breath unit through scripted or interactive serial input.

This keeps the production policy state machine as the system under test while replacing only the physical Panda backends in the devboard profile. The same runner can operate locally or build on a workstation and execute beside a remotely attached serial device over SSH.

## Safety model

The devboard profile compiles out relay, fan gate, zero-cross GPIO, ADC, Panda LED, and board-strap access. Logical actuator and LED state remains observable for assertions.

Real-Panda runs retain active hardware. The runner separately requires:

- `--allow-panda-flash` before replacing real-unit firmware
- `--allow-heater` before positive-target commands

The Panda HIL profile explicitly disables `CONFIG_PB_POWER_LED` because GPIO21 is UART0 TX.

## Hardware qualification

The complete devboard suite passed on a dual-USB-C ESP32-C3 board through its CH341-family UART bridge:

- 2 scenarios
- 34 steps / 28 serial requests
- AUTO threshold and disconnect fail-closed behavior
- lease issuance, heartbeat, and stale-lease rejection
- chamber open-circuit fault and explicit recovery
- fixed PTC over-temperature cutoff
- zero-cross injection
- `mains_gpio_compiled_out: true` throughout

The SSH workflow was validated both against an existing image and end to end through local build, manifest-driven transfer, remote flash, reset, suite execution, and automatic retrieval of `report.json` and `serial.jsonl`.

The non-heating real-Panda smoke scenario also passed on physical hardware through the on-board QinHeng `1a86:7522` UART bridge:

- ESP-IDF 5.3.1 Panda build, manifest transfer, guarded remote flash, reset, scenario run, and artifact retrieval: PASS
- already-flashed attach/run/artifact retrieval path: PASS
- real chamber/PTC readings and live zero-cross counts observed
- `target: "panda"` and `mains_gpio_compiled_out: false` confirmed
- both runs finished in OFF with heater demand and output false
- no positive heat command was authorized or sent

A complete 4 MiB flash backup was captured and verified before flashing. The Panda build used UART0 with `CONFIG_PB_POWER_LED` disabled, and the runner released the serial port after each test.

The native-USB profile builds, flashes, and passes compile-out validation, but the tested devboard's application-side native USB serial endpoint did not respond during qualification and remains open for diagnosis.

## Documentation

`docs/HIL.md` covers:

- safety boundaries and target profiles
- local and generic Linux SSH device-host operation
- ESP-IDF build isolation
- real-Panda safeguards and physical qualification evidence
- scenario schema, variables, and assertion operators
- serial protocol and state snapshots
- reports and transcripts
- CI coverage
- USB, permissions, bootloader, transport, and configuration troubleshooting

## Validation

- `sh tests/run_policy_host_test.sh`
- `sh tests/check_api_v2_contract.sh`
- `node tests/check_dashboard_js.mjs`
- `python -m unittest discover -s tests -p test_hil_runner.py` (11 tests)
- `python -m py_compile tools/hil.py tests/test_hil_runner.py`
- `sh tests/check_hil_compileout.sh build-hil-devboard`
- `sh tests/check_hil_compileout.sh build-hil-devboard-uart`
- compile-out audit missing-tool failure path
- ESP-IDF 5.3.1 builds: normal firmware, native-USB devboard HIL, UART devboard HIL, and UART Panda HIL
- live UART devboard HIL suite: PASS
- remote no-flash suite and full remote build/flash/suite/result retrieval: PASS
- real-Panda guarded build/flash/non-heating smoke/result retrieval: PASS
- real-Panda already-flashed non-heating smoke/result retrieval: PASS
