### PR TITLE
feat(ui): restore fan + controller status on the dashboard (v0.5.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-07-24
+
+### Fixed
+- **Live UI could silently stop updating (SSE slot leak).** The device caps
+  concurrent SSE event streams at 2, but a client that disconnected without a
+  clean close (tab killed, Wi-Fi blip, or a Moonraker-link flap churning the
+  network) held its slot for *minutes* — so after a couple of such drops every new
+  stream got `503` and the dashboard/Klipper live view froze even though the device
+  itself was fine and responsive. TCP keepalive is now enabled on the HTTP server
+  so a vanished peer is detected in ~25 s, and the SSE task additionally checks for
+  a peer FIN/RST every loop and frees the slot immediately (~0.3 s on the bench).
+  Normal (non-SSE) request latency was already healthy (~20 ms) and is unchanged.
+
 ## [0.5.1] - 2026-07-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,6 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
-## [0.5.3] - 2026-07-24
-
-### Fixed
-- **Dashboard shows fan and controller status again (regression from v0.5.0).**
-  The rewritten dashboard dropped the old at-a-glance detail, so you could no
-  longer tell what the fan was doing or who was in control. The System status card
-  now shows **Fan** (off, or on with the reason — heating / cooldown purge /
-  manual / safety airflow — and %), **Controller** (command source + lease owner),
-  **Auto** (engaged or waiting, with the bed threshold, when armed), **Drying**
-  (time remaining, when active), **Printer** (Moonraker link + bed temperature),
-  and **Fault**. All of it comes from the existing SSE `/api/v2/state` stream — no
-  API or firmware-behavior change.
-
 ## [0.5.2] - 2026-07-24
 
 ### Fixed
@@ -32,6 +19,15 @@ below into the GitHub Release notes.
   so a vanished peer is detected in ~25 s, and the SSE task additionally checks for
   a peer FIN/RST every loop and frees the slot immediately (~0.3 s on the bench).
   Normal (non-SSE) request latency was already healthy (~20 ms) and is unchanged.
+- **Dashboard shows fan and controller status again (regression from v0.5.0).**
+  The rewritten dashboard dropped the old at-a-glance detail, so you could no
+  longer tell what the fan was doing or who was in control. The System status card
+  now shows **Fan** (off, or on with the reason — heating / cooldown purge /
+  manual / safety airflow — and %), **Controller** (command source + lease owner),
+  **Auto** (engaged or waiting, with the bed threshold, when armed), **Drying**
+  (time remaining, when active), **Printer** (Moonraker link + bed temperature),
+  and **Fault**. All of it comes from the existing SSE `/api/v2/state` stream — no
+  API or firmware-behavior change.
 
 ## [0.5.1] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-07-24
+
+### Fixed
+- **Dashboard shows fan and controller status again (regression from v0.5.0).**
+  The rewritten dashboard dropped the old at-a-glance detail, so you could no
+  longer tell what the fan was doing or who was in control. The System status card
+  now shows **Fan** (off, or on with the reason — heating / cooldown purge /
+  manual / safety airflow — and %), **Controller** (command source + lease owner),
+  **Auto** (engaged or waiting, with the bed threshold, when armed), **Drying**
+  (time remaining, when active), **Printer** (Moonraker link + bed temperature),
+  and **Fault**. All of it comes from the existing SSE `/api/v2/state` stream — no
+  API or firmware-behavior change.
+
 ## [0.5.2] - 2026-07-24
 
 ### Fixed

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -20,6 +20,8 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "mbedtls/sha256.h"
+#include "lwip/sockets.h"   // recv(), MSG_DONTWAIT/MSG_PEEK for SSE FIN detection
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -539,9 +541,22 @@ static esp_err_t sse_send(
 static void sse_task(void *arg)
 {
     httpd_req_t *req = arg;
+    int sockfd = httpd_req_to_sockfd(req);
     uint32_t last_revision = UINT32_MAX;
     int64_t last_telemetry_us = 0;
     for (;;) {
+        // Detect a client that closed the stream (FIN) or reset it, so the SSE
+        // slot is freed promptly instead of waiting for a telemetry send to fail.
+        // A live client never sends on this stream, so MSG_PEEK is non-destructive:
+        // 0 = peer closed, <0 with a real error = reset, EWOULDBLOCK = still alive.
+        // (Keepalive, set on the httpd socket, backstops a peer that vanishes with
+        // no FIN by erroring the socket after ~25 s of unacked traffic.)
+        if (sockfd >= 0) {
+            char probe;
+            int pk = recv(sockfd, &probe, 1, MSG_DONTWAIT | MSG_PEEK);
+            if (pk == 0 || (pk < 0 && errno != EWOULDBLOCK && errno != EAGAIN))
+                break;
+        }
         pb_policy_snapshot_t snap;
         pb_policy_get_snapshot(&snap);
         int64_t now = esp_timer_get_time();
@@ -1039,6 +1054,19 @@ esp_err_t pb_httpd_start(void)
     // app descriptor on-stack, which overflows the 4 KB default httpd task stack
     // (stack-protection panic). Give it headroom.
     cfg.stack_size = 8192;
+    // TCP keepalive on every accepted socket. The SSE stream (GET /api/v2/events,
+    // capped at SSE_MAX_CLIENTS) only frees its client slot when a send fails; a
+    // peer that vanishes without a clean FIN/RST (tab killed, Wi-Fi blip, or a
+    // Moonraker-link flap churning the network) otherwise holds its slot for
+    // MINUTES while writes succeed into the TCP buffer, so after a couple of leaks
+    // every SSE gets 503 and the live UI silently stops updating. Keepalive tracks
+    // time since the last *received* segment, so a dead peer (no ACKs) is detected
+    // even while we keep streaming telemetry: ~idle + interval*count ≈ 25 s, after
+    // which the socket errors, the send fails, and the slot is reclaimed.
+    cfg.keep_alive_enable   = true;
+    cfg.keep_alive_idle     = 10;   // s idle (no rx) before the first probe
+    cfg.keep_alive_interval = 5;    // s between probes
+    cfg.keep_alive_count    = 3;    // probes before the socket is declared dead
     esp_err_t err = httpd_start(&s_server, &cfg);
     if (err != ESP_OK) return err;
 

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -191,7 +191,15 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
 .app[data-state="drying"] .state-light{ background: var(--viz-series-1); }
 .app[data-state="waiting"] .state-light{ background: var(--viz-series-3); }
 .app[data-state="fault"] .state-light{ background: var(--destructive); }
-.summary{ min-height: 36px; color: var(--muted-foreground); font-size: 12px; }
+.summary{ min-height: 18px; color: var(--muted-foreground); font-size: 12px; }
+.status-detail{ margin: 4px 0; min-height: 0; flex: 1 1 auto; overflow: auto;
+  display: flex; flex-direction: column; gap: 2px; font-size: 12px; }
+.status-detail > div{ display: flex; align-items: baseline; justify-content: space-between;
+  gap: 10px; padding: 3px 0; border-bottom: 1px solid var(--border); }
+.status-detail > div:last-child{ border-bottom: 0; }
+.status-detail dt{ color: var(--muted-foreground); flex: none; }
+.status-detail dd{ margin: 0; text-align: right; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .actions{ display: flex; gap: 6px; margin-top: auto; }
 .actions .btn{ flex: 1; }
 
@@ -393,6 +401,14 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
           <h3>System status</h3>
           <div class="state"><i class="state-light"></i><span id="db-status">--</span></div>
           <div class="summary" id="db-summary"></div>
+          <dl class="status-detail">
+            <div><dt>Fan</dt><dd id="db-fan">--</dd></div>
+            <div><dt>Controller</dt><dd id="db-controller">--</dd></div>
+            <div id="db-auto-row" hidden><dt>Auto</dt><dd id="db-auto">--</dd></div>
+            <div id="db-drying-row" hidden><dt>Drying</dt><dd id="db-drying">--</dd></div>
+            <div><dt>Printer</dt><dd id="db-printer">--</dd></div>
+            <div><dt>Fault</dt><dd id="db-fault">--</dd></div>
+          </dl>
           <div class="actions">
             <button class="btn btn-sm" type="button" id="db-clear" hidden><svg class="icon"><use href="#i-refresh"/></svg> Clear fault</button>
             <button class="btn btn-primary btn-sm" type="button" id="db-stop" disabled><svg class="icon"><use href="#i-power"/></svg> Stop</button>
@@ -752,6 +768,22 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
     if(c){ c.setAttribute('aria-label', online?'Connection: online':'Connection: offline'); c.title = online?'Online':'Offline'; }
   }
 
+  function sourceLabel(src){
+    return ({web:'Web UI', klipper:'Klipper', button:'Front panel', boot:'—',
+             safety:'Safety', watchdog:'Watchdog'})[src] || src || '—';
+  }
+  function fanLabel(s){
+    var f=s.fan||{}, why=({heater:'heating', thermal_purge:'cooldown purge',
+                           requested:'manual', fault:'safety airflow'})[f.reason];
+    if(f.reason==='off' || (!why && !f.effective_percent)) return 'Off';
+    return 'On — '+(why||f.reason)+(f.effective_percent? ' ('+f.effective_percent+'%)':'');
+  }
+  function controllerLabel(s){
+    var l=(s.control||{}).lease||{};
+    if(l.active) return sourceLabel(s.source)+(l.owner? ' ('+l.owner+')':'');
+    return s.mode==='off' ? '—' : sourceLabel(s.source);
+  }
+
   function apply(s){
     if(!s || s.api_version!==2) return;
     if(last && s.boot_id===last.boot_id && s.state_revision<rev) return;
@@ -768,6 +800,22 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
     app.setAttribute('data-state', st);
     u('db-status', statusLabel(st, s));
     u('db-summary', summary(st, s));
+
+    /* At-a-glance detail rows — all from the SSE snapshot. */
+    u('db-fan', fanLabel(s));
+    u('db-controller', controllerLabel(s));
+    var autoRow = s.mode==='auto';
+    $('db-auto-row').hidden = !autoRow;
+    if(autoRow) u('db-auto', (s.environment.auto_engaged?'engaged':'waiting')
+      +' @ bed ≥'+Math.round(s.environment.auto_bed_threshold_c)+' °C');
+    var dryRow = s.drying.active;
+    $('db-drying-row').hidden = !dryRow;
+    if(dryRow) u('db-drying', fmtDur(s.drying.remaining_seconds)+' left');
+    u('db-printer', s.environment.moonraker_connected
+      ? 'connected'+(s.environment.bed_temperature_c!=null ? ' · bed '+Math.round(s.environment.bed_temperature_c)+' °C' : '')
+      : 'not connected');
+    u('db-fault', s.safety.inhibited ? ('inhibited: '+(s.safety.reason||'unknown'))
+      : s.safety.fault_latched ? ('latched: '+(s.safety.reason||'unknown')) : 'none');
 
     /* progress bar: chamber vs. effective target */
     var pct=0;


### PR DESCRIPTION
Restores the at-a-glance status the v0.5.0 rewrite dropped — you could no longer see what the **fan** was doing (e.g. running for a cooldown purge) or **who was in control**. Targets **v0.5.3**.

**Stacked on #25 (SSE fix / 0.5.2)** — base is `fix/sse-keepalive` so this diff is just the dashboard change. Merge order: #25 → tag 0.5.2, then retarget/merge this → tag 0.5.3.

## Change (frontend only)
The dashboard's **System status** card now shows:
- **Fan** — off, or on with the reason (`heating` / `cooldown purge` / `manual` / `safety airflow`) + %
- **Controller** — command source (Web UI / Klipper / Front panel) + lease owner
- **Auto** — engaged or waiting + bed threshold (shown only when AUTO is armed)
- **Drying** — time remaining (shown only when drying)
- **Printer** — Moonraker link + bed temperature
- **Fault** — latched/inhibited reason, or none

All values come straight from the existing SSE `/api/v2/state` stream — **no API or firmware-behavior change**.

## Validation (bench, live)
Rendered at panel (1040×660) and compact (460×380), dark theme:
- Idle → Fan Off, Controller —, Printer connected · bed 27 °C, Fault none (Auto/Drying rows hidden).
- AUTO armed (no heat, bed below threshold) → Controller **Web UI**, Auto **waiting @ bed ≥100 °C**, status **Waiting**.
Contract + build pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)