### PR TITLE
feat(safety): B2 — persistent fault latch + hardened residual-heat purge

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Test sensor-calibration safety clamp (set + NVS-load bound)
         run: sh tests/run_ntc_calibration_host_test.sh
 
+      - name: Test persistent fault-latch boot restore (fail-safe)
+        run: sh tests/run_heater_fault_host_test.sh
+
       - name: Test HIL scenario runner
         run: python3 -m unittest tests/test_hil_runner.py
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+### Added
+- **Persistent safety-fault latch (B2).** A hazard-driven safety trip (PTC/chamber
+  over-temp, sensor fault while heating, comms-loss watchdog) now survives a power
+  cycle: it is written to NVS on the latching transition and restored at boot, so a
+  device that tripped before losing power comes back up **heater-OFF with commands
+  inhibited** instead of silently ready to heat. NVS is loaded **before** the
+  control task starts, and a failed persist is **retried** (a pending flag keeps
+  trying until the commit lands) so an early or transiently-failed write can't lose
+  the latch across a reboot. The persisted cause is a stable numeric code (a live
+  reason string still carries session detail). Boot restore is **fail-safe** — if
+  the stored state cannot be read reliably the device comes up latched. Clearing a
+  fault is **persist-first**: if the NVS clear fails the latch is kept and the API
+  returns HTTP 500 (`persist_failed`) rather than falsely reporting it cleared.
+  User panic-off and the permanent inhibit are not persisted (documented
+  reboot-clears behavior); active mode/target/deadline/lease still never persist.
+
+### Changed
+- **Residual-heat purge hardened.** The post-heat cooldown fan now uses hysteresis
+  (engage at ≥ 40 °C, release only once **both** the chamber and PTC sensors are
+  below 37 °C) instead of a single chamber-only threshold, and it also runs when a
+  sensor reading is **unknown** right as heating ends (can't confirm cool → fail
+  safe). It remains strictly session-gated: the fan never starts on temperature
+  alone, and a power-cycle-while-hot does **not** spin it.
+
 ## [0.5.2] - 2026-07-24
 
 ### Fixed

--- a/components/pb_heater/include/pb_heater.h
+++ b/components/pb_heater/include/pb_heater.h
@@ -13,6 +13,55 @@
 #include <stdint.h>
 #include "esp_err.h"
 
+// Machine-readable fault cause. Persisted across reboot as a u8 (see
+// pb_heater_load_fault); a live free-form reason string (pb_heater_fault_reason)
+// carries session detail that is NOT persisted. Append new causes at the END so
+// the persisted numeric codes stay stable across firmware versions.
+typedef enum {
+    PB_FAULT_NONE = 0,
+    PB_FAULT_PTC_OVERTEMP,        // element over-temp cutoff
+    PB_FAULT_CHAMBER_OVERTEMP,    // chamber over-temp cutoff
+    PB_FAULT_CHAMBER_SENSOR,      // chamber thermistor open/short/uninit while armed
+    PB_FAULT_PTC_SENSOR,          // PTC thermistor open/short/uninit while armed
+    PB_FAULT_LINK_LOST,           // comms-loss watchdog while heating
+    PB_FAULT_PANIC_OFF,           // front-panel long-press panic-off
+    PB_FAULT_INHIBITED,           // permanent inhibit (reboot-only)
+    PB_FAULT_EMERGENCY,           // generic external emergency_off trip
+    PB_FAULT_NVS_UNREADABLE,      // boot fail-safe: persisted fault state unreadable
+    PB_FAULT__COUNT               // sentinel: any stored code >= this is treated as
+                                  // corrupt and mapped to a generic latched fault
+} pb_fault_reason_t;
+
+// Pure fail-safe decision for the boot-time fault restore (pb_heater_load_fault),
+// inline so it can be host-tested without an NVS backend. Given the outcome of
+// reading the persisted latch/code, decides whether to come up latched and with
+// which code:
+//   - namespace/key never written (fresh device)  -> NOT latched.
+//   - a genuine read error (open or latch read)    -> FAIL SAFE: latch, NVS_UNREADABLE.
+//   - a readable latch flag == 1                   -> latched with the stored code;
+//       an out-of-range/NONE stored code is corrupt -> latch anyway (PB_FAULT_EMERGENCY).
+// open_ok / latch_read_ok are false ONLY on a real error (the not-found cases are
+// signalled separately via ns_not_found / latch_not_found).
+static inline bool pb_heater_fault_decide(bool open_ok, bool ns_not_found,
+                                          bool latch_read_ok, bool latch_not_found,
+                                          uint8_t latch_val, uint8_t code_val,
+                                          pb_fault_reason_t *out_code)
+{
+    pb_fault_reason_t code = PB_FAULT_NONE;
+    bool latched = false;
+    if (ns_not_found || latch_not_found) {
+        latched = false;                                   // fresh device / never latched
+    } else if (!open_ok || !latch_read_ok) {
+        latched = true; code = PB_FAULT_NVS_UNREADABLE;    // can't read -> fail safe
+    } else if (latch_val) {
+        latched = true;
+        code = (code_val < PB_FAULT__COUNT && code_val != PB_FAULT_NONE)
+               ? (pb_fault_reason_t)code_val : PB_FAULT_EMERGENCY;   // corrupt code -> generic
+    }
+    if (out_code) *out_code = code;
+    return latched;
+}
+
 // --- Safety limits ----------------------------------------------------------
 // Fixed hardware-safety cutoffs — NEVER user-configurable.
 #define PB_HEATER_PTC_CUTOFF_C   105.0f   // element over-temp -> force off (stock parity)
@@ -51,6 +100,13 @@ float pb_heater_get_target_c(void);
 // nvs_init() — pb_heater_init() only sets conservative defaults (nvs isn't up
 // yet). Values are clamped on read.
 void  pb_heater_load_config(void);
+// Restore a persisted fault latch from NVS. MUST be called AFTER nvs_init() and
+// BEFORE the control task / HTTP API are exposed, so a device that latched off
+// before a power cycle comes back up heater-OFF and commands-inhibited rather than
+// silently ready to heat. Fail-safe: if the persisted state cannot be read
+// reliably it latches a generic fault (PB_FAULT_NVS_UNREADABLE). A namespace that
+// was never written (fresh device) is NOT a fault.
+void  pb_heater_load_fault(void);
 // Settable set-point ceiling. Setter clamps to [MIN_TARGET_C, ABS_MAX_TARGET_C],
 // persists it, and pulls a live target down if it now exceeds the cap.
 esp_err_t pb_heater_set_max_target_c(float max_c);
@@ -85,9 +141,14 @@ void pb_heater_request_panic_off(const char *reason);
 
 // Explicitly clear a latched safety fault (over-temp / sensor fault / comms loss).
 // Setting a new target does NOT auto-clear it — this is a deliberate reset. The
-// next tick re-evaluates safety and re-latches if the fault still holds.
-// A permanent inhibit (pb_heater_inhibit) is NOT cleared by this.
-void pb_heater_clear_fault(void);
+// next tick re-evaluates safety and re-latches if the fault still holds. Also
+// clears the persisted latch in NVS. Returns:
+//   ESP_OK                - cleared (and the NVS clear committed)
+//   ESP_ERR_INVALID_STATE - a permanent inhibit is latched (not clearable)
+//   other                 - the RAM latch was cleared but persisting the clear
+//                           FAILED (so it would return on reboot); callers should
+//                           surface this (HTTP 500) rather than report success.
+esp_err_t pb_heater_clear_fault(void);
 
 // PERMANENT inhibit: force the heater off and refuse all heat until reboot. Unlike
 // a latched fault this is NOT clearable by pb_heater_clear_fault()/API clear_fault —
@@ -102,8 +163,17 @@ bool pb_heater_is_inhibited(void);
 // True if a safety trip has latched the heater off (needs an explicit clear).
 bool pb_heater_is_faulted(void);
 
