### PR TITLE
fix(policy): tighten button feedback and target bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+### Fixed
+- **Prompt control feedback across every command source.** Accepted front-panel,
+  Web UI, Klipper, and HIL mode commands now wake the full control task
+  immediately instead of waiting up to 500 ms for the periodic tick, so panel
+  LEDs and outputs track authoritative state promptly. Rejected button commands
+  now log the actual policy result, and remembered mode targets are clamped to
+  the runtime-configured heater maximum as soon as they load from NVS.
+
 ## [0.4.0] - 2026-07-24
 
 Phase C — the physical front panel comes alive. All four buttons and all four

--- a/components/pb_policy/include/pb_policy.h
+++ b/components/pb_policy/include/pb_policy.h
@@ -55,7 +55,8 @@ typedef struct {
 // caller does not supply its own (front-panel buttons) and the values the UI
 // pre-fills from.  These are the ONLY policy state that survives a reboot --
 // never a mode, target, deadline, heating flag, or lease.  See
-// pb_policy_load_params().
+// pb_policy_load_params(). Target parameters are clamped to the heater's live
+// runtime-configured maximum when loaded.
 typedef struct {
     float manual_target_c;        // last accepted POWER_ON target
     float auto_target_c;          // last accepted AUTO target
@@ -181,9 +182,9 @@ void pb_policy_on_button(pb_button_id_t id, pb_button_event_t ev);
 // drops the SSR without waiting for the next periodic tick.
 void pb_policy_request_panic_off(pb_source_t source, const char *reason);
 
-// Callback invoked (outside any policy lock) whenever the policy needs the
-// control task to run a tick promptly -- currently only after a panic-off.  Keep
-// it ISR-light: a single task notification.  Optional; if unset, the change is
+// Callback invoked (outside any policy lock) whenever an accepted panel action
+// or safety transition needs the control task to run a tick promptly. Keep it
+// ISR-light: a single task notification. Optional; if unset, the change is
 // picked up on the next periodic tick.
 typedef void (*pb_policy_wake_fn)(void);
 void pb_policy_set_wake_cb(pb_policy_wake_fn fn);

--- a/components/pb_policy/include/pb_policy.h
+++ b/components/pb_policy/include/pb_policy.h
@@ -182,10 +182,10 @@ void pb_policy_on_button(pb_button_id_t id, pb_button_event_t ev);
 // drops the SSR without waiting for the next periodic tick.
 void pb_policy_request_panic_off(pb_source_t source, const char *reason);
 
-// Callback invoked (outside any policy lock) whenever an accepted panel action
-// or safety transition needs the control task to run a tick promptly. Keep it
-// ISR-light: a single task notification. Optional; if unset, the change is
-// picked up on the next periodic tick.
+// Callback invoked (outside any policy lock) whenever an accepted control
+// command or safety transition needs the control task to run a tick promptly.
+// Keep it ISR-light: a single task notification. Optional; if unset, the change
+// is picked up on the next periodic tick.
 typedef void (*pb_policy_wake_fn)(void);
 void pb_policy_set_wake_cb(pb_policy_wake_fn fn);
 

--- a/components/pb_policy/pb_policy.c
+++ b/components/pb_policy/pb_policy.c
@@ -85,6 +85,11 @@ static pb_policy_wake_fn s_wake_cb;
 
 void pb_policy_set_wake_cb(pb_policy_wake_fn fn) { s_wake_cb = fn; }
 
+static void wake_control_task(void)
+{
+    if (s_wake_cb) s_wake_cb();
+}
+
 static bool source_is_remote(pb_source_t source)
 {
     return source == PB_SOURCE_WEB || source == PB_SOURCE_KLIPPER;
@@ -178,24 +183,31 @@ static float centi_to_c(uint32_t centi) { return (float)centi / 100.0f; }
 // to the default defensively.
 static float clamp_or_default(float v, float lo, float hi, float dflt)
 {
-    if (!isfinite(v)) return dflt;
+    if (!isfinite(v)) v = dflt;
     return v < lo ? lo : (v > hi ? hi : v);
 }
 
 static void params_clamp(pb_policy_params_t *p)
 {
+    // pb_heater_load_config() runs before pb_policy_load_params(), so use the
+    // live configured ceiling here. This keeps remembered/UI-prefill values
+    // inside a user-lowered maximum immediately after boot, not merely when a
+    // later command is submitted.
+    float max_target_c = clamp_or_default(
+        pb_heater_get_max_target_c(), PB_MIN_MODE_TARGET_C,
+        PB_HEATER_ABS_MAX_TARGET_C, PB_HEATER_ABS_MAX_TARGET_C);
     p->manual_target_c = clamp_or_default(
         p->manual_target_c, PB_MIN_MODE_TARGET_C,
-        PB_HEATER_ABS_MAX_TARGET_C, PB_DEFAULT_MANUAL_TARGET_C);
+        max_target_c, PB_DEFAULT_MANUAL_TARGET_C);
     p->auto_target_c = clamp_or_default(
         p->auto_target_c, PB_MIN_MODE_TARGET_C,
-        PB_HEATER_ABS_MAX_TARGET_C, PB_DEFAULT_AUTO_TARGET_C);
+        max_target_c, PB_DEFAULT_AUTO_TARGET_C);
     p->auto_bed_threshold_c = clamp_or_default(
         p->auto_bed_threshold_c, PB_AUTO_BED_MIN_C,
         PB_AUTO_BED_MAX_C, PB_DEFAULT_AUTO_BED_C);
     p->dry_target_c = clamp_or_default(
         p->dry_target_c, PB_MIN_MODE_TARGET_C,
-        PB_HEATER_ABS_MAX_TARGET_C, PB_DEFAULT_DRY_TARGET_C);
+        max_target_c, PB_DEFAULT_DRY_TARGET_C);
     if (p->dry_hours == 0 || p->dry_hours > PB_DRYING_MAX_HOURS)
         p->dry_hours = PB_DEFAULT_DRY_HOURS;
 }
