### PR TITLE
fix(httpd): stop SSE slot leak that froze the live UI (v0.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-07-24
+
+### Fixed
+- **Live UI could silently stop updating (SSE slot leak).** The device caps
+  concurrent SSE event streams at 2, but a client that disconnected without a
+  clean close (tab killed, Wi-Fi blip, or a Moonraker-link flap churning the
+  network) held its slot for *minutes* — so after a couple of such drops every new
+  stream got `503` and the dashboard/Klipper live view froze even though the device
+  itself was fine and responsive. TCP keepalive is now enabled on the HTTP server
+  so a vanished peer is detected in ~25 s, and the SSE task additionally checks for
+  a peer FIN/RST every loop and frees the slot immediately (~0.3 s on the bench).
+  Normal (non-SSE) request latency was already healthy (~20 ms) and is unchanged.
+
 ## [0.5.1] - 2026-07-24
 
 ### Fixed

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -20,6 +20,8 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "mbedtls/sha256.h"
+#include "lwip/sockets.h"   // recv(), MSG_DONTWAIT/MSG_PEEK for SSE FIN detection
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -539,9 +541,22 @@ static esp_err_t sse_send(
 static void sse_task(void *arg)
 {
     httpd_req_t *req = arg;
+    int sockfd = httpd_req_to_sockfd(req);
     uint32_t last_revision = UINT32_MAX;
     int64_t last_telemetry_us = 0;
     for (;;) {
+        // Detect a client that closed the stream (FIN) or reset it, so the SSE
+        // slot is freed promptly instead of waiting for a telemetry send to fail.
+        // A live client never sends on this stream, so MSG_PEEK is non-destructive:
+        // 0 = peer closed, <0 with a real error = reset, EWOULDBLOCK = still alive.
+        // (Keepalive, set on the httpd socket, backstops a peer that vanishes with
+        // no FIN by erroring the socket after ~25 s of unacked traffic.)
+        if (sockfd >= 0) {
+            char probe;
+            int pk = recv(sockfd, &probe, 1, MSG_DONTWAIT | MSG_PEEK);
+            if (pk == 0 || (pk < 0 && errno != EWOULDBLOCK && errno != EAGAIN))
+                break;
+        }
         pb_policy_snapshot_t snap;
         pb_policy_get_snapshot(&snap);
         int64_t now = esp_timer_get_time();
@@ -1039,6 +1054,19 @@ esp_err_t pb_httpd_start(void)
     // app descriptor on-stack, which overflows the 4 KB default httpd task stack
     // (stack-protection panic). Give it headroom.
     cfg.stack_size = 8192;
+    // TCP keepalive on every accepted socket. The SSE stream (GET /api/v2/events,
+    // capped at SSE_MAX_CLIENTS) only frees its client slot when a send fails; a
+    // peer that vanishes without a clean FIN/RST (tab killed, Wi-Fi blip, or a
+    // Moonraker-link flap churning the network) otherwise holds its slot for
+    // MINUTES while writes succeed into the TCP buffer, so after a couple of leaks
+    // every SSE gets 503 and the live UI silently stops updating. Keepalive tracks
+    // time since the last *received* segment, so a dead peer (no ACKs) is detected
+    // even while we keep streaming telemetry: ~idle + interval*count ≈ 25 s, after
+    // which the socket errors, the send fails, and the slot is reclaimed.
+    cfg.keep_alive_enable   = true;
+    cfg.keep_alive_idle     = 10;   // s idle (no rx) before the first probe
+    cfg.keep_alive_interval = 5;    // s between probes
+    cfg.keep_alive_count    = 3;    // probes before the socket is declared dead
     esp_err_t err = httpd_start(&s_server, &cfg);
     if (err != ESP_OK) return err;
 


### PR DESCRIPTION
Fixes the real remaining cause of the "device web UI goes unresponsive" report, found by re-testing on v0.5.1. Targets a **v0.5.2** patch.

## The bug
The SSE event stream (`GET /api/v2/events`) is capped at 2 concurrent clients, but a slot was only freed when a *send failed*, and **no TCP keepalive** was configured. A client that disconnected without a clean FIN/RST — tab killed, Wi-Fi blip, or the pv_moonraker WS flap churning the network — held its slot for **minutes** (writes keep succeeding into the TCP buffer). After ~2 such leaks, every new stream gets `503` → the dashboard/Klipper **live view freezes**, even though the device is otherwise fine.

Verified live: `sse_clients` was stuck at **1 with nobody connected** for 25 s+.

## The fix
- **httpd TCP keepalive** (idle 10 s / interval 5 s / count 3): keepalive tracks time since the last *received* segment, so a vanished peer (no ACKs) is detected in ~25 s even while we keep streaming telemetry → the send errors → the slot is reclaimed.
- **`sse_task` FIN/RST check**: a non-blocking `MSG_PEEK` recv each loop frees the slot immediately on a clean close.

## Validation (bench, live)
- Clean-close (FIN) and abrupt (RST) clients both reaped in **~0.3 s**.
- Fresh boot: `sse_clients=0` (was stuck at 1).
- SSE cap (2) and 3rd-client `503` unchanged; normal request latency ~20 ms unchanged.

The silent-vanish case (no FIN, ~25 s keepalive path) can't be forced on the bench without packet dropping, so it's covered by the keepalive config + reasoning. The outbound Moonraker WS flap remains Justin's shared-core PR — this fixes only our inbound-SSE half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)