-// The reason string from the most recent trip (NULL if none / after clear).
+// The reason string from the most recent trip (NULL if none / after clear). This
+// is live session detail and is NOT persisted; after a reboot-restored latch it
+// reflects the canonical string for the persisted code.
 const char *pb_heater_fault_reason(void);
+
+// The machine-readable cause of the current latch (PB_FAULT_NONE if not faulted).
+// Stable across firmware versions and survives a reboot, unlike the reason string.
+pb_fault_reason_t pb_heater_fault_code(void);
+
+// Canonical, stable string for a fault code (never NULL; out-of-range -> generic).
+const char *pb_heater_fault_str(pb_fault_reason_t code);
 
 // True if the SSR is currently commanded on (momentary bang-bang state).
 bool pb_heater_is_on(void);

--- a/components/pb_heater/pb_heater.c
+++ b/components/pb_heater/pb_heater.c
@@ -8,9 +8,15 @@
 #include "esp_timer.h"
 #include "driver/gpio.h"
 #include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 #include "nvs.h"
 
 static const char *TAG = "pb_heater";
+
+// Serializes fault-latch NVS writes (do_latch persist, clear_fault, tick retry)
+// so a concurrent clear and a deferred-persist retry can't reorder into a stale
+// write that resurrects a just-cleared latch. NULL until pb_heater_init().
+static SemaphoreHandle_t s_persist_lock;
 
 // Heater state is touched by BOTH the control task (pb_heater_tick, via the
 // 2 Hz loop) and the HTTP task (set_target / notify_link_alive / clear_fault /
@@ -24,6 +30,9 @@ static bool        s_inhibited;     // guarded by s_mux (PERMANENT; reboot-only)
 static int64_t     s_last_link_us;  // guarded by s_mux
 static const char *s_fault_reason;  // guarded by s_mux (points at a string literal)
 static pb_fault_reason_t s_fault_code; // guarded by s_mux (machine-readable, persisted)
+static bool        s_persist_pending;  // guarded by s_mux — a latch persist not yet committed
+                                       // to NVS; retried from pb_heater_tick until it lands
+static int64_t     s_persist_retry_us; // guarded by s_mux — last persist-retry timestamp
 static bool        s_on;            // written only by the control task; atomic read
 static float       s_max_target_c;      // guarded by s_mux — settable set-point ceiling
 static int64_t     s_comms_timeout_us;  // guarded by s_mux — comms deadman (microseconds)