@@ -580,7 +592,7 @@ void pb_policy_request_panic_off(pb_source_t source, const char *reason)
 
     // Drop the SSR now rather than on the next periodic tick: the control task
     // runs the full safety tick immediately on this notification.
-    if (s_wake_cb) s_wake_cb();
+    wake_control_task();
     // Keep logging after the wake: diagnostic I/O must never consume the
     // panic-off latency budget.
     ESP_LOGW(TAG, "panic-off requested: %s", reason ? reason : "(unspecified)");
@@ -600,29 +612,29 @@ static const char *button_str(pb_button_id_t id)
 // Toggle a mode: if already in `target_mode`, go OFF; otherwise arm it from the
 // remembered parameters. Runs the setter WITHOUT the policy lock (setters take
 // it themselves); source=BUTTON, revision-any (a physical actor always wins).
-static void button_toggle_mode(pb_mode_t target_mode)
+static pb_policy_result_t button_toggle_mode(pb_mode_t target_mode)
 {
     if (pb_policy_get_mode() == target_mode) {
         pb_policy_set_mode_off(PB_SOURCE_BUTTON);
-        return;
+        return PB_POLICY_OK;
     }
     pb_policy_params_t p;
     pb_policy_get_params(&p);
     switch (target_mode) {
         case PB_MODE_POWER_ON:
-            pb_policy_set_power_on(p.manual_target_c, PB_SOURCE_BUTTON,
-                                   "button", PB_POLICY_REVISION_ANY, NULL);
-            break;
+            return pb_policy_set_power_on(
+                p.manual_target_c, PB_SOURCE_BUTTON,
+                "button", PB_POLICY_REVISION_ANY, NULL);
         case PB_MODE_AUTO:
-            pb_policy_set_auto(p.auto_target_c, p.auto_bed_threshold_c,
-                               PB_SOURCE_BUTTON, PB_POLICY_REVISION_ANY);
-            break;
+            return pb_policy_set_auto(
+                p.auto_target_c, p.auto_bed_threshold_c,
+                PB_SOURCE_BUTTON, PB_POLICY_REVISION_ANY);
         case PB_MODE_DRYING:
-            pb_policy_start_drying(p.dry_target_c, p.dry_hours,
-                                   PB_SOURCE_BUTTON, PB_POLICY_REVISION_ANY);
-            break;
+            return pb_policy_start_drying(
+                p.dry_target_c, p.dry_hours,
+                PB_SOURCE_BUTTON, PB_POLICY_REVISION_ANY);
         default:
-            break;
+            return PB_POLICY_INVALID;
     }
 }
 
