### PR TITLE
fix(ui): bound SPA on large/4K, unfloat action button, restyle portal (v0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-07-24
+
+### Fixed
+- **Web UI no longer sprawls on large / 4K displays.** The SPA is built to fill
+  its Fluidd/Mainsail iframe, so opening it standalone on a big monitor stretched
+  every element edge-to-edge. It is now bounded to a centered panel (max
+  1200×820) on large viewports while still filling a small embed.
+- **Control-screen action button no longer floats over the last control.** On
+  Manual/Auto/Dry the primary action (e.g. "Start drying") used a sticky footer
+  that overlapped the final control (target/duration) when the screen was tight.
+  The action now sits in normal flow directly below the controls.
+- **Firmware-update (`/fw`), Wi-Fi setup (`/setup`), and the AP captive portal
+  match the new UI.** These pages still used the old stock-BIQU blue banner; they
+  now use the charcoal palette and dragon mark of the main app.
+
 ## [0.5.0] - 2026-07-24
 
 A ground-up **responsive, touch-first Web UI** (issue #19), delivered as a

--- a/components/pb_portal/pb_portal.c
+++ b/components/pb_portal/pb_portal.c
@@ -116,37 +116,48 @@ static void html_attr_escape(const char *in, char *out, size_t outsz)
 }
 
 // ---- static page pieces ----
-// Styled to match the stock BIQU Panda Breath web UI (dark #272525 page, #333
-// rounded cards, Arial, blue accent) — palette lifted from the stock firmware,
-// with the primary accent switched from stock red to the stock's blue (#4087FE).
-// Shared head + CSS + header + <div class=wrap> — used by both the status page
-// (STA root) and the config page (AP captive / /setup).
+// Charcoal palette + dragon mark matching the STA-mode SPA (app.html) in its dark
+// theme, so /setup, /fw, and the AP captive portal read as the same product rather
+// than the old stock-BIQU blue look. Shared head + CSS + header + <div class=wrap>,
+// used by both the config page (AP captive / /setup) and the /fw update page. These
+// utility pages stay dark (the SPA carries the light/dark toggle).
 static const char PAGE_HEAD[] =
-    "<!doctype html><html><head><meta charset=utf-8>"
+    "<!doctype html><html lang=en><head><meta charset=utf-8>"
     "<meta name=viewport content='width=device-width,initial-scale=1'>"
+    "<meta name=color-scheme content=dark><meta name=referrer content=no-referrer>"
+    "<link rel=icon href=/favicon.ico>"
     "<title>DragonBreath</title><style>"
-    ":root{--bg:#272525;--card:#333;--accent:#4087FE;--text:#F0F0F0;--input:#2c2c2c;--border:rgba(255,255,255,.12);color-scheme:dark}"
+    ":root{color-scheme:dark;--bg:#181818;--card:rgba(255,255,255,.05);--accent:#83c3ff;"
+    "--accent-fg:#0d0d0d;--text:#fff;--muted:rgba(255,255,255,.55);--input:rgba(0,0,0,.18);"
+    "--border:rgba(255,255,255,.14);--bad:#ff8549}"
     "*{box-sizing:border-box}"
-    "body{margin:0;background:var(--bg);font-family:Arial,Helvetica,sans-serif;color:var(--text)}"
-    ".hdr{background:linear-gradient(135deg,#4087FE 0%,#0a2e6b 100%);padding:22px 16px 18px;text-align:center}"
-    ".hdr h1{margin:0;font-size:1.4rem}.hdr p{margin:.25em 0 0;font-size:.8rem;color:#cdddff}"
-    ".wrap{max-width:27em;margin:0 auto;padding:16px}"
-    ".card{background:var(--card);border-radius:16px;padding:16px;margin:16px 0}"
-    ".card h2{margin:0 0 .2em;font-size:1.1rem;font-weight:600;color:var(--accent)}"
-    "label{display:block;margin:.85em 0 .3em;font-size:.8rem;color:#bdbdbd}"
-    "input,select{width:100%;padding:12px 14px;font-size:1rem;background:var(--input);color:var(--text);"
+    "body{margin:0;background:var(--bg);color:var(--text);"
+    "font:14px/1.4 -apple-system,system-ui,'Segoe UI',Roboto,sans-serif}"
+    ".hdr{display:flex;align-items:center;justify-content:center;gap:9px;padding:16px;"
+    "border-bottom:1px solid var(--border);background:var(--card)}"
+    ".hdr svg{width:27px;height:27px;fill:currentColor}"
+    ".hdr h1{margin:0;font-size:1.15rem;font-weight:700}"
+    ".wrap{max-width:28em;margin:0 auto;padding:16px}"
+    ".card{background:var(--card);border:1px solid var(--border);border-radius:12px;padding:16px;margin:14px 0}"
+    ".card h2{margin:0 0 .3em;font-size:1rem;font-weight:600}"
+    "label{display:block;margin:.85em 0 .3em;font-size:.8rem;color:var(--muted)}"
+    "input,select{width:100%;padding:11px 13px;font-size:1rem;background:var(--input);color:var(--text);"
     "border:1px solid var(--border);border-radius:8px}"
-    "input:focus,select:focus{outline:none;border-color:var(--accent)}"
+    "input:focus,select:focus{outline:2px solid var(--accent);outline-offset:1px;border-color:var(--accent)}"
     ".pw{display:flex;gap:8px}.pw input{flex:1}"
-    ".pw button{width:52px;flex:none;background:var(--input);border:1px solid var(--border);border-radius:8px;font-size:1.2rem;cursor:pointer}"
-    "button.go{width:100%;padding:14px;margin-top:6px;border:0;border-radius:10px;background:var(--accent);color:#fff;font-size:1.05rem;font-weight:600;cursor:pointer}"
-    "button.sec{width:100%;padding:10px;margin-top:12px;border:1px solid var(--border);border-radius:8px;background:#3a3a3a;color:#ddd;cursor:pointer}"
-    "button.sec.active{background:var(--accent);border-color:var(--accent);color:#fff;font-weight:600}"
-    "button:disabled{opacity:.4;cursor:not-allowed}"
-    ".srow{display:flex;justify-content:space-between;padding:8px 0;border-bottom:1px solid rgba(255,255,255,.07)}.srow:last-child{border:0}"
-    ".msg{min-height:1.2em;margin-top:.55em;font-size:.76rem;color:#bdbdbd}.msg.bad{color:#ff9d9d}"
-    "small{color:#8a8a8a}a{color:#4aa3ff}</style></head><body>"
-    "<div class=hdr><h1>\xF0\x9F\x90\x89 DragonBreath</h1></div>"
+    ".pw button{width:50px;flex:none;background:var(--input);border:1px solid var(--border);border-radius:8px;font-size:1.1rem;cursor:pointer;color:var(--text)}"
+    "button.go{width:100%;padding:13px;margin-top:8px;border:0;border-radius:9px;background:var(--accent);color:var(--accent-fg);font-size:1rem;font-weight:600;cursor:pointer}"
+    "button.sec{width:100%;padding:10px;margin-top:12px;border:1px solid var(--border);border-radius:8px;background:transparent;color:var(--text);cursor:pointer}"
+    "button.sec.active{background:var(--accent);border-color:var(--accent);color:var(--accent-fg);font-weight:600}"
+    "button:disabled{opacity:.45;cursor:not-allowed}"
+    ".srow{display:flex;justify-content:space-between;padding:8px 0;border-bottom:1px solid var(--border)}.srow:last-child{border:0}"
+    ".msg{min-height:1.2em;margin-top:.55em;font-size:.78rem;color:var(--muted)}.msg.bad{color:var(--bad)}"
+    "small{color:var(--muted)}a{color:var(--accent)}h3{margin:.2em 0}code{font-size:.9em}</style></head><body>"
+    "<div class=hdr>"
+    "<svg viewBox='0 0 32 32' aria-hidden=true><path fill-rule=evenodd "
+    "d='M2 15 L8 13 L11 11 L13 8 L15 10 L21 3 L18 11 L21 13 L24 15 L28 17 L23 18 L27 22 L20 20 L18 20 L16 19 L3 19 Z "
+    "M10 12 a1.4 1.4 0 100 2.8 1.4 1.4 0 000-2.8Z'/></svg>"
+    "<h1>DragonBreath</h1></div>"
     "<div class=wrap>";
 
 // Wi-Fi form card (config page).

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -49,6 +49,8 @@ body{
   background: var(--background);
   font: 14px/1.35 var(--font-sans);
   overflow: hidden;              /* embeds cleanly in a Fluidd/Mainsail iframe */
+  display: grid;                 /* center + bound the app on large/4K displays */
+  place-items: center;
 }
 [hidden]{ display: none !important; }
 
@@ -102,8 +104,15 @@ body{
 svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
   stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
 
-/* ---- Shell: topbar + icon rail + main. .app is the responsive query container. ---- */
-.app{ container-type: inline-size; height: 100%; }
+/* ---- Shell: topbar + icon rail + main. .app is the responsive query container.
+   width/height fill a small iframe (the Fluidd/Mainsail embed); the max-* caps
+   bound it into a centered panel on large/4K displays instead of sprawling. ---- */
+.app{ container-type: inline-size;
+  width: 100%; height: 100%;
+  max-width: 1200px; max-height: 820px;
+  overflow: hidden;
+  border: 1px solid var(--border); border-radius: var(--radius-lg);
+  box-shadow: 0 1px 4px light-dark(rgb(0 0 0 / 8%), rgb(0 0 0 / 30%)); }
 .shell{
   height: 100%;
   display: grid;
@@ -234,12 +243,11 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
 .settings-links{ display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
 .settings-links .btn{ gap: 6px; text-decoration: none; }
 
-/* ---- U2 [P1] fix: keep each control screen's primary action visible at compact
-   size. The controls scroll inside the screen's own single scroll (.page-only),
-   while the action+feedback stay pinned to the bottom — no nested scrollbar. ---- */
-.mode-footer{ position: sticky; bottom: 0; margin-top: auto; z-index: 3;
-  display: flex; flex-direction: column; gap: 4px; padding-top: 8px;
-  background: linear-gradient(to top, var(--card) 78%, transparent); }
+/* ---- Primary action + feedback sit in normal flow right below the controls.
+   (An earlier sticky bottom:0 footer floated OVER the last control when the
+   screen was tight — the whole .mode-controls scrolls instead, so the action
+   never overlaps.) ---- */
+.mode-footer{ display: flex; flex-direction: column; gap: 4px; padding-top: 4px; }
 .mode-footer .mode-action{ margin-top: 0; }
 
 /* ---- U3 Settings: a single scrolling column of sections; each section is a


### PR DESCRIPTION
Three UI fixes reported after v0.5.0, targeting a **v0.5.1** patch release.

### Fixes
1. **4K / large-display sprawl.** The SPA fills its container by design (Fluidd/Mainsail iframe embed), so standalone on a big monitor it stretched edge-to-edge. `.app` is now bounded to a centered **1200×820** panel on large viewports; small embeds still fill.
2. **Floating action button.** On Manual/Auto/Dry the sticky `bottom:0` `.mode-footer` overlapped the last control (e.g. "Start drying" sat on top of the duration stepper). The action now flows in normal position directly below the controls.
3. **Old-UI portal pages.** `/fw` (firmware update), `/setup` (Wi-Fi + Moonraker), and the AP captive portal still used the stock-BIQU blue banner. The shared `PAGE_HEAD` is restyled to the SPA's charcoal palette + dragon mark. (No page-body markup changed — same class names.)

### Validation
Built (46% flash free) and OTA-flashed to the bench; verified via headless-Chromium renders: SPA at 3840×2160 centered/bounded; dry screen (panel/phone/dark) action correctly placed; `/fw` and `/setup` charcoal + dragon header. Static contract gate passes locally; the node dashboard-js gate runs in CI. CSS/markup only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