@@ -77,6 +86,7 @@ static void ssr_set(bool on)        // control-task context only
 
 esp_err_t pb_heater_init(void)
 {
+    if (!s_persist_lock) s_persist_lock = xSemaphoreCreateMutex();
 #ifndef CONFIG_PB_HIL_DEVBOARD
     const gpio_config_t io = {
         .pin_bit_mask = (1ULL << PB_GPIO_RELAY),
@@ -262,7 +272,20 @@ static void do_latch(pb_fault_reason_t code, const char *reason,
     s_fault_code = code;
     s_fault_reason = reason ? reason : pb_heater_fault_str(code);
     taskEXIT_CRITICAL(&s_mux);
-    if (persist && transition) persist_fault(true, code);
+    if (persist && transition) {
+        if (s_persist_lock) xSemaphoreTake(s_persist_lock, portMAX_DELAY);
+        esp_err_t pe = persist_fault(true, code);
+        if (s_persist_lock) xSemaphoreGive(s_persist_lock);
+        if (pe != ESP_OK) {
+            // The write failed (NVS busy, or a fault before nvs_init on early boot).
+            // Mark it pending so pb_heater_tick() keeps retrying until it commits —
+            // otherwise a reboot would lose a latch that only ever lived in RAM.
+            taskENTER_CRITICAL(&s_mux);
+            s_persist_pending = true;
+            taskEXIT_CRITICAL(&s_mux);
+            ESP_LOGW(TAG, "fault persist deferred (will retry): %s", pb_heater_fault_str(code));
+        }
+    }
 }
 
 // Control-task safety trip: latch (driving the SSR down) + persist + log.
@@ -303,11 +326,14 @@ esp_err_t pb_heater_clear_fault(void)
     was = s_latched_off;
     taskEXIT_CRITICAL(&s_mux);
 
-    // Persist-first: clear NVS BEFORE RAM so the two never disagree. If the persist
-    // fails, leave the fault latched (fail-safe) and report it — the heater stays
-    // off rather than falsely appearing cleared but returning on the next reboot.
+    // Persist-first, under the persist lock so a concurrent tick retry can't write
+    // a stale "latched" after this clears NVS. If the persist fails, leave the fault
+    // latched (fail-safe) and report it — the heater stays off rather than falsely
+    // appearing cleared but returning on the next reboot.
+    if (s_persist_lock) xSemaphoreTake(s_persist_lock, portMAX_DELAY);
     esp_err_t err = persist_fault(false, PB_FAULT_NONE);
     if (err != ESP_OK) {
+        if (s_persist_lock) xSemaphoreGive(s_persist_lock);
         ESP_LOGE(TAG, "clear rejected: NVS clear failed (%s) — fault stays latched", esp_err_to_name(err));
         return err;
     }
@@ -316,7 +342,9 @@ esp_err_t pb_heater_clear_fault(void)
     s_target_c = 0.0f;              // reset leaves the target at ZERO — a fresh
     s_fault_reason = NULL;          // target command is required to resume heating.
     s_fault_code = PB_FAULT_NONE;
+    s_persist_pending = false;      // NVS now holds "not latched"; nothing to retry
     taskEXIT_CRITICAL(&s_mux);
+    if (s_persist_lock) xSemaphoreGive(s_persist_lock);
     if (was) ESP_LOGW(TAG, "fault latch cleared; target reset to 0 (send a fresh target to resume)");
     return ESP_OK;
 }
@@ -386,6 +414,37 @@ bool pb_heater_heat_mode(void)     // "armed and not tripped" (independent of SS
 
 void pb_heater_tick(void)          // control-task context; sole writer of s_on
 {
+    // Retry a deferred fault-latch persist until it commits, so a latch that
+    // couldn't be written when it happened (NVS busy, or a fault before nvs_init)
+    // still survives a reboot. Throttled and serialized with clear_fault via the
+    // persist lock; re-reads the latch state INSIDE the lock so a clear that landed
+    // meanwhile is never overwritten with a stale "latched".
+    bool pending;
+    taskENTER_CRITICAL(&s_mux);
+    pending = s_persist_pending;
+    taskEXIT_CRITICAL(&s_mux);
+    if (pending) {
+        int64_t now = esp_timer_get_time();
+        taskENTER_CRITICAL(&s_mux);
+        bool due = (now - s_persist_retry_us) >= 2000000;   // ~2 s: bound NVS churn/log spam
+        taskEXIT_CRITICAL(&s_mux);
+        if (due && s_persist_lock && xSemaphoreTake(s_persist_lock, 0) == pdTRUE) {
+            taskENTER_CRITICAL(&s_mux);
+            bool still = s_latched_off;
+            pb_fault_reason_t code = s_fault_code;
+            s_persist_retry_us = now;
+            taskEXIT_CRITICAL(&s_mux);
+            esp_err_t pr = still ? persist_fault(true, code) : ESP_OK;  // cleared -> nothing to write
+            if (pr == ESP_OK) {
+                taskENTER_CRITICAL(&s_mux);
+                s_persist_pending = false;
+                taskEXIT_CRITICAL(&s_mux);
+                ESP_LOGI(TAG, "deferred fault persist committed");
+            }
+            xSemaphoreGive(s_persist_lock);
+        }
+    }
+
     float   target;
     bool    latched;
     int64_t last_link;

--- a/components/pb_heater/pb_heater.c
+++ b/components/pb_heater/pb_heater.c
@@ -23,6 +23,7 @@ static bool        s_latched_off;   // guarded by s_mux (set by a safety trip)
 static bool        s_inhibited;     // guarded by s_mux (PERMANENT; reboot-only)
 static int64_t     s_last_link_us;  // guarded by s_mux
 static const char *s_fault_reason;  // guarded by s_mux (points at a string literal)
+static pb_fault_reason_t s_fault_code; // guarded by s_mux (machine-readable, persisted)
 static bool        s_on;            // written only by the control task; atomic read
 static float       s_max_target_c;      // guarded by s_mux — settable set-point ceiling
 static int64_t     s_comms_timeout_us;  // guarded by s_mux — comms deadman (microseconds)
@@ -31,6 +32,32 @@ static int64_t     s_comms_timeout_us;  // guarded by s_mux — comms deadman (m
 #define NVS_NS             "app_nvs"
 #define KEY_HEAT_MAX_C     "heat_max_c"      // u32 centi-°C
 #define KEY_HEAT_COMMS_MS  "heat_comms_ms"   // u32 ms
+#define KEY_FAULT_LATCH    "fault_latch"     // u8 0/1 — persisted safety-fault latch
+#define KEY_FAULT_CODE     "fault_code"      // u8 pb_fault_reason_t
+
+// Canonical, stable strings for each fault code (index == code). Kept identical to
+// the historical trip strings so the API contract doesn't change for existing
+// causes. Any out-of-range/corrupt code maps to a generic latched-fault string.
+static const char *const k_fault_str[PB_FAULT__COUNT] = {
+    [PB_FAULT_NONE]             = "none",
+    [PB_FAULT_PTC_OVERTEMP]     = "PTC element over-temp",
+    [PB_FAULT_CHAMBER_OVERTEMP] = "chamber over-temp",
+    [PB_FAULT_CHAMBER_SENSOR]   = "chamber sensor fault",
+    [PB_FAULT_PTC_SENSOR]       = "PTC sensor fault",
+    [PB_FAULT_LINK_LOST]        = "controller link lost",
+    [PB_FAULT_PANIC_OFF]        = "panic-off",
+    [PB_FAULT_INHIBITED]        = "inhibited",
+    [PB_FAULT_EMERGENCY]        = "safety trip",
+    [PB_FAULT_NVS_UNREADABLE]   = "persisted fault state unreadable",
+};
+
+const char *pb_heater_fault_str(pb_fault_reason_t code)
+{
+    if ((unsigned)code >= PB_FAULT__COUNT || !k_fault_str[code]) return "latched fault";
+    return k_fault_str[code];
+}
+// pb_heater_fault_decide() is a pure header inline (see pb_heater.h) so the
+// boot-time fail-safe logic can be host-tested without an NVS backend.
 
 static float centi_to_c(uint32_t v) { return (float)v / 100.0f; }
 static uint32_t c_to_centi(float c)
@@ -66,6 +93,7 @@ esp_err_t pb_heater_init(void)
     s_target_c = 0.0f;
     s_latched_off = false;
     s_fault_reason = NULL;
+    s_fault_code = PB_FAULT_NONE;
     s_last_link_us = esp_timer_get_time();
     // Conservative defaults ONLY — nvs isn't up yet; pb_heater_load_config()
     // applies persisted values later (called after nvs_init in app_main).
@@ -199,14 +227,54 @@ void pb_heater_notify_link_alive(void)
     taskEXIT_CRITICAL(&s_mux);
 }
 
-void pb_heater_emergency_off(const char *reason)   // control-task context
+// Persist (or clear) the safety-fault latch to NVS. NVS ops MUST run outside
+// s_mux (they can block / need interrupts). On latch this is best-effort — RAM is
+// authoritative for the session; on CLEAR the return matters so a failed persist
+// can be surfaced (HTTP 500) rather than falsely reporting the fault gone.
+static esp_err_t persist_fault(bool latched, pb_fault_reason_t code)
 {
-    ssr_set(false);
+    nvs_handle_t h;
+    esp_err_t err = nvs_open(NVS_NS, NVS_READWRITE, &h);
+    if (err != ESP_OK) { ESP_LOGE(TAG, "fault persist: nvs_open %s", esp_err_to_name(err)); return err; }
+    err = nvs_set_u8(h, KEY_FAULT_LATCH, latched ? 1 : 0);
+    if (err == ESP_OK) err = nvs_set_u8(h, KEY_FAULT_CODE, (uint8_t)code);
+    if (err == ESP_OK) err = nvs_commit(h);
+    nvs_close(h);
+    if (err != ESP_OK) ESP_LOGE(TAG, "fault persist: %s", esp_err_to_name(err));
+    return err;
+}
+
+// Latch the heater off with a machine-readable code + live reason string. Sets RAM
+// under the lock, then (only on the false->true transition) persists it. persist==
+// false leaves NVS untouched — used for the reboot-restore path (already in NVS)
+// and for the permanent inhibit, whose "a reboot clears it" semantics must not
+// survive a power cycle. drive_ssr is CONTROL-TASK ONLY (it writes the GPIO).
+static void do_latch(pb_fault_reason_t code, const char *reason,
+                     bool inhibit, bool drive_ssr, bool persist)
+{
+    if (drive_ssr) ssr_set(false);
+    bool transition;
     taskENTER_CRITICAL(&s_mux);
+    transition = !s_latched_off;                 // first latch of this episode?
     s_target_c = 0.0f;
     s_latched_off = true;
-    s_fault_reason = reason ? reason : "unspecified";
+    if (inhibit) s_inhibited = true;
+    s_fault_code = code;
+    s_fault_reason = reason ? reason : pb_heater_fault_str(code);
     taskEXIT_CRITICAL(&s_mux);
+    if (persist && transition) persist_fault(true, code);
+}
+
+// Control-task safety trip: latch (driving the SSR down) + persist + log.
+static void trip(pb_fault_reason_t code)
+{
+    do_latch(code, NULL, /*inhibit=*/false, /*drive_ssr=*/true, /*persist=*/true);
+    ESP_LOGW(TAG, "EMERGENCY OFF: %s", pb_heater_fault_str(code));
+}
+
+void pb_heater_emergency_off(const char *reason)   // control-task context
+{
+    do_latch(PB_FAULT_EMERGENCY, reason, /*inhibit=*/false, /*drive_ssr=*/true, /*persist=*/true);
     ESP_LOGW(TAG, "EMERGENCY OFF: %s", reason ? reason : "(unspecified)");
 }
 
@@ -217,39 +285,48 @@ void pb_heater_request_panic_off(const char *reason)   // any task
     // single-SSR-writer invariant by leaving the actual ssr_set(false) to the
     // next pb_heater_tick() on the control task. Callers that need the SSR down
     // fast should wake the control task immediately after this returns.
-    taskENTER_CRITICAL(&s_mux);
-    s_target_c = 0.0f;
-    s_latched_off = true;
-    s_fault_reason = reason ? reason : "panic-off";
-    taskEXIT_CRITICAL(&s_mux);
+    // persist=false: a user panic-off is a manual stop, documented to clear on
+    // reboot (only hazard-driven trips — over-temp/sensor/comms — persist).
+    do_latch(PB_FAULT_PANIC_OFF, reason, /*inhibit=*/false, /*drive_ssr=*/false, /*persist=*/false);
 }
 
-void pb_heater_clear_fault(void)
+esp_err_t pb_heater_clear_fault(void)
 {
+    bool was;
     taskENTER_CRITICAL(&s_mux);
     // A permanent inhibit is NOT clearable — leave everything latched.
     if (s_inhibited) {
         taskEXIT_CRITICAL(&s_mux);
         ESP_LOGW(TAG, "clear ignored: heater permanently inhibited (reboot required)");
-        return;
+        return ESP_ERR_INVALID_STATE;
     }
-    bool was = s_latched_off;
+    was = s_latched_off;
+    taskEXIT_CRITICAL(&s_mux);
+
+    // Persist-first: clear NVS BEFORE RAM so the two never disagree. If the persist
+    // fails, leave the fault latched (fail-safe) and report it — the heater stays
+    // off rather than falsely appearing cleared but returning on the next reboot.
+    esp_err_t err = persist_fault(false, PB_FAULT_NONE);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "clear rejected: NVS clear failed (%s) — fault stays latched", esp_err_to_name(err));
+        return err;
+    }
+    taskENTER_CRITICAL(&s_mux);
     s_latched_off = false;