@@ -637,6 +649,7 @@ void pb_policy_on_button(pb_button_id_t id, pb_button_event_t ev)
             // A physical actor always wins, so revision-any is correct here.
             pb_policy_result_t r =
                 pb_policy_clear_fault(PB_SOURCE_BUTTON, PB_POLICY_REVISION_ANY);
+            if (r == PB_POLICY_OK) wake_control_task();
             pv_evlog_add("btn: power long -> clear fault (%s)",
                          pb_policy_result_str(r));
             return;
@@ -649,18 +662,40 @@ void pb_policy_on_button(pb_button_id_t id, pb_button_event_t ev)
     }
 
     // SHORT press.
+    pb_policy_result_t r;
     switch (id) {
         case PB_BUTTON_ON:
-            button_toggle_mode(PB_MODE_POWER_ON);
-            pv_evlog_add("btn: on -> %s", pb_policy_mode_str(pb_policy_get_mode()));
+            r = button_toggle_mode(PB_MODE_POWER_ON);
+            if (r == PB_POLICY_OK) {
+                wake_control_task();
+                pv_evlog_add("btn: on -> %s",
+                             pb_policy_mode_str(pb_policy_get_mode()));
+            } else {
+                pv_evlog_add("btn: on rejected (%s)",
+                             pb_policy_result_str(r));
+            }
             break;
         case PB_BUTTON_AUTO:
-            button_toggle_mode(PB_MODE_AUTO);
-            pv_evlog_add("btn: auto -> %s", pb_policy_mode_str(pb_policy_get_mode()));
+            r = button_toggle_mode(PB_MODE_AUTO);
+            if (r == PB_POLICY_OK) {
+                wake_control_task();
+                pv_evlog_add("btn: auto -> %s",
+                             pb_policy_mode_str(pb_policy_get_mode()));
+            } else {
+                pv_evlog_add("btn: auto rejected (%s)",
+                             pb_policy_result_str(r));
+            }
             break;
         case PB_BUTTON_DRY:
-            button_toggle_mode(PB_MODE_DRYING);
-            pv_evlog_add("btn: dry -> %s", pb_policy_mode_str(pb_policy_get_mode()));
+            r = button_toggle_mode(PB_MODE_DRYING);
+            if (r == PB_POLICY_OK) {
+                wake_control_task();
+                pv_evlog_add("btn: dry -> %s",
+                             pb_policy_mode_str(pb_policy_get_mode()));
+            } else {
+                pv_evlog_add("btn: dry rejected (%s)",
+                             pb_policy_result_str(r));
+            }
             break;
         case PB_BUTTON_POWER:
             // Master OFF. Already-off is a deliberate no-op: log it but do not
@@ -669,6 +704,7 @@ void pb_policy_on_button(pb_button_id_t id, pb_button_event_t ev)
                 pv_evlog_add("btn: power (already off)");
             } else {
                 pb_policy_set_mode_off(PB_SOURCE_BUTTON);
+                wake_control_task();
                 pv_evlog_add("btn: power -> off");
             }
             break;

