### PR TITLE
feat(leds): drive all four panel LEDs from policy mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+### Added
+- **Serial hardware-in-the-loop harness (`pb_hil` / `tools/hil.py`).** A
+  line-delimited JSON console for injecting chamber/PTC readings, sensor faults,
+  printer environment, and zero-cross events, and for reading back heater demand,
+  fan state, LEDs, mode, lease, and fault state. Ships with an isolated ESP32-C3
+  dev-board target whose mains GPIO is **compiled out**, so it is structurally
+  incapable of energizing Panda hardware, plus scripted scenarios, console
+  capture, and JSON pass/fail reports. A non-heating UART profile for the real
+  Panda is documented as the pre-release qualification gate. (#14)
+- **OEM parity matrix (`docs/OEM_PARITY.md`).** Tracks every user-visible stock
+  Panda Breath behavior as implemented, partial, planned, intentionally changed,
+  intentionally omitted, or unverified — so deliberate deviations are
+  distinguishable from gaps. (#12)
+
+### Changed
+- **Front-panel LEDs now show the active mode.** All four outputs are driven from
+  the authoritative policy snapshot instead of Power and On duplicating a single
+  "heating" signal: Power is solid whenever the device is up and blinks on fault,
+  while On, Auto, and Dry each light for their own mode. Auto slow-blinks when
+  armed but not engaged (no Moonraker link, or bed below the threshold), so the
+  panel distinguishes "waiting" from "heating". Power remains release-only —
+  GPIO21 is also the serial console TX.
+
+### Fixed
+- **Automatic and drying controls work from the dashboard.** v0.3.0 shipped both
+  modes in the state machine and API but the UI could not reliably drive them.
+  The cards now submit correctly, their input bounds match the policy's own
+  limits, and automatic status refreshes from live state rather than the value
+  last typed. (#13)
+- **`docs/HARDWARE.md` GPIO map corrected.** It still described buttons on GPIO7
+  and GPIO0 — those are the zero-cross detector and the chamber NTC. The table now
+  matches the bench-probed map already in `pb_board.h` (buttons on 9/8/10/2, Power
+  LED on 21) and documents the strapping-pin caveat.
+
 ## [0.3.0] - 2026-07-23
 
 Iteration-2 core: an authoritative device-side control state machine, a

--- a/components/pb_leds/Kconfig
+++ b/components/pb_leds/Kconfig
@@ -5,9 +5,10 @@ config PB_POWER_LED
     default n
     help
       The front-panel "Power" LED is wired to GPIO21, which is also the UART0
-      console TX pin. Enable this to drive it as the heating indicator (matching
-      the stock firmware: on while heating). Doing so gives up runtime serial log
-      output on TX (USB flashing still works — that uses the ROM bootloader).
+      console TX pin. Enable this to drive it as the device-health indicator:
+      solid while healthy and blinking on a fault. Doing so gives up runtime
+      serial log output on TX (USB flashing still works — that uses the ROM
+      bootloader).
 
       Leave DISABLED for development builds that need the serial console; enable
       it for release builds. The release CI pipeline sets it via sdkconfig.release.

--- a/components/pb_leds/include/pb_leds.h
+++ b/components/pb_leds/include/pb_leds.h
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
-// pb_leds — the three button-indicator LEDs (K1/K2/K3, active-high via 1K on
-// GPIO6/5/4). One 50 ms-tick task drives all three from an atomic per-LED
-// pattern, so any task can set a pattern without touching GPIO or blocking.
-// pb_heater no longer drives any LED; pb_policy owns the indication.
+// pb_leds — the four button-indicator LEDs (active-high via 1K on GPIO6/5/4,
+// plus Power on GPIO21). One 50 ms-tick task drives them all from an atomic
+// per-LED pattern, so any task can set a pattern without touching GPIO or
+// blocking. pb_heater no longer drives any LED; pb_policy owns the indication:
+// Power = device alive (blink on fault), On/Auto/Dry = the active mode.
 #pragma once
 
 #include <stdint.h>
@@ -34,7 +35,7 @@ typedef enum {
     PB_LED_CODE,         // N short pulses, gap, repeat (count via pb_leds_set_code)
 } pb_led_pattern_t;
 
-// Configure the 3 LED GPIOs (driven low) and start the driver task. Idempotent-
+// Configure the LED GPIOs (driven low) and start the driver task. Idempotent-
 // guarded: a second call returns ESP_ERR_INVALID_STATE.
 esp_err_t pb_leds_start(void);
 

--- a/components/pb_policy/pb_policy.c
+++ b/components/pb_policy/pb_policy.c
@@ -449,13 +449,21 @@ void pb_policy_tick(void)
     if (want_airflow && fan < 30) fan = 30;
     pb_fan_set_level(fan);
 
-    // Preserve Phase A's panel semantics through the state-machine rewrite.
-    // The Power LED is release-only because GPIO21 is also console TX; the On
-    // LED mirrors it until the later mode/button work owns Auto/On/Dry.
-    pb_led_pattern_t heat_pat =
-        faulted ? PB_LED_BLINK : heat ? PB_LED_SOLID : PB_LED_OFF;
-    pb_leds_set(PB_LED_POWER, heat_pat);
-    pb_leds_set(PB_LED_ON, heat_pat);
+    // Front-panel indication. Power is the "device alive / something's wrong"
+    // light; On/Auto/Dry each carry their own mode, so the panel alone tells you
+    // which mode is active. `faulted` is pb_heater_is_faulted(), which already
+    // covers a permanent inhibit as well as a latched trip. A fault forces
+    // mode=OFF above, so the mode LEDs go dark on their own.
+    // Power is release-only: GPIO21 is also the console TX pin (CONFIG_PB_POWER_LED).
+    pb_leds_set(PB_LED_POWER, faulted ? PB_LED_BLINK : PB_LED_SOLID);
+    pb_leds_set(PB_LED_ON, s.mode == PB_MODE_POWER_ON ? PB_LED_SOLID : PB_LED_OFF);
+    // AUTO distinguishes armed-but-waiting (no Moonraker link, or bed below the
+    // threshold) from actually driving heat — the most useful thing the panel says.
+    pb_leds_set(PB_LED_AUTO,
+                s.mode != PB_MODE_AUTO  ? PB_LED_OFF
+                : s.auto_engaged        ? PB_LED_SOLID
+                                        : PB_LED_BLINK_SLOW);
+    pb_leds_set(PB_LED_DRY, s.mode == PB_MODE_DRYING ? PB_LED_SOLID : PB_LED_OFF);
 
     if (local_limit_expired)
         ESP_LOGW(TAG, "local POWER_ON limit expired; mode set OFF");

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -21,16 +21,30 @@ schematic, and the stock firmware.
 |---|---|---|
 | Heater SSR (RLY_MOSFET) | 18 | INFERRED (pad 26) |
 | Fan TRIAC gate | 3 | CONFIRMED (IO03) |
-| Zero-cross detect | 7 | CONFIRMED (IO07; shared w/ K1 btn) |
-| Chamber NTC (TH0) | 0 / ADC1_CH0 | INFERRED (pad 12; shared w/ K2 btn) |
+| Zero-cross detect | 7 | CONFIRMED (IO07) |
+| Chamber NTC (TH0) | 0 / ADC1_CH0 | INFERRED (pad 12) |
 | PTC element NTC (TH1) | 1 / ADC1_CH1 | INFERRED (pad 13) |
 | Rref divider strap | 19 | reads 82 vs 33 kΩ series resistor |
-| Button LEDs K1/K2/K3 | 6 / 5 / 4 | CONFIRMED |
-| Buttons K2/K3 | 0 / 2 | (not implemented) |
+| Mode LEDs Auto / On / Dry | 6 / 5 / 4 | CONFIRMED |
+| Power LED | 21 | CONFIRMED (shared w/ UART0-TX; needs `CONFIG_PB_POWER_LED`) |
+| Buttons Power / Auto / On / Dry | 9 / 8 / 10 / 2 | CONFIRMED (bench-probed active-low) |
 | Console UART0 TX/RX | 21 / 20 | CONFIRMED |
 
 > **Continuity-test the INFERRED pins before the first flash.** A wrong heater or
 > TRIAC pin is a safety issue.
+
+> ⚠️ **Do not hold a front-panel button while powering the board on.** GPIO9
+> (Power) is the ROM download-mode strap, and GPIO8 (Auto) and GPIO2 (Dry) are
+> also strapping pins that must read HIGH at reset. GPIO10 (On) is the only
+> button on a non-strapping pin. Buttons are active-low with internal pull-ups,
+> so a held button pulls its strap low at reset and the board will not boot
+> normally.
+
+An earlier revision of this table claimed buttons were on GPIO7 and GPIO0,
+shared with the zero-cross detector and the chamber NTC. That was **wrong** —
+a live bench probe (2026-07-23) placed all four buttons on their own unshared
+pins. Each button is co-located with the LED of the same panel label (e.g. Auto
+= button GPIO8 / LED GPIO6).
 
 ## Flashing path
 The ESP32-C3's *native* USB-Serial-JTAG is on GPIO18/19; GPIO18 drives the heater

--- a/docs/OEM_PARITY.md
+++ b/docs/OEM_PARITY.md
@@ -15,7 +15,7 @@ Current as of **v0.3.0**.
 | Sensor-fault and over-temperature shutdown | **Implemented** | Heater fails closed; fixed 85 °C chamber and 105 °C PTC cutoffs are not user-configurable. |
 | Fan follows heater | **Implemented** | TRIAC is held on/off and never phase-angle PWM'd. |
 | Residual-heat fan purge | **Partial** | Current cooldown is session-gated. A persisted, opt-in temperature-latched policy is planned; the default will remain session-gated so a warm idle chamber does not start the fan unexpectedly. Fault airflow remains unconditional. |
-| Front-panel mode LEDs | **Partial** | The four-output pattern driver is implemented. On, plus release-only Power, are solid while a heat target is armed and blink on fault. Auto/Dry are initialized off but receive no policy updates yet. |
+| Front-panel mode LEDs | **Implemented** | All four outputs are driven from the authoritative policy snapshot: Power is solid whenever the device is up and blinks on fault; On, Auto, and Dry each light for their own mode. Auto slow-blinks when armed but not engaged (no Moonraker link, or bed below the threshold). Power is release-only — GPIO21 is also the serial console TX. |
 | Front-panel buttons | **Planned (mapped only)** | Power GPIO9, Auto GPIO8, On GPIO10, and Dry GPIO2 were live-probed active-low. No GPIO setup, polling, debounce, event handling, or actions exist today; presses do nothing until Phase C. |
 | Local status/configuration UI | **Implemented** | Responsive work continues, but manual, automatic, drying, safety settings, setup, and OTA controls are present. |
 | Wi-Fi captive setup and mDNS | **Implemented** | Product identity is DragonBreath; reachable as `dragonbreath.local` when mDNS works. |

--- a/sdkconfig.release
+++ b/sdkconfig.release
@@ -1,5 +1,5 @@
 # Release-only overlay (layered on top of sdkconfig.defaults by the CI build).
-# Drive the front-panel Power LED on GPIO21 (heating indicator, stock parity).
+# Drive the front-panel Power LED on GPIO21 (solid healthy, blinking on fault).
 # This repurposes the UART0 console TX pin, so release builds have no runtime
 # serial log output — intentional. Dev builds (plain `idf.py build`) omit this
 # file and keep the console.

--- a/tests/pb_policy_host_test.c
+++ b/tests/pb_policy_host_test.c
@@ -324,7 +324,7 @@ static void test_external_fault_sync_off_and_clear(void)
     CHECK(strcmp(snap.fault_reason, "external trip") == 0);
     CHECK(!snap.lease_active);
     CHECK(led_pattern[PB_LED_POWER] == PB_LED_BLINK);
-    CHECK(led_pattern[PB_LED_ON] == PB_LED_BLINK);
+    CHECK(led_pattern[PB_LED_ON] == PB_LED_OFF);   // fault forced mode OFF
 
     // OFF is unconditional even while the underlying safety fault remains latched.
     pb_policy_set_mode_off(PB_SOURCE_WEB);
@@ -343,6 +343,61 @@ static void test_external_fault_sync_off_and_clear(void)
     CHECK(snap.source == PB_SOURCE_WEB);
     CHECK(!snap.fault_latched);
     CHECK(snap.effective_target_c == 0.0f);
+}
+
+// Power = device alive (blink on fault); On/Auto/Dry each carry their own mode,
+// with Auto distinguishing armed-but-waiting from actually engaged.
+static void test_panel_leds_track_mode(void)
+{
+    reset_fixture();
+    pb_policy_tick();
+    CHECK(led_pattern[PB_LED_POWER] == PB_LED_SOLID);
+    CHECK(led_pattern[PB_LED_ON] == PB_LED_OFF);
+    CHECK(led_pattern[PB_LED_AUTO] == PB_LED_OFF);
+    CHECK(led_pattern[PB_LED_DRY] == PB_LED_OFF);
+
+    CHECK(pb_policy_set_power_on(
+        45.0f, PB_SOURCE_WEB, "tab", 1, NULL) == PB_POLICY_OK);
+    pb_policy_tick();
+    CHECK(led_pattern[PB_LED_ON] == PB_LED_SOLID);
+    CHECK(led_pattern[PB_LED_AUTO] == PB_LED_OFF);
+    CHECK(led_pattern[PB_LED_DRY] == PB_LED_OFF);
+
+    // AUTO armed but not engaged (no printer link) -> slow blink, not solid.
+    pb_policy_set_mode_off(PB_SOURCE_WEB);
+    CHECK(pb_policy_set_auto(
+        60.0f, 100.0f, PB_SOURCE_WEB, PB_POLICY_REVISION_ANY) == PB_POLICY_OK);
+    pb_policy_set_env(20.0f, false);
+    pb_policy_tick();
+    CHECK(led_pattern[PB_LED_AUTO] == PB_LED_BLINK_SLOW);
+    CHECK(led_pattern[PB_LED_ON] == PB_LED_OFF);
+
+    pb_policy_set_env(105.0f, true);
+    pb_policy_tick();
+    CHECK(snapshot().auto_engaged);
+    CHECK(led_pattern[PB_LED_AUTO] == PB_LED_SOLID);
+
+    pb_policy_set_mode_off(PB_SOURCE_WEB);
+    CHECK(pb_policy_start_drying(
+        55.0f, 2, PB_SOURCE_WEB, PB_POLICY_REVISION_ANY) == PB_POLICY_OK);
+    pb_policy_tick();
+    CHECK(led_pattern[PB_LED_DRY] == PB_LED_SOLID);
+    CHECK(led_pattern[PB_LED_AUTO] == PB_LED_OFF);
+    CHECK(led_pattern[PB_LED_POWER] == PB_LED_SOLID);
+
+    // A fault forces mode OFF, so every mode LED goes dark and Power blinks.
+    pb_heater_emergency_off("test trip");
+    pb_policy_tick();
+    CHECK(led_pattern[PB_LED_POWER] == PB_LED_BLINK);
+    CHECK(led_pattern[PB_LED_ON] == PB_LED_OFF);
+    CHECK(led_pattern[PB_LED_AUTO] == PB_LED_OFF);
+    CHECK(led_pattern[PB_LED_DRY] == PB_LED_OFF);
+
+    // A permanent inhibit reports as a fault too, so Power must keep blinking.
+    heater_fault = false;
+    heater_inhibited = true;
+    pb_policy_tick();
+    CHECK(led_pattern[PB_LED_POWER] == PB_LED_BLINK);
 }
 
 static void test_fault_clear_requires_current_revision(void)
@@ -371,6 +426,7 @@ int main(void)
     test_local_power_limit_expires_off_without_fault();
     test_external_fault_sync_off_and_clear();
     test_fault_clear_requires_current_revision();
+    test_panel_leds_track_mode();
     puts("pb_policy host tests: PASS");
     return 0;
 }


### PR DESCRIPTION
First of three stacked PRs closing out Phase C (front panel). This one is LEDs
only — no button code, no NVS.

## Problem

`pb_policy_tick()` drove **Power and On to the identical pattern** (`fault→BLINK,
heat→SOLID, else OFF`) and never touched Auto or Dry. Two of four LEDs were dead
and the panel could not distinguish manual / auto / drying.

## Change

All four outputs are now driven from the authoritative snapshot:

| LED | Pattern |
|---|---|
| Power (GPIO21, release-only) | `BLINK` on fault, else `SOLID` |
| On (GPIO5) | `SOLID` in POWER_ON |
| Auto (GPIO6) | `SOLID` when engaged, `BLINK_SLOW` when armed but waiting |
| Dry (GPIO4) | `SOLID` while drying |

Power becomes the "device alive / something's wrong" light now that On/Auto/Dry
each carry their own mode. `faulted` is `pb_heater_is_faulted()`, which already
reports a permanent inhibit as well as a latched trip, so no extra call is
needed. A fault forces `mode = OFF` in the same tick, so the mode LEDs go dark on
their own.

Auto's armed-vs-engaged distinction is the state the panel previously could not
express at all: AUTO selected but no Moonraker link, or bed below the threshold.

## Also in here

`docs/HARDWARE.md` still claimed buttons on GPIO7 and GPIO0 — those are the
zero-cross detector and the chamber NTC. `pb_board.h` was corrected in `e6bea23`
after the 2026-07-23 bench probe, but the hardware doc, which is the page someone
reads *before flashing*, was not. The table now matches reality (buttons on
9/8/10/2, Power LED on 21) and documents the strapping-pin caveat.

Changelog also backfills #12, #13, and #14, which merged without an Unreleased
entry. Bench review also corrected stale Kconfig/release-overlay text that still
described Power as a heating indicator.

## Verification

- [x] `tests/run_policy_host_test.sh` — new `test_panel_leds_track_mode` covers
      every mode, the armed-vs-engaged split, fault, and permanent inhibit. The
      pre-existing fault test asserted the old `On == BLINK` semantics and is
      updated to `OFF`.
- [x] `tests/check_api_v2_contract.sh`, `tests/check_dashboard_js.mjs`
- [x] ESP-IDF 5.3.1 Panda HIL and release builds clean

Bench validation was split because the Panda HIL profile leaves GPIO21 assigned
to console TX:

- [x] **UART HIL build** — physical On solid, Auto slow-blink, and Dry/blue solid
      were observed on a real Panda. HIL state reported the matching patterns and
      logical Power solid. Each active mode used a 30 °C target below the
      32.1–32.2 °C chamber temperature; `heater.output` remained false throughout,
      live sensor/ZCD telemetry remained healthy, and the script finished OFF.
- [x] **Release build** (`CONFIG_PB_POWER_LED=y`) — API state and webcam frames
      jointly verified physical Power solid while healthy. POWER_ON at 30 °C
      showed red Power + amber On with heater output false. Withholding heartbeat
      produced the expected 60 s watchdog transition to mode OFF, source
      `watchdog`, `controller lease expired`, On dark, and physical Power blinking.
      A 16-frame sequence captured the blink cadence. Clearing the recoverable
      fault returned Power to continuously solid across eight frames and left the
      unit healthy, fan stopped, and heater OFF.