-    s_target_c = 0.0f;          // reset leaves the target at ZERO — a fresh
-    s_fault_reason = NULL;      // target command is required to resume heating.
+    s_target_c = 0.0f;              // reset leaves the target at ZERO — a fresh
+    s_fault_reason = NULL;          // target command is required to resume heating.
+    s_fault_code = PB_FAULT_NONE;
     taskEXIT_CRITICAL(&s_mux);
     if (was) ESP_LOGW(TAG, "fault latch cleared; target reset to 0 (send a fresh target to resume)");
+    return ESP_OK;
 }
 
 void pb_heater_inhibit(const char *reason)
 {
-    ssr_set(false);
-    taskENTER_CRITICAL(&s_mux);
-    s_inhibited = true;
-    s_latched_off = true;
-    s_target_c = 0.0f;
-    s_fault_reason = reason ? reason : "inhibited";
-    taskEXIT_CRITICAL(&s_mux);
+    // Permanent (reboot-only) -> persist=false: a power cycle must lift it, so
+    // persisting could brick the device across reboots on a transient init failure.
+    // Any clearable latch already in NVS is left intact.
+    do_latch(PB_FAULT_INHIBITED, reason, /*inhibit=*/true, /*drive_ssr=*/true, /*persist=*/false);
     ESP_LOGE(TAG, "HEATER INHIBITED (reboot-only): %s", reason ? reason : "(unspecified)");
 }
 
@@ -263,6 +340,40 @@ const char *pb_heater_fault_reason(void)
     const char *r = s_fault_reason;
     taskEXIT_CRITICAL(&s_mux);
     return r;
+}
+
+pb_fault_reason_t pb_heater_fault_code(void)
+{
+    taskENTER_CRITICAL(&s_mux);
+    pb_fault_reason_t c = s_fault_code;
+    taskEXIT_CRITICAL(&s_mux);
+    return c;
+}
+
+void pb_heater_load_fault(void)
+{
+    nvs_handle_t h;
+    esp_err_t oe = nvs_open(NVS_NS, NVS_READONLY, &h);
+    bool ns_not_found = (oe == ESP_ERR_NVS_NOT_FOUND);
+    bool open_ok      = (oe == ESP_OK);
+    uint8_t latch_val = 0, code_val = PB_FAULT_NONE;
+    bool latch_read_ok = false, latch_not_found = false;
+    if (open_ok) {
+        esp_err_t le = nvs_get_u8(h, KEY_FAULT_LATCH, &latch_val);
+        latch_not_found = (le == ESP_ERR_NVS_NOT_FOUND);
+        latch_read_ok   = (le == ESP_OK);
+        nvs_get_u8(h, KEY_FAULT_CODE, &code_val);   // best-effort; decide() range-checks
+        nvs_close(h);
+    }
+    pb_fault_reason_t code;
+    bool latched = pb_heater_fault_decide(open_ok, ns_not_found, latch_read_ok,
+                                          latch_not_found, latch_val, code_val, &code);
+    if (latched) {
+        // persist=false (already in NVS, or unreadable); drive_ssr=false (init()
+        // already forced the SSR off and the control task is not running yet).
+        do_latch(code, NULL, /*inhibit=*/false, /*drive_ssr=*/false, /*persist=*/false);
+        ESP_LOGW(TAG, "boot: restored latched fault: %s", pb_heater_fault_str(code));
+    }
 }
 
 bool pb_heater_heat_mode(void)     // "armed and not tripped" (independent of SSR cycling)
@@ -296,27 +407,27 @@ void pb_heater_tick(void)          // control-task context; sole writer of s_on
 
     // Over-temp cutoffs — unconditional whenever the sensor reads valid.
     if (ps == PB_NTC_OK && ptc_c >= PB_HEATER_PTC_CUTOFF_C) {
-        pb_heater_emergency_off("PTC element over-temp");
+        trip(PB_FAULT_PTC_OVERTEMP);
         return;
     }
     if (cs == PB_NTC_OK && chamber_c >= PB_HEATER_CHAMBER_MAX_C) {
-        pb_heater_emergency_off("chamber over-temp");
+        trip(PB_FAULT_CHAMBER_OVERTEMP);
         return;
     }
     // While armed, EITHER thermistor being anything other than OK — OPEN, SHORT,
     // or a UNINIT read error — is fail-closed. A blind heater (dead chamber
     // sensor) or an unmonitored element (dead PTC sensor) must latch off.
     if (armed && cs != PB_NTC_OK) {
-        pb_heater_emergency_off("chamber sensor fault");
+        trip(PB_FAULT_CHAMBER_SENSOR);
         return;
     }
     if (armed && ps != PB_NTC_OK) {
-        pb_heater_emergency_off("PTC sensor fault");
+        trip(PB_FAULT_PTC_SENSOR);
         return;
     }
     // Comms-loss watchdog (only while trying to heat).
     if (armed && (esp_timer_get_time() - last_link) > comms_timeout_us) {
-        pb_heater_emergency_off("controller link lost");
+        trip(PB_FAULT_LINK_LOST);
         return;
     }
 

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -340,12 +340,20 @@ static esp_err_t policy_error(
     pb_policy_result_t result,
     const char *request_id)
 {
-    const char *status = result == PB_POLICY_INVALID
-        ? "400 Bad Request" : "409 Conflict";
+    const char *status, *message;
+    if (result == PB_POLICY_INVALID) {
+        status = "400 Bad Request";
+        message = "command rejected by authoritative policy";
+    } else if (result == PB_POLICY_PERSIST_FAILED) {
+        status = "500 Internal Server Error";
+        message = "fault cleared in RAM but persisting it failed; the latch remains";
+    } else {
+        status = "409 Conflict";
+        message = "command rejected by authoritative policy";
+    }
     const char *code = result == PB_POLICY_INVALID
         ? "invalid_command" : pb_policy_result_str(result);
-    return api_error(req, status, code,
-                     "command rejected by authoritative policy", request_id);
+    return api_error(req, status, code, message, request_id);
 }
 
 static esp_err_t command_post(httpd_req_t *req)