--- a/components/pb_policy/pb_policy.c
+++ b/components/pb_policy/pb_policy.c
@@ -429,6 +429,7 @@ pb_policy_result_t pb_policy_set_power_on(
     s.params.manual_target_c = s.requested_target_c;   // post-clamp
     s.params_dirty = true;
     xSemaphoreGive(s_lock);
+    wake_control_task();
     params_notify();
     return PB_POLICY_OK;
 }
@@ -464,6 +465,7 @@ pb_policy_result_t pb_policy_set_auto(
     s.params.auto_bed_threshold_c = bed_threshold_c;
     s.params_dirty = true;
     xSemaphoreGive(s_lock);
+    wake_control_task();
     params_notify();
     return PB_POLICY_OK;
 }
@@ -502,6 +504,7 @@ pb_policy_result_t pb_policy_start_drying(
     s.params.dry_hours = hours;
     s.params_dirty = true;
     xSemaphoreGive(s_lock);
+    wake_control_task();
     params_notify();
     return PB_POLICY_OK;
 }
@@ -512,6 +515,7 @@ void pb_policy_set_mode_off(pb_source_t source)
     xSemaphoreTake(s_lock, portMAX_DELAY);
     set_off_locked(source);
     xSemaphoreGive(s_lock);
+    wake_control_task();
 }
 
 void pb_policy_stop_drying(pb_source_t source)
@@ -567,6 +571,7 @@ pb_policy_result_t pb_policy_clear_fault(
     s.last_faulted = false;
     set_off_locked(source);
     xSemaphoreGive(s_lock);
+    wake_control_task();
     return PB_POLICY_OK;
 }
 
@@ -649,7 +654,6 @@ void pb_policy_on_button(pb_button_id_t id, pb_button_event_t ev)
             // A physical actor always wins, so revision-any is correct here.
             pb_policy_result_t r =
                 pb_policy_clear_fault(PB_SOURCE_BUTTON, PB_POLICY_REVISION_ANY);
-            if (r == PB_POLICY_OK) wake_control_task();
             pv_evlog_add("btn: power long -> clear fault (%s)",
                          pb_policy_result_str(r));
             return;