--- a/components/pb_policy/include/pb_policy.h
+++ b/components/pb_policy/include/pb_policy.h
@@ -45,6 +45,7 @@ typedef enum {
     PB_POLICY_FAULT_LATCHED,
     PB_POLICY_INHIBITED,
     PB_POLICY_STALE_LEASE,
+    PB_POLICY_PERSIST_FAILED,   // action succeeded in RAM path but NVS persist failed -> HTTP 500
 } pb_policy_result_t;
 
 typedef struct {
@@ -165,6 +166,15 @@ pb_policy_result_t pb_policy_clear_fault(
 // applies the heater/fan outputs, enforces deadlines, and synchronizes safety
 // trips back into the authoritative state.
 void pb_policy_tick(void);
+
+// Pure, session-gated residual-heat purge decision (exposed for host testing).
+// Returns whether the cooldown fan should run and updates *heated_this_session.
+// It purges only after heat ran this session (never on temperature alone), with
+// hysteresis: latch at >= PB_PURGE_LATCH_C on either sensor, release only once
+// BOTH are known below PB_PURGE_RELEASE_C.
+bool pb_purge_decide(bool heat, bool *heated_this_session,
+                     bool chamber_ok, float chamber_c,
+                     bool ptc_ok, float ptc_c, bool prev_cooldown);
 
 // Front-panel button handler.  Short presses toggle the button's labeled mode
 // (re-arming from the remembered parameters); a 2 s long press latches a

--- a/components/pb_policy/pb_policy.c
+++ b/components/pb_policy/pb_policy.c
@@ -732,15 +732,19 @@ bool pb_purge_decide(bool heat, bool *heated_this_session,
     if (heat) { *heated_this_session = true; return false; }  // heating: fan is heat's job
     if (!*heated_this_session) return false;                  // never heated -> no temp-only purge
 
-    bool hot = (chamber_ok && chamber_c >= PB_PURGE_LATCH_C) ||
-               (ptc_ok     && ptc_c     >= PB_PURGE_LATCH_C);
+    // Start the purge unless we can CONFIRM it's cool — i.e. unless BOTH sensors
+    // are known and below the latch temp. So a sensor that's hot, OR unknown right
+    // as heating ends, starts the fan (can't confirm cool -> fail safe) rather than
+    // only starting when a sensor actively reads >= the latch.
+    bool confirmed_cool = (chamber_ok && chamber_c < PB_PURGE_LATCH_C) &&
+                          (ptc_ok     && ptc_c     < PB_PURGE_LATCH_C);
     // Release only once BOTH sensors are KNOWN below the release temp; an unknown
     // (faulted) or still-hot sensor keeps the fan running (fail-safe).
     bool both_cool = (chamber_ok && chamber_c < PB_PURGE_RELEASE_C) &&
                      (ptc_ok     && ptc_c     < PB_PURGE_RELEASE_C);
 
-    bool cooldown = prev_cooldown ? !both_cool   // purging: keep on until both cool
-                                  : hot;          // idle: start only at/above the latch
+    bool cooldown = prev_cooldown ? !both_cool        // purging: keep on until both cool
+                                  : !confirmed_cool;  // idle: start unless confirmed cool
     if (!cooldown) *heated_this_session = false;  // fully cooled -> end the session purge
     return cooldown;
 }

--- a/components/pb_policy/pb_policy.c
+++ b/components/pb_policy/pb_policy.c
@@ -22,7 +22,13 @@
 
 static const char *TAG = "pb_policy";
 
-#define PB_COOLDOWN_TEMP_C          40.0f
+// Session-gated residual-heat purge: after heat ran this boot, keep the fan on
+// while the chamber OR PTC is hot, with hysteresis (latch at >=40 C, release only
+// once BOTH are < 37 C). Session-gated (heated_this_session) so the fan NEVER
+// auto-starts on temperature alone — and because that flag is RAM-only, a
+// power-cycle-while-hot does NOT spin the fan.
+#define PB_PURGE_LATCH_C            40.0f
+#define PB_PURGE_RELEASE_C         37.0f
 #define PB_AUTO_BED_HYSTERESIS_C     3.0f
 #define PB_DRYING_MAX_HOURS         12U
 #define PB_MIN_MODE_TARGET_C        30.0f
@@ -66,6 +72,7 @@ typedef struct {
     int64_t lease_deadline_us;
 
     bool heated_this_session;
+    bool last_cooldown;          // hysteresis memory for the residual-heat purge
     bool last_faulted;
 
     pb_policy_params_t params;   // remembered mode parameters
@@ -567,7 +574,12 @@ pb_policy_result_t pb_policy_clear_fault(
         xSemaphoreGive(s_lock);
         return PB_POLICY_INHIBITED;
     }
-    pb_heater_clear_fault();
+    // Persist-first clear: if the NVS clear fails the heater stays latched, so
+    // surface it (HTTP 500) instead of reporting the fault gone.
+    if (pb_heater_clear_fault() != ESP_OK) {
+        xSemaphoreGive(s_lock);
+        return PB_POLICY_PERSIST_FAILED;
+    }
     s.last_faulted = false;
     set_off_locked(source);
     xSemaphoreGive(s_lock);
@@ -713,6 +725,26 @@ void pb_policy_on_button(pb_button_id_t id, pb_button_event_t ev)
     }
 }
 
+bool pb_purge_decide(bool heat, bool *heated_this_session,
+                     bool chamber_ok, float chamber_c,
+                     bool ptc_ok, float ptc_c, bool prev_cooldown)
+{
+    if (heat) { *heated_this_session = true; return false; }  // heating: fan is heat's job
+    if (!*heated_this_session) return false;                  // never heated -> no temp-only purge
+
+    bool hot = (chamber_ok && chamber_c >= PB_PURGE_LATCH_C) ||
+               (ptc_ok     && ptc_c     >= PB_PURGE_LATCH_C);
+    // Release only once BOTH sensors are KNOWN below the release temp; an unknown
+    // (faulted) or still-hot sensor keeps the fan running (fail-safe).
+    bool both_cool = (chamber_ok && chamber_c < PB_PURGE_RELEASE_C) &&
+                     (ptc_ok     && ptc_c     < PB_PURGE_RELEASE_C);
+
+    bool cooldown = prev_cooldown ? !both_cool   // purging: keep on until both cool
+                                  : hot;          // idle: start only at/above the latch
+    if (!cooldown) *heated_this_session = false;  // fully cooled -> end the session purge
+    return cooldown;
+}
+
 void pb_policy_tick(void)
 {
     if (!s_lock) return;
@@ -806,17 +838,13 @@ void pb_policy_tick(void)
     float chamber_c = pb_ntc_smoothed_c(PB_NTC_CHAMBER);
     bool chamber_ok = pb_ntc_last_status(PB_NTC_CHAMBER) == PB_NTC_OK
                       && isfinite(chamber_c);
+    float ptc_c = pb_ntc_smoothed_c(PB_NTC_PTC);
+    bool ptc_ok = pb_ntc_last_status(PB_NTC_PTC) == PB_NTC_OK && isfinite(ptc_c);
 
-    if (heat) s.heated_this_session = true;
-
-    bool cooldown = false;
-    if (!heat && s.heated_this_session) {
-        if (chamber_ok && chamber_c > PB_COOLDOWN_TEMP_C) {
-            cooldown = true;
-        } else {
-            s.heated_this_session = false;
-        }
-    }
+    bool cooldown = pb_purge_decide(heat, &s.heated_this_session,
+                                    chamber_ok, chamber_c, ptc_ok, ptc_c,
+                                    s.last_cooldown);
+    s.last_cooldown = cooldown;
 
     if (faulted && !s.last_faulted) {
         s.mode = PB_MODE_OFF;
@@ -951,6 +979,7 @@ const char *pb_policy_result_str(pb_policy_result_t result)
         case PB_POLICY_FAULT_LATCHED:     return "fault_latched";
         case PB_POLICY_INHIBITED:         return "inhibited";
         case PB_POLICY_STALE_LEASE:       return "stale_lease";
+        case PB_POLICY_PERSIST_FAILED:    return "persist_failed";
         default:                          return "unknown";
     }
 }

--- a/docs/OEM_PARITY.md
+++ b/docs/OEM_PARITY.md
@@ -4,7 +4,7 @@ DragonBreath is not intended to reproduce the stock firmware byte-for-byte. This
 matrix records which user-visible Panda Breath behaviors are implemented, still
 planned, deliberately changed for safety, or intentionally omitted.
 
-Current as of **v0.4.0**.
+Current as of **v0.6.0**.
 
 | Stock/OEM behavior | DragonBreath status | Notes |
 |---|---|---|
@@ -14,17 +14,17 @@ Current as of **v0.4.0**.
 | Chamber and PTC temperature display | **Implemented** | Both sensors and their health are exposed in the dashboard and API v2 state. |
 | Sensor-fault and over-temperature shutdown | **Implemented** | Heater fails closed; fixed 85 °C chamber and 105 °C PTC cutoffs are not user-configurable. |
 | Fan follows heater | **Implemented** | TRIAC is held on/off and never phase-angle PWM'd. |
-| Residual-heat fan purge | **Partial** | Current cooldown is session-gated. A persisted, opt-in temperature-latched policy is planned; the default will remain session-gated so a warm idle chamber does not start the fan unexpectedly. Fault airflow remains unconditional. |
+| Residual-heat fan purge | **Implemented** | Session-gated cooldown with hysteresis (engage ≥ 40 °C, release only once **both** chamber and PTC are < 37 °C; an unknown sensor keeps the fan on). Strictly session-gated: the fan never starts on temperature alone, and a power-cycle-while-hot does not spin it. The opt-in temperature-latched policy was **intentionally not added** for that reason. Fault airflow remains unconditional. |
 | Front-panel mode LEDs | **Implemented** | All four outputs are driven from the authoritative policy snapshot: Power is solid whenever the device is up and blinks on fault; On, Auto, and Dry each light for their own mode. Auto slow-blinks when armed but not engaged (no Moonraker link, or bed below the threshold). Power is release-only — GPIO21 is also the serial console TX. |
 | Front-panel buttons | **Implemented** | All four (Power GPIO9, Auto GPIO8, On GPIO10, Dry GPIO2) are polled with debounce and short/long-press detection. A short press toggles the button's labeled mode (arming from the remembered parameters); a 2 s long-press latches a panic-off, except a long-press on Power while faulted attempts a fault clear. Every button action is attributed to the panel and invalidates any remote lease. A button held at power-on is ignored until released (GPIO9/8/2 are strapping pins). |
-| Local status/configuration UI | **Implemented** | Responsive work continues, but manual, automatic, drying, safety settings, setup, and OTA controls are present. |
+| Local status/configuration UI | **Implemented** | Responsive, touch-first single-page dashboard with manual/automatic/drying control screens, a settings screen (safety limits, sensor calibration, LEDs), an at-a-glance status panel (fan + reason, controller, auto/drying, printer, fault), and setup/OTA pages. Light/dark themes. |
 | Wi-Fi captive setup and mDNS | **Implemented** | Product identity is DragonBreath; reachable as `dragonbreath.local` when mDNS works. |
 | Firmware update | **Implemented** | Like stock, DragonBreath accepts a local firmware upload from its Web UI. DragonBreath additionally authenticates the write, verifies project identity, refuses updates while heating, and uses dual-slot rollback. |
 | Printer integration | **Implemented for Klipper** | Both stock and DragonBreath can read Klipper bed state through Moonraker. DragonBreath also exposes heater control through its Klipper helper/API v2. Stock additionally supports Bambu MQTT and Home Assistant MQTT; DragonBreath intentionally focuses on Moonraker/Klipper. |
 | Home Assistant MQTT discovery | **Intentionally omitted** | DragonBreath uses HTTP/JSON plus Server-Sent Events; no MQTT broker is required. |
 | Stock WebSocket API and Web UI | **Intentionally omitted** | API v2 and the DragonBreath dashboard are the supported interfaces. |
 | Boot/resume active heating | **Intentionally changed** | DragonBreath always boots OFF and never restores active heat, timers, or leases after reboot. |
-| Persistent fault latch | **Planned** | Current fault state is RAM-only. NVS persistence is tracked as Phase B2 safety work. |
+| Persistent fault latch | **Implemented** | Hazard-driven trips (over-temp, sensor fault, comms-loss) are persisted to NVS on the latching transition and restored at boot, so a device that tripped before losing power comes back up heater-OFF with commands inhibited. Boot restore is fail-safe (unreadable store → latched); a failed persist is retried until it commits; clearing is persist-first (HTTP 500 rather than a false "cleared"). User panic-off and the permanent inhibit are deliberately not persisted (clear on reboot). |
 | Fan-only filtration mode | **Unverified / optional** | Not required for parity until stock behavior is confirmed; may be added as a DragonBreath enhancement. |
 
 Safety takes precedence over exact OEM behavior. See [SAFETY.md](SAFETY.md) for

--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -56,8 +56,10 @@ mode to OFF. It is called **panic-off**, deliberately, and is **not** a
 safety-rated emergency stop — it is software running on the same MCU as the rest
 of the control loop, so a firmware fault could defeat it. The Layer-1 bonded
 cutoff and Layer-2 PTC physics remain the actual emergency layer.
-The panic-off latch is RAM-only and clears on reboot; reboot still starts with
-the SSR, mode, and target OFF, and never restores an active heat command.
+The panic-off latch is RAM-only and clears on reboot (it is a manual stop, not a
+hazard trip); reboot still starts with the SSR, mode, and target OFF, and never
+restores an active heat command. Hazard-driven trips, by contrast, **persist** —
+see below.
 
 How it stays inside the safety model:
 - The button task never writes the SSR GPIO. `pb_policy_request_panic_off()`
@@ -79,6 +81,36 @@ A **long-press on Power while a fault is latched** attempts a fault clear instea
 of a redundant panic. The clear only succeeds if the underlying condition has
 recovered — the next control tick re-evaluates safety and re-latches if the trip
 still holds, so an accidental press cannot revive an unsafe device.
+
+## Persistent fault latch (survives a power cycle)
+A **hazard-driven** safety trip — PTC/chamber over-temp, a sensor fault while
+heating, or the comms-loss watchdog — is written to NVS on the latching
+transition and **restored at boot**. A device that tripped and then lost power
+comes back up **heater-OFF with heat/mode commands inhibited**, rather than
+silently ready to heat, and stays that way until an **explicit** clear after the
+condition has recovered (the next tick re-latches if it hasn't). The persisted
+cause is a small, range-checked numeric code; a live reason string carries
+session detail but is not persisted.
+
+Boot restore is **fail-safe**: if the persisted state cannot be read reliably it
+comes up latched (`persisted fault state unreadable`). A fresh device (no NVS
+namespace yet) is not a fault. Clearing is **persist-first** — the NVS latch is
+cleared *before* the RAM latch, so a failed persist keeps the heater latched and
+the API returns HTTP 500 rather than falsely reporting the fault gone.
+
+This is deliberately separate from heat resume: the persisted latch is the **only**
+fault state that survives a reboot. The active mode, target, deadline, and lease
+are never persisted — the device always boots OFF. The permanent inhibit
+(`pb_heater_inhibit`) is likewise **not** persisted, so a power cycle lifts it (a
+transient init failure must not brick the device across reboots).
+
+## Residual-heat purge (session-gated, hysteresis)
+After heat has run **this session**, the cooldown fan keeps running while the
+chamber **or** PTC sensor is hot, engaging at ≥ 40 °C and releasing only once
+**both** are below 37 °C (an unknown/faulted sensor keeps the fan on). It is
+strictly session-gated: the fan **never** starts on temperature alone, and
+because that gate is RAM-only, a **power-cycle-while-hot does not spin the fan**.
+A fault forces airflow ON unconditionally, independent of this purge.
 
 ## What is NOT protected
 - **Over-current** is only the 6.3 A mains fuse. There is no PCB over-temp cutoff.

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -261,24 +261,26 @@ void app_main(void)
     ESP_ERROR_CHECK(pb_policy_init());
     ESP_ERROR_CHECK(pb_leds_start());       // indicator LEDs (pb_policy drives them)
 
-    // Start the safety/telemetry loop FIRST — it must run regardless of the
-    // network coming up (a blocking/hung network stack must never stop it). The
-    // SSR is already forced off by pb_heater_init(), so nothing can arm heat
-    // before this; there is no need to start command inputs (buttons/HIL) any
-    // earlier, and doing so would let a press arm a target before this task —
-    // the sole actuator — is even running.
-    xTaskCreate(control_task, "pb_control", 4096, NULL, 10, &s_control_task);
-    pb_policy_set_wake_cb(control_wake);     // accepted commands can now wake the loop
-    ESP_LOGI(TAG, "control loop running; heater held OFF (bring-up: no auto-heat)");
-
-    // Bring up networking. If a start call blocks under a flaky link, the control
-    // loop above is already running, so safety + telemetry continue.
+    // Bring up NVS and load persisted config/state BEFORE the control task starts.
+    // NVS is local + fast (unlike network bring-up, which stays after the safety
+    // loop), and the control task must see a restored fault latch on its very first
+    // tick AND be able to persist a fault that trips during early boot — so a
+    // safety trip can never be lost across a reboot for want of an initialized NVS.
     nvs_init();
-    pb_heater_load_config();                 // apply persisted max-target + comms timeout (NVS is up now)
-    pb_heater_load_fault();                   // restore a persisted safety-fault latch (fail-safe on NVS error)
+    pb_heater_load_config();                 // persisted max-target + comms timeout
+    pb_heater_load_fault();                  // restore a persisted safety-fault latch (fail-safe on NVS error)
     pb_ntc_load_calibration();               // persisted per-channel offsets (clamped ±5 °C on load)
     pb_leds_load_config();                   // persisted status-LED master enable (default ON)
     pb_policy_load_params();                 // remembered mode params (never a mode/target — boot stays OFF)
+
+    // Start the safety/telemetry loop — it then runs regardless of the network
+    // coming up (a blocking/hung network stack must never stop it). The SSR is
+    // already forced off by pb_heater_init(), so nothing can arm heat before this;
+    // command inputs (buttons/HIL) start after so a press can't arm a target before
+    // this task — the sole actuator — is running.
+    xTaskCreate(control_task, "pb_control", 4096, NULL, 10, &s_control_task);
+    pb_policy_set_wake_cb(control_wake);     // accepted commands can now wake the loop
+    ESP_LOGI(TAG, "control loop running; heater held OFF (bring-up: no auto-heat)");
 
     // Command inputs come up AFTER the actuator task and the remembered params:
     // a button press arms a mode from those params, so both must exist first.

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -275,6 +275,7 @@ void app_main(void)
     // loop above is already running, so safety + telemetry continue.
     nvs_init();
     pb_heater_load_config();                 // apply persisted max-target + comms timeout (NVS is up now)
+    pb_heater_load_fault();                   // restore a persisted safety-fault latch (fail-safe on NVS error)
     pb_ntc_load_calibration();               // persisted per-channel offsets (clamped ±5 °C on load)
     pb_leds_load_config();                   // persisted status-LED master enable (default ON)
     pb_policy_load_params();                 // remembered mode params (never a mode/target — boot stays OFF)

--- a/tests/pb_heater_fault_host_test.c
+++ b/tests/pb_heater_fault_host_test.c
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+// Host test for the SAFETY-CRITICAL boot-time fault-restore decision
+// (pb_heater_fault_decide) — a pure header inline, verified without an NVS
+// backend. This logic is what guarantees a device that latched a safety fault
+// comes back up LOCKED after a power cycle, and fails SAFE (latched) whenever the
+// persisted fault state cannot be read reliably.
+#include "pb_heater.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define CHECK(expr) do { \
+    if (!(expr)) { \
+        fprintf(stderr, "%s:%d: CHECK failed: %s\n", __FILE__, __LINE__, #expr); \
+        exit(1); \
+    } \
+} while (0)
+
+int main(void)
+{
+    pb_fault_reason_t code;
+
+    // Fresh device: the NVS namespace was never written -> NOT latched.
+    CHECK(pb_heater_fault_decide(false, /*ns_not_found=*/true,
+                                 false, false, 0, 0, &code) == false);
+    CHECK(code == PB_FAULT_NONE);
+
+    // Namespace exists but the latch key was never written -> NOT latched.
+    CHECK(pb_heater_fault_decide(true, false,
+                                 false, /*latch_not_found=*/true, 0, 0, &code) == false);
+    CHECK(code == PB_FAULT_NONE);
+
+    // Latched with a valid stored code -> come up latched with that exact code.
+    CHECK(pb_heater_fault_decide(true, false, /*latch_read_ok=*/true, false,
+                                 1, PB_FAULT_CHAMBER_OVERTEMP, &code) == true);
+    CHECK(code == PB_FAULT_CHAMBER_OVERTEMP);
+
+    // Latch flag == 0 -> not latched even if a stale code sits in NVS.
+    CHECK(pb_heater_fault_decide(true, false, true, false,
+                                 0, PB_FAULT_PTC_OVERTEMP, &code) == false);
+    CHECK(code == PB_FAULT_NONE);
+
+    // Latched but the stored code is out of range (corrupt) -> latch anyway,
+    // mapped to a generic cause rather than trusting the garbage byte.
+    CHECK(pb_heater_fault_decide(true, false, true, false, 1, 250, &code) == true);
+    CHECK(code == PB_FAULT_EMERGENCY);
+
+    // Latched with a NONE(0) code is inconsistent -> also generic, still latched.
+    CHECK(pb_heater_fault_decide(true, false, true, false,
+                                 1, PB_FAULT_NONE, &code) == true);
+    CHECK(code == PB_FAULT_EMERGENCY);
+
+    // FAIL-SAFE: a genuine nvs_open error (not "namespace not found") -> latch.
+    CHECK(pb_heater_fault_decide(/*open_ok=*/false, false, false, false,
+                                 0, 0, &code) == true);
+    CHECK(code == PB_FAULT_NVS_UNREADABLE);
+
+    // FAIL-SAFE: opened OK but the latch key read genuinely failed -> latch.
+    CHECK(pb_heater_fault_decide(true, false, /*latch_read_ok=*/false,
+                                 /*latch_not_found=*/false, 0, 0, &code) == true);
+    CHECK(code == PB_FAULT_NVS_UNREADABLE);
+
+    puts("pb_heater fault-restore checks: PASS");
+    return 0;
+}

--- a/tests/pb_policy_host_test.c
+++ b/tests/pb_policy_host_test.c
@@ -22,6 +22,9 @@ static uint32_t heater_comms_timeout_ms;
 // When set, the "sensor condition" is still unsafe, so the next tick re-latches
 // after any clear -- mirroring pb_heater_tick()'s real re-evaluation.
 static bool heater_relatch;
+// When set, clearing the fault "fails to persist" (NVS write error), so the real
+// heater keeps the latch and pb_heater_clear_fault() returns non-OK.
+static bool heater_clear_persist_fails;
 static uint8_t fan_level;
 static pb_led_pattern_t led_pattern[PB_LED_COUNT];
 static float chamber_c = 25.0f;
@@ -87,12 +90,14 @@ void pb_heater_request_panic_off(const char *reason)
     heater_reason = reason;
 }
 
-void pb_heater_clear_fault(void)
+esp_err_t pb_heater_clear_fault(void)
 {
-    if (heater_inhibited) return;
+    if (heater_inhibited) return ESP_ERR_INVALID_STATE;
+    if (heater_clear_persist_fails) return ESP_FAIL;   // persist-first failure: stays latched
     heater_fault = false;
     heater_target = 0.0f;
     heater_reason = NULL;
+    return ESP_OK;
 }
 
 bool pb_heater_is_inhibited(void) { return heater_inhibited; }
@@ -866,6 +871,59 @@ static void test_button_power_long_clears_or_holds_fault(void)
     CHECK(snapshot().mode == PB_MODE_OFF);
 }
 
+// B2: clearing a fault whose NVS persist fails must leave the heater LATCHED and
+// report PERSIST_FAILED (never falsely appear cleared, since it would return on reboot).
+static void test_fault_clear_persist_failure_stays_latched(void)
+{
+    reset_fixture();
+    heater_fault = true;
+    heater_reason = "test fault";
+    heater_clear_persist_fails = true;
+    pb_policy_snapshot_t snap = snapshot();
+    CHECK(pb_policy_clear_fault(PB_SOURCE_WEB, snap.state_revision) == PB_POLICY_PERSIST_FAILED);
+    CHECK(heater_fault);                         // stays latched (fail-safe)
+    heater_clear_persist_fails = false;          // persistence recovers
+    snap = snapshot();
+    CHECK(pb_policy_clear_fault(PB_SOURCE_WEB, snap.state_revision) == PB_POLICY_OK);
+    CHECK(!heater_fault);
+}
+
+// B2: the residual-heat purge is session-gated (never temperature-only, so a
+// reboot-while-hot does NOT spin the fan) with 40 C-latch / 37 C-release hysteresis
+// over BOTH the chamber and PTC sensors.
+static void test_purge_decide_session_and_hysteresis(void)
+{
+    bool heated = false;
+    // Never heated this session -> no purge even when hot. This is EXACTLY the
+    // reboot-while-hot case (the heated flag is RAM-only and starts false).
+    CHECK(pb_purge_decide(false, &heated, true, 60.0f, true, 60.0f, false) == false);
+    CHECK(heated == false);
+
+    // Actively heating marks the session; the fan is heat control's job, not purge.
+    CHECK(pb_purge_decide(true, &heated, true, 55.0f, true, 55.0f, false) == false);
+    CHECK(heated == true);
+
+    // Heat stops while hot (chamber >= 40) -> purge starts.
+    CHECK(pb_purge_decide(false, &heated, true, 50.0f, true, 30.0f, false) == true);
+    // Hysteresis: drifts into the 37-40 band while purging -> stays on.
+    CHECK(pb_purge_decide(false, &heated, true, 38.0f, true, 30.0f, true) == true);
+    // Releases only once BOTH sensors are below 37.
+    CHECK(pb_purge_decide(false, &heated, true, 36.9f, true, 36.0f, true) == false);
+    CHECK(heated == false);                      // fully cooled -> session ends
+
+    // Stopping in the band (38 C, below the 40 latch) does NOT start a purge.
+    heated = true;
+    CHECK(pb_purge_decide(false, &heated, true, 38.0f, true, 30.0f, false) == false);
+
+    // PTC alone hot (chamber cool) still triggers the purge.
+    heated = true;
+    CHECK(pb_purge_decide(false, &heated, true, 25.0f, true, 45.0f, false) == true);
+
+    // A faulted/unknown sensor while purging keeps the fan on (can't confirm cool).
+    heated = true;
+    CHECK(pb_purge_decide(false, &heated, false, 0.0f, true, 30.0f, true) == true);
+}
+
 int main(void)
 {
     test_boot_is_off();
@@ -893,6 +951,8 @@ int main(void)
     test_button_rejection_is_logged_without_wake();
     test_button_long_press_panic_off();
     test_button_power_long_clears_or_holds_fault();
+    test_fault_clear_persist_failure_stays_latched();
+    test_purge_decide_session_and_hysteresis();
     puts("pb_policy host tests: PASS");
     return 0;
 }