@@ -667,7 +671,6 @@ void pb_policy_on_button(pb_button_id_t id, pb_button_event_t ev)
         case PB_BUTTON_ON:
             r = button_toggle_mode(PB_MODE_POWER_ON);
             if (r == PB_POLICY_OK) {
-                wake_control_task();
                 pv_evlog_add("btn: on -> %s",
                              pb_policy_mode_str(pb_policy_get_mode()));
             } else {
@@ -678,7 +681,6 @@ void pb_policy_on_button(pb_button_id_t id, pb_button_event_t ev)
         case PB_BUTTON_AUTO:
             r = button_toggle_mode(PB_MODE_AUTO);
             if (r == PB_POLICY_OK) {
-                wake_control_task();
                 pv_evlog_add("btn: auto -> %s",
                              pb_policy_mode_str(pb_policy_get_mode()));
             } else {
@@ -689,7 +691,6 @@ void pb_policy_on_button(pb_button_id_t id, pb_button_event_t ev)
         case PB_BUTTON_DRY:
             r = button_toggle_mode(PB_MODE_DRYING);
             if (r == PB_POLICY_OK) {
-                wake_control_task();
                 pv_evlog_add("btn: dry -> %s",
                              pb_policy_mode_str(pb_policy_get_mode()));
             } else {
@@ -704,7 +705,6 @@ void pb_policy_on_button(pb_button_id_t id, pb_button_event_t ev)
                 pv_evlog_add("btn: power (already off)");
             } else {
                 pb_policy_set_mode_off(PB_SOURCE_BUTTON);
-                wake_control_task();
                 pv_evlog_add("btn: power -> off");
             }
             break;

--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -38,6 +38,8 @@ mode to OFF. It is called **panic-off**, deliberately, and is **not** a
 safety-rated emergency stop — it is software running on the same MCU as the rest
 of the control loop, so a firmware fault could defeat it. The Layer-1 bonded
 cutoff and Layer-2 PTC physics remain the actual emergency layer.
+The panic-off latch is RAM-only and clears on reboot; reboot still starts with
+the SSR, mode, and target OFF, and never restores an active heat command.
 
 How it stays inside the safety model:
 - The button task never writes the SSR GPIO. `pb_policy_request_panic_off()`

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -59,9 +59,9 @@ static volatile bool s_net_up = false;
 // failed to initialize (its internal state/mutex may be unset).
 static volatile bool s_mk_up = false;
 
-// Control-task handle, so accepted panel actions can update outputs/LEDs without
-// waiting up to a full periodic tick. Panic-off uses the same prompt path to
-// drop the SSR.
+// Control-task handle, so accepted policy commands can update outputs/LEDs
+// without waiting up to a full periodic tick. Panic-off uses the same prompt
+// path to drop the SSR.
 static TaskHandle_t s_control_task;
 
 // pb_policy wake callback: a single notification. Runs on whatever task
@@ -223,7 +223,7 @@ static void control_task(void *arg)
         }
 
         // Wait for the next periodic deadline, but wake early on a notification
-        // (an accepted panel action or policy panic-off). Guardrails so
+        // (an accepted control command or policy panic-off). Guardrails so
         // notifications can never drag or accelerate the safety schedule: the
         // deadline is ABSOLUTE; a notify wake runs one extra full tick against
         // the SAME deadline; only a timeout advances it (with an overrun
@@ -268,7 +268,7 @@ void app_main(void)
     // earlier, and doing so would let a press arm a target before this task —
     // the sole actuator — is even running.
     xTaskCreate(control_task, "pb_control", 4096, NULL, 10, &s_control_task);
-    pb_policy_set_wake_cb(control_wake);     // panel actions can now wake the loop
+    pb_policy_set_wake_cb(control_wake);     // accepted commands can now wake the loop
     ESP_LOGI(TAG, "control loop running; heater held OFF (bring-up: no auto-heat)");
 
     // Bring up networking. If a start call blocks under a flaky link, the control

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -59,12 +59,13 @@ static volatile bool s_net_up = false;
 // failed to initialize (its internal state/mutex may be unset).
 static volatile bool s_mk_up = false;
 
-// Control-task handle, so a policy panic-off (from the button task) can wake the
-// loop immediately instead of waiting up to a full tick to drop the SSR.
+// Control-task handle, so accepted panel actions can update outputs/LEDs without
+// waiting up to a full periodic tick. Panic-off uses the same prompt path to
+// drop the SSR.
 static TaskHandle_t s_control_task;
 
 // pb_policy wake callback: a single notification. Runs on whatever task
-// requested the panic-off (the button task); keep it minimal.
+// requested the policy change (the button task); keep it minimal.
 static void control_wake(void)
 {
     if (s_control_task) xTaskNotifyGive(s_control_task);
@@ -222,13 +223,14 @@ static void control_task(void *arg)
         }
 
         // Wait for the next periodic deadline, but wake early on a notification
-        // (a policy panic-off). Guardrails so notifications can never drag or
-        // accelerate the safety schedule: the deadline is ABSOLUTE; a notify
-        // wake runs one extra full tick against the SAME deadline; only a
-        // timeout advances it (with an overrun resync). Every wake, notified or
-        // timed out, runs the complete pb_policy_tick() above — there is no
-        // partial "just drop the SSR" path. The watchdog is fed only after that
-        // successful tick, so an extra iteration keeps coverage armed.
+        // (an accepted panel action or policy panic-off). Guardrails so
+        // notifications can never drag or accelerate the safety schedule: the
+        // deadline is ABSOLUTE; a notify wake runs one extra full tick against
+        // the SAME deadline; only a timeout advances it (with an overrun
+        // resync). Every wake, notified or timed out, runs the complete
+        // pb_policy_tick() above — there is no partial "just drop the SSR"
+        // path. The watchdog is fed only after that successful tick, so an
+        // extra iteration keeps coverage armed.
         // Use SIGNED deltas so the comparison stays correct across the 32-bit
         // tick-count wrap (~497 days at 100 Hz). An unsigned `next_deadline > now`
         // inverts right at the wrap and would busy-spin full ticks for up to one
@@ -266,7 +268,7 @@ void app_main(void)
     // earlier, and doing so would let a press arm a target before this task —
     // the sole actuator — is even running.
     xTaskCreate(control_task, "pb_control", 4096, NULL, 10, &s_control_task);
-    pb_policy_set_wake_cb(control_wake);     // panic-off can now wake the loop
+    pb_policy_set_wake_cb(control_wake);     // panel actions can now wake the loop
     ESP_LOGI(TAG, "control loop running; heater held OFF (bring-up: no auto-heat)");
 
     // Bring up networking. If a start call blocks under a flaky link, the control

--- a/tests/pb_policy_host_test.c
+++ b/tests/pb_policy_host_test.c
@@ -747,6 +747,7 @@ static void test_button_invalidates_remote_lease(void)
     CHECK(pb_policy_set_power_on(
         45.0f, PB_SOURCE_KLIPPER, "klippy", 1, &lease) == PB_POLICY_OK);
     CHECK(snapshot().lease_active);
+    wake_calls = 0;
 
     // A physical OFF must drop the lease and beat any later heartbeat.
     pb_policy_on_button(PB_BUTTON_POWER, PB_BUTTON_SHORT);
@@ -754,6 +755,45 @@ static void test_button_invalidates_remote_lease(void)
     CHECK(pb_policy_heartbeat(&lease) == PB_POLICY_STALE_LEASE);
     CHECK(snapshot().source == PB_SOURCE_BUTTON);
     CHECK(wake_calls == 1);
+}
+
+static void test_remote_commands_wake_only_when_accepted(void)
+{
+    reset_fixture();
+    pb_policy_load_params();
+
+    CHECK(pb_policy_set_power_on(
+        45.0f, PB_SOURCE_WEB, "tab", PB_POLICY_REVISION_ANY, NULL)
+        == PB_POLICY_OK);
+    CHECK(wake_calls == 1);
+
+    pb_policy_set_mode_off(PB_SOURCE_WEB);
+    CHECK(wake_calls == 2);
+
+    CHECK(pb_policy_set_auto(
+        50.0f, 60.0f, PB_SOURCE_WEB, PB_POLICY_REVISION_ANY)
+        == PB_POLICY_OK);
+    CHECK(wake_calls == 3);
+
+    pb_policy_set_mode_off(PB_SOURCE_KLIPPER);
+    CHECK(wake_calls == 4);
+
+    CHECK(pb_policy_start_drying(
+        50.0f, 2, PB_SOURCE_KLIPPER, PB_POLICY_REVISION_ANY)
+        == PB_POLICY_OK);
+    CHECK(wake_calls == 5);
+
+    // Rejected commands do not change policy/output state and must not wake.
+    heater_fault = true;
+    heater_reason = "test fault";
+    CHECK(pb_policy_set_power_on(
+        45.0f, PB_SOURCE_WEB, "tab", PB_POLICY_REVISION_ANY, NULL)
+        == PB_POLICY_FAULT_LATCHED);
+    CHECK(wake_calls == 5);
+
+    CHECK(pb_policy_clear_fault(
+        PB_SOURCE_WEB, PB_POLICY_REVISION_ANY) == PB_POLICY_OK);
+    CHECK(wake_calls == 6);
 }
 
 static void test_button_rejection_is_logged_without_wake(void)