--- a/tests/pb_policy_host_test.c
+++ b/tests/pb_policy_host_test.c
@@ -922,6 +922,15 @@ static void test_purge_decide_session_and_hysteresis(void)
     // A faulted/unknown sensor while purging keeps the fan on (can't confirm cool).
     heated = true;
     CHECK(pb_purge_decide(false, &heated, false, 0.0f, true, 30.0f, true) == true);
+
+    // Sensors UNKNOWN exactly as heating ends (prev=false) -> START the purge: we
+    // can't confirm it's cool, so fail safe rather than skipping the cooldown.
+    heated = true;
+    CHECK(pb_purge_decide(false, &heated, false, 0.0f, false, 0.0f, false) == true);
+    // ...but a single known-cool sensor with the other unknown still can't confirm
+    // cool -> also purge (conservative).
+    heated = true;
+    CHECK(pb_purge_decide(false, &heated, true, 25.0f, false, 0.0f, false) == true);
 }
 
 int main(void)

--- a/tests/run_heater_fault_host_test.sh
+++ b/tests/run_heater_fault_host_test.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+out="${TMPDIR:-/tmp}/dragonbreath-pb-heater-fault-test"
+
+# The real pb_heater.h must win over the tests/stubs one (it carries the fault
+# enum + the pure pb_heater_fault_decide inline), so its include dir comes FIRST;
+# esp_err.h is picked up from the stubs.
+cc -std=c11 -Wall -Wextra -Werror \
+  -I"$root/components/pb_heater/include" \
+  -I"$root/tests/stubs" \
+  "$root/tests/pb_heater_fault_host_test.c" \
+  -o "$out"
+
+"$out"

--- a/tests/stubs/esp_err.h
+++ b/tests/stubs/esp_err.h
@@ -1,6 +1,7 @@
 #pragma once
 typedef int esp_err_t;
 #define ESP_OK 0
+#define ESP_FAIL -1
 #define ESP_ERR_NO_MEM 0x101
 #define ESP_ERR_INVALID_ARG 0x102
 #define ESP_ERR_INVALID_STATE 0x103

--- a/tests/stubs/pb_heater.h
+++ b/tests/stubs/pb_heater.h
@@ -14,7 +14,7 @@ void pb_heater_notify_link_alive(void);
 void pb_heater_tick(void);
 void pb_heater_emergency_off(const char *reason);
 void pb_heater_request_panic_off(const char *reason);
-void pb_heater_clear_fault(void);
+esp_err_t pb_heater_clear_fault(void);
 bool pb_heater_is_inhibited(void);
 bool pb_heater_is_faulted(void);
 const char *pb_heater_fault_reason(void);


### PR DESCRIPTION
Implements **B2** from the iteration-2 roadmap — the deferred safety work — as an independently-reviewable PR. Two features:

## 1. Persistent fault latch (`pb_heater`)
Previously a latched safety fault was RAM-only, so a power cycle cleared it and the device could come back up ready to heat.

- A **hazard-driven** trip (PTC/chamber over-temp, sensor fault while heating, comms-loss watchdog) is now written to NVS on the latching transition and **restored at boot** → device comes up **heater-OFF, commands inhibited** until an explicit clear after the condition recovers.
- Persisted cause is a stable **`u8` enum** (`pb_fault_reason_t`); a live reason string still carries session detail (design decision: enum for the persisted code + RAM string for detail).
- Boot restore is **fail-safe**, via a pure header-inline `pb_heater_fault_decide()`: unreadable store → latched; corrupt code → generic latch; fresh device (no namespace) → not a fault.
- Clearing is **persist-first**: `pb_heater_clear_fault()` clears NVS before RAM and returns `esp_err_t`; a failed persist keeps the latch and surfaces as **HTTP 500** (`PB_POLICY_PERSIST_FAILED`) — never a false "cleared".
- **Not** persisted: the user **panic-off** (documented reboot-clears manual stop) and the permanent **inhibit** (a power cycle must lift it). Active mode/target/deadline/lease still never persist — boot stays OFF.

## 2. Hardened residual-heat purge (`pb_policy`)
The session-gated cooldown fan now has proper **hysteresis** (engage at ≥ 40 °C, release only once **both** chamber and PTC are < 37 °C; an unknown/faulted sensor keeps the fan on) instead of a single chamber-only threshold — factored into a pure `pb_purge_decide()`.
- Still strictly **session-gated**: never starts on temperature alone, and a **power-cycle-while-hot does not spin the fan** (honors the prior explicit decision on this).

## Tests / CI
- New `tests/run_heater_fault_host_test.sh` (fail-safe boot-restore decision) **wired into `firmware-build.yml`** as a required step.
- `pb_policy` host test gains purge-hysteresis and persist-failure-clear cases.
- All host tests + contract/dashboard gates pass locally; ESP-IDF build clean.

## Validation
Bench OTA confirmed a normal device (existing `app_nvs`, no fault keys) boots **un-latched** (`fault_latched=false`, mode off) — no false fail-safe trip. A real over-temp can't be forced safely on the bench, so the fail-safe/persistence decision logic is covered by the host tests.

Docs: `SAFETY.md` (persistent-fault + purge sections) and `CHANGELOG` updated. Ships as **v0.6.0** after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)