@@ -849,6 +889,7 @@ int main(void)
     test_button_short_toggles_modes();
     test_button_power_short_while_off_does_not_bump_revision();
     test_button_invalidates_remote_lease();
+    test_remote_commands_wake_only_when_accepted();
     test_button_rejection_is_logged_without_wake();
     test_button_long_press_panic_off();
     test_button_power_long_clears_or_holds_fault();

--- a/tests/pb_policy_host_test.c
+++ b/tests/pb_policy_host_test.c
@@ -4,6 +4,7 @@
 #include "nvs.h"
 
 #include <math.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -114,11 +115,16 @@ static unsigned wake_calls;
 static void count_wake(void) { wake_calls++; }
 
 static bool panic_logged_before_wake;
+static char last_evlog[128];
 void pv_evlog_init(void) {}
 void pv_evlog_add(const char *fmt, ...)
 {
     if (strstr(fmt, "panic-off") && wake_calls == 0)
         panic_logged_before_wake = true;
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(last_evlog, sizeof last_evlog, fmt, ap);
+    va_end(ap);
 }
 
 // --- In-memory NVS ----------------------------------------------------------
@@ -218,6 +224,7 @@ static void reset_fixture(void)
     fan_level = 0;
     wake_calls = 0;
     panic_logged_before_wake = false;
+    last_evlog[0] = '\0';
     memset(led_pattern, 0, sizeof led_pattern);
     chamber_c = 25.0f;
     ptc_c = 25.0f;
@@ -495,6 +502,23 @@ static void test_params_clamp_corrupt_values(void)
     CHECK(snapshot().mode == PB_MODE_OFF);
 }
 
+static void test_params_load_respects_runtime_max(void)
+{
+    reset_fixture();
+    heater_max_target_c = 55.0f;
+    CHECK(nvs_set_u32(1, "md_last", 7000) == ESP_OK);
+    CHECK(nvs_set_u32(1, "md_auto_tgt", 6500) == ESP_OK);
+    CHECK(nvs_set_u32(1, "md_dry_tgt", 6000) == ESP_OK);
+    pb_policy_load_params();
+
+    pb_policy_params_t p;
+    pb_policy_get_params(&p);
+    CHECK(p.manual_target_c == 55.0f);
+    CHECK(p.auto_target_c == 55.0f);
+    CHECK(p.dry_target_c == 55.0f);
+    CHECK(snapshot().mode == PB_MODE_OFF);
+}
+
 static void test_params_persist_only_changed_keys(void)
 {
     reset_fixture();
@@ -669,6 +693,7 @@ static void test_button_short_toggles_modes(void)
 
     // On -> POWER_ON at the remembered manual target, attributed to BUTTON.
     pb_policy_on_button(PB_BUTTON_ON, PB_BUTTON_SHORT);
+    CHECK(wake_calls == 1);
     pb_policy_snapshot_t snap = snapshot();
     CHECK(snap.mode == PB_MODE_POWER_ON);
     CHECK(snap.source == PB_SOURCE_BUTTON);
@@ -676,25 +701,30 @@ static void test_button_short_toggles_modes(void)
     CHECK(!snap.lease_active);
     // Press again -> OFF.
     pb_policy_on_button(PB_BUTTON_ON, PB_BUTTON_SHORT);
+    CHECK(wake_calls == 2);
     CHECK(snapshot().mode == PB_MODE_OFF);
 
     // Auto toggles AUTO with the remembered target + threshold.
     pb_policy_on_button(PB_BUTTON_AUTO, PB_BUTTON_SHORT);
+    CHECK(wake_calls == 3);
     snap = snapshot();
     CHECK(snap.mode == PB_MODE_AUTO);
     CHECK(snap.source == PB_SOURCE_BUTTON);
     CHECK(snap.auto_bed_threshold_c == 100.0f);
     pb_policy_on_button(PB_BUTTON_AUTO, PB_BUTTON_SHORT);
+    CHECK(wake_calls == 4);
     CHECK(snapshot().mode == PB_MODE_OFF);
 
     // Dry toggles DRYING.
     pb_policy_on_button(PB_BUTTON_DRY, PB_BUTTON_SHORT);
+    CHECK(wake_calls == 5);
     snap = snapshot();
     CHECK(snap.mode == PB_MODE_DRYING);
     CHECK(snap.drying);
 
     // Power short is master OFF from any mode.
     pb_policy_on_button(PB_BUTTON_POWER, PB_BUTTON_SHORT);
+    CHECK(wake_calls == 6);
     CHECK(snapshot().mode == PB_MODE_OFF);
 }
 
@@ -704,6 +734,7 @@ static void test_button_power_short_while_off_does_not_bump_revision(void)
     pb_policy_load_params();
     uint32_t rev = snapshot().state_revision;
     pb_policy_on_button(PB_BUTTON_POWER, PB_BUTTON_SHORT);   // already OFF
+    CHECK(wake_calls == 0);
     CHECK(snapshot().state_revision == rev);                 // evlog only, no bump
     CHECK(snapshot().mode == PB_MODE_OFF);
 }
@@ -722,6 +753,21 @@ static void test_button_invalidates_remote_lease(void)
     CHECK(!snapshot().lease_active);
     CHECK(pb_policy_heartbeat(&lease) == PB_POLICY_STALE_LEASE);
     CHECK(snapshot().source == PB_SOURCE_BUTTON);
+    CHECK(wake_calls == 1);
+}
+
+static void test_button_rejection_is_logged_without_wake(void)
+{
+    reset_fixture();
+    pb_policy_load_params();
+    heater_fault = true;
+    heater_reason = "test fault";
+
+    pb_policy_on_button(PB_BUTTON_AUTO, PB_BUTTON_SHORT);
+
+    CHECK(snapshot().mode == PB_MODE_OFF);
+    CHECK(wake_calls == 0);
+    CHECK(strcmp(last_evlog, "btn: auto rejected (fault_latched)") == 0);
 }
 
 static void test_button_long_press_panic_off(void)
@@ -795,6 +841,7 @@ int main(void)
     test_panel_leds_track_mode();
     test_params_default_and_load_never_arms();
     test_params_clamp_corrupt_values();
+    test_params_load_respects_runtime_max();
     test_params_persist_only_changed_keys();
     test_params_persist_canonical_post_clamp_value();
     test_params_failed_write_stays_dirty_and_retries();
@@ -802,6 +849,7 @@ int main(void)
     test_button_short_toggles_modes();
     test_button_power_short_while_off_does_not_bump_revision();
     test_button_invalidates_remote_lease();
+    test_button_rejection_is_logged_without_wake();
     test_button_long_press_panic_off();
     test_button_power_long_clears_or_holds_fault();
     puts("pb_policy host tests: PASS");


### PR DESCRIPTION
## Summary

- Wake the control task after every accepted front-panel state change, so mode
  LEDs and outputs update promptly instead of waiting up to 500 ms for the
  periodic tick.
- Preserve the single-SSR-writer invariant: button actions still only notify
  the control task, which runs the complete policy/safety tick.
- Log rejected mode presses with the actual policy result instead of reporting
  a misleading transition to `off`.
- Clamp remembered manual, Auto, and Dry targets to the live
  runtime-configured heater maximum when loading them from NVS.
- Document that the panic-off latch is RAM-only and clears on reboot while the
  device still boots fully OFF.

## Root cause

The wake callback was used only by panic-off, and the short-press handler
discarded mode-setter results. Separately, boot-time parameter loading used the
absolute 70 °C ceiling instead of the already-loaded runtime ceiling.

## Validation

- `sh tests/run_policy_host_test.sh`
- `sh tests/run_buttons_host_test.sh`
- `sh tests/check_api_v2_contract.sh`
- `node tests/check_dashboard_js.mjs`
- `python3 -m unittest tests/test_hil_runner.py` — 11 tests
- ESP-IDF v5.3 production build
- ESP-IDF v5.3 USB HIL build + compile-out check
- ESP-IDF v5.3 UART HIL build + compile-out check

New host coverage verifies accepted button wakes, no wake for an already-off
no-op or fault rejection, accurate fault-rejection logging, and
runtime-ceiling clamping of all remembered heat targets.
