### PR TITLE
feat(heater): element-temperature foldback limiter below the 105 °C cutoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+### Added
+- **Element-temperature foldback limiter.** Instead of driving the heater full-power
+  into the 105 °C PTC-element cutoff and hard-faulting, the SSR duty is now linearly
+  folded back once the element climbs into `[100 °C, 105 °C)`, so it *holds* just under
+  the cutoff and the chamber keeps warming instead of tripping. On a hot/marginal
+  install this replaces the "trip → clear → trip again" loop with a stable (if slower)
+  approach to set-point. Because the SSR is a zero-cross type, the duty is applied by
+  time-proportioning (a first-order sigma-delta) across the 2 Hz control ticks. **Safety
+  is unchanged:** the foldback can only ever *reduce* power, and the hard 105 °C cutoff
+  remains the first, unconditional, latching check — if the element still reaches it
+  (welded SSR, runaway, sensor fault) it latches off exactly as before. The pure
+  foldback curve is covered by host tests.
+
 ## [0.6.2] - 2026-07-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ below into the GitHub Release notes.
 ### Added
 - **Element-temperature foldback limiter.** Instead of driving the heater full-power
   into the 105 °C PTC-element cutoff and hard-faulting, the SSR duty is now linearly
-  folded back once the element climbs into `[100 °C, 105 °C)`, so it *holds* just under
+  folded back once the element climbs into `[102 °C, 105 °C)`, so it *holds* just under
   the cutoff and the chamber keeps warming instead of tripping. On a hot/marginal
   install this replaces the "trip → clear → trip again" loop with a stable (if slower)
   approach to set-point. Because the SSR is a zero-cross type, the duty is applied by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ below into the GitHub Release notes.
 ### Added
 - **Element-temperature foldback limiter.** Instead of driving the heater full-power
   into the 105 °C PTC-element cutoff and hard-faulting, the SSR duty is now linearly
-  folded back once the element climbs into `[102 °C, 105 °C)`, so it *holds* just under
+  folded back once the element climbs into `[100 °C, 105 °C)`, so it *holds* just under
   the cutoff and the chamber keeps warming instead of tripping. On a hot/marginal
   install this replaces the "trip → clear → trip again" loop with a stable (if slower)
   approach to set-point. Because the SSR is a zero-cross type, the duty is applied by

--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ DragonBreath mirrors OpenVent's ESP-IDF + `components/` layout on purpose, so th
 shared core (WiFi, captive portal, Moonraker client) is lifted in rather than
 re-implemented.
 
-> ⚠️ **Hardware validated on board revisions V1.0.1 and V1.0.** The pin map,
-> sensor conversion, and heater/fan actuation were reverse-engineered on a V1.0.1
-> board and are **confirmed working on a V1.0 board** as well (boot, OTA, heat
-> cycle, and the element-foldback limiter all validated on V1.0). Other Panda
-> Breath revisions are untested — **verify the pinout against your own board
-> before flashing.** This is community firmware with no warranty — read
-> [`docs/SAFETY.md`](docs/SAFETY.md) and supervise early runs.
+> ⚠️ **Hardware validated on board revision V1.0.1 only.** The pin map, sensor
+> conversion, and heater/fan actuation were reverse-engineered and validated on a
+> V1.0.1 board (boot, OTA, heat cycle, and the element-foldback limiter). A V1.0
+> board appears functionally identical (same PSU, SSR, NTCs, and pinout) and is
+> **expected** to work, but that is **not yet confirmed on hardware** — feedback
+> from a V1.0 user is pending. Other Panda Breath revisions are untested —
+> **verify the pinout against your own board before flashing.** This is community
+> firmware with no warranty — read [`docs/SAFETY.md`](docs/SAFETY.md) and
+> supervise early runs.
 
 **Docs:** full feature set → [`docs/FEATURES.md`](docs/FEATURES.md) · control API →
 [`docs/api-v2.md`](docs/api-v2.md) · safety model → [`docs/SAFETY.md`](docs/SAFETY.md) ·
@@ -26,7 +28,7 @@ OEM parity → [`docs/OEM_PARITY.md`](docs/OEM_PARITY.md) · hardware →
 ## Status
 | Component | State |
 |---|---|
-| `pb_board` | ✅ Pinout RE'd (V1.0.1); boots on hardware (V1.0.1 + V1.0 confirmed) |
+| `pb_board` | ✅ Pinout RE'd (V1.0.1); boots on hardware (V1.0.1 confirmed; V1.0 pending) |
 | `pb_ntc` | ✅ Stock conversion ported; **hardware-validated** (reads chamber temp matching the printer) |
 | `pb_heater` | ✅ Bang-bang + full safety cutoffs; SSR confirmed, heat cycle validated on hardware |
 | `pb_fan` | ✅ TRIAC **on/off held-gate** (stock model — the gate is never PWM'd/phase-chopped) |
@@ -70,7 +72,8 @@ auto / light / dark toggle are built in.
 ESP32-C3-MINI-1, mains PSU, PTC heater via SSR (GPIO18), ~220 VAC blower switched
 by a **TRIAC held on/off** (GPIO3 gate + GPIO7 zero-cross — **never** phase-angle
 PWM'd), two NTCs on ADC1. Full map: [`docs/HARDWARE.md`](docs/HARDWARE.md).
-Reverse-engineered from a **V1.0.1** board; also confirmed working on **V1.0**.
+Reverse-engineered and validated on a **V1.0.1** board (**V1.0** looks identical
+but is not yet hardware-confirmed).
 
 ## Safety
 Two independent **hardware** over-temp backstops (a bonded thermal cutoff in the

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ DragonBreath mirrors OpenVent's ESP-IDF + `components/` layout on purpose, so th
 shared core (WiFi, captive portal, Moonraker client) is lifted in rather than
 re-implemented.
 
-> ⚠️ **Hardware tested on a single board revision (V1.0.1) only.** That is the
-> only unit available for testing; the pin map, sensor conversion, and
-> heater/fan actuation are validated against it and may differ on other Panda
-> Breath board revisions. **Verify the pinout against your own board before
-> flashing.** Heater control is functional and hardware-validated on V1.0.1, but
-> this is community firmware with no warranty — read [`docs/SAFETY.md`](docs/SAFETY.md)
-> and supervise early runs.
+> ⚠️ **Hardware validated on board revisions V1.0.1 and V1.0.** The pin map,
+> sensor conversion, and heater/fan actuation were reverse-engineered on a V1.0.1
+> board and are **confirmed working on a V1.0 board** as well (boot, OTA, heat
+> cycle, and the element-foldback limiter all validated on V1.0). Other Panda
+> Breath revisions are untested — **verify the pinout against your own board
+> before flashing.** This is community firmware with no warranty — read
+> [`docs/SAFETY.md`](docs/SAFETY.md) and supervise early runs.
 
 **Docs:** full feature set → [`docs/FEATURES.md`](docs/FEATURES.md) · control API →
 [`docs/api-v2.md`](docs/api-v2.md) · safety model → [`docs/SAFETY.md`](docs/SAFETY.md) ·
@@ -26,7 +26,7 @@ OEM parity → [`docs/OEM_PARITY.md`](docs/OEM_PARITY.md) · hardware →
 ## Status
 | Component | State |
 |---|---|
-| `pb_board` | ✅ Pinout RE'd (V1.0.1); boots on hardware |
+| `pb_board` | ✅ Pinout RE'd (V1.0.1); boots on hardware (V1.0.1 + V1.0 confirmed) |
 | `pb_ntc` | ✅ Stock conversion ported; **hardware-validated** (reads chamber temp matching the printer) |
 | `pb_heater` | ✅ Bang-bang + full safety cutoffs; SSR confirmed, heat cycle validated on hardware |
 | `pb_fan` | ✅ TRIAC **on/off held-gate** (stock model — the gate is never PWM'd/phase-chopped) |
@@ -70,7 +70,7 @@ auto / light / dark toggle are built in.
 ESP32-C3-MINI-1, mains PSU, PTC heater via SSR (GPIO18), ~220 VAC blower switched
 by a **TRIAC held on/off** (GPIO3 gate + GPIO7 zero-cross — **never** phase-angle
 PWM'd), two NTCs on ADC1. Full map: [`docs/HARDWARE.md`](docs/HARDWARE.md).
-Reverse-engineered from a **V1.0.1** board.
+Reverse-engineered from a **V1.0.1** board; also confirmed working on **V1.0**.
 
 ## Safety
 Two independent **hardware** over-temp backstops (a bonded thermal cutoff in the

--- a/components/pb_heater/include/pb_heater.h
+++ b/components/pb_heater/include/pb_heater.h
@@ -74,7 +74,11 @@ static inline bool pb_heater_fault_decide(bool open_ok, bool ns_not_found,
 // PB_HEATER_PTC_CUTOFF_C (welded SSR, runaway, sensor issue) the latching trip fires
 // exactly as before. It only shapes power below the wall so a marginal/hot install can
 // hold set-point instead of tripping and needing a manual clear.
-#define PB_HEATER_PTC_FOLDBACK_START_C  100.0f
+// Start point bench-tuned to 102 C (3 C bleed-off band): a 100 C start trimmed power
+// noticeably earlier than needed given how fast the element responds to a duty cut,
+// costing chamber-heating performance; 102 keeps full power longer while still leaving
+// a 3 C margin to catch a hard-airflow-block climb before the 105 C trip.
+#define PB_HEATER_PTC_FOLDBACK_START_C  102.0f
 
 // Pure element-temperature foldback, inline so it is host-testable without hardware.
 // Given the base demand duty `base_duty` (0..1, from the chamber bang-bang) and the

--- a/components/pb_heater/include/pb_heater.h
+++ b/components/pb_heater/include/pb_heater.h
@@ -74,11 +74,11 @@ static inline bool pb_heater_fault_decide(bool open_ok, bool ns_not_found,
 // PB_HEATER_PTC_CUTOFF_C (welded SSR, runaway, sensor issue) the latching trip fires
 // exactly as before. It only shapes power below the wall so a marginal/hot install can
 // hold set-point instead of tripping and needing a manual clear.
-// Start point bench-tuned to 102 C (3 C bleed-off band): a 100 C start trimmed power
-// noticeably earlier than needed given how fast the element responds to a duty cut,
-// costing chamber-heating performance; 102 keeps full power longer while still leaving
-// a 3 C margin to catch a hard-airflow-block climb before the 105 C trip.
-#define PB_HEATER_PTC_FOLDBACK_START_C  102.0f
+// Start point 100 C (5 C bleed-off band below the fixed 105 C cutoff). Bench testing at
+// 102 C held fine on the V1.0.1/82 kOhm board, but the V1.0/33 kOhm board was seen
+// running closer to the cutoff, so we give a wider 5 C margin for both — the small loss
+// of top-end heating on the 82 kOhm board is negligible.
+#define PB_HEATER_PTC_FOLDBACK_START_C  100.0f
 
 // Pure element-temperature foldback, inline so it is host-testable without hardware.
 // Given the base demand duty `base_duty` (0..1, from the chamber bang-bang) and the

--- a/components/pb_heater/include/pb_heater.h
+++ b/components/pb_heater/include/pb_heater.h
@@ -67,6 +67,33 @@ static inline bool pb_heater_fault_decide(bool open_ok, bool ns_not_found,
 #define PB_HEATER_PTC_CUTOFF_C   105.0f   // element over-temp -> force off (stock parity)
 #define PB_HEATER_CHAMBER_MAX_C  85.0f    // chamber over-temp -> force off
 #define PB_HEATER_HYSTERESIS_C   1.0f
+// Soft element-temperature FOLDBACK, a layer strictly BELOW the hard cutoff: once the
+// PTC element climbs into [FOLDBACK_START, CUTOFF) the SSR duty is linearly reduced so
+// the element HOLDS just under the cutoff instead of slamming into the latching trip.
+// This never adds heat and never delays the hard cutoff — if the element still reaches
+// PB_HEATER_PTC_CUTOFF_C (welded SSR, runaway, sensor issue) the latching trip fires
+// exactly as before. It only shapes power below the wall so a marginal/hot install can
+// hold set-point instead of tripping and needing a manual clear.
+#define PB_HEATER_PTC_FOLDBACK_START_C  100.0f
+
+// Pure element-temperature foldback, inline so it is host-testable without hardware.
+// Given the base demand duty `base_duty` (0..1, from the chamber bang-bang) and the
+// current PTC element temperature, returns the duty to apply: unchanged below
+// FOLDBACK_START, then linearly ramped to 0 as ptc_c -> CUTOFF. It can only ever
+// REDUCE base_duty (a cool element never boosts power). The hard cutoff (ptc >= CUTOFF)
+// is enforced separately as a latching trip; this shapes power strictly below it.
+static inline float pb_heater_foldback_duty(float base_duty, float ptc_c)
+{
+    float duty = base_duty;
+    if (ptc_c > PB_HEATER_PTC_FOLDBACK_START_C) {
+        const float span = PB_HEATER_PTC_CUTOFF_C - PB_HEATER_PTC_FOLDBACK_START_C;
+        float f = (PB_HEATER_PTC_CUTOFF_C - ptc_c) / span;   // 1 at start -> 0 at cutoff
+        if (f < 0.0f) f = 0.0f;
+        else if (f > 1.0f) f = 1.0f;
+        if (f < duty) duty = f;                              // only ever reduces
+    }
+    return duty;
+}
 // Settable set-point ceiling: default + absolute cap + floor. Raising the
 // production cap above 70 C is a separate hw-validation item (80 C leaves only
 // 5 C below the fixed 85 C chamber trip — not enough margin without measured

--- a/components/pb_heater/pb_heater.c
+++ b/components/pb_heater/pb_heater.c
@@ -34,6 +34,11 @@ static bool        s_persist_pending;  // guarded by s_mux — a latch persist n
                                        // to NVS; retried from pb_heater_tick until it lands
 static int64_t     s_persist_retry_us; // guarded by s_mux — last persist-retry timestamp
 static bool        s_on;            // written only by the control task; atomic read
+static bool        s_heat_intent;   // control-task only — chamber-hysteresis latch (the
+                                    // "want heat at all" decision, distinct from the
+                                    // momentary SSR state s_on which the foldback modulates)
+static float       s_duty_accum;    // control-task only — sigma-delta accumulator for the
+                                    // element-foldback time-proportioning of the zero-cross SSR
 static float       s_max_target_c;      // guarded by s_mux — settable set-point ceiling
 static int64_t     s_comms_timeout_us;  // guarded by s_mux — comms deadman (microseconds)
 static float       s_cool_release_c;    // guarded by s_mux — residual-heat purge "cool down to" temp
@@ -527,13 +532,38 @@ void pb_heater_tick(void)          // control-task context; sole writer of s_on
 
     if (latched || !armed) {
         if (s_on) ssr_set(false);
+        s_heat_intent = false;   // drop hysteresis + foldback state so the next arm
+        s_duty_accum  = 0.0f;    // starts clean rather than mid-modulation
         return;
     }
 
-    // Here: armed && !latched && cs==OK && ps==OK — bang-bang with hysteresis.
-    if (!s_on && chamber_c < (target - PB_HEATER_HYSTERESIS_C)) {
-        ssr_set(true);
-    } else if (s_on && chamber_c >= target) {
-        ssr_set(false);
+    // Here: armed && !latched && cs==OK && ps==OK.
+    // Step 1 — chamber bang-bang with hysteresis decides the BASE demand (do we want
+    // heat at all). s_heat_intent holds across the hysteresis band; it is the steady
+    // "want heat" latch, distinct from the momentary SSR state s_on.
+    if (chamber_c < (target - PB_HEATER_HYSTERESIS_C)) {
+        s_heat_intent = true;
+    } else if (chamber_c >= target) {
+        s_heat_intent = false;
     }
+    float duty = s_heat_intent ? 1.0f : 0.0f;
+
+    // Step 2 — element foldback: reduce the duty as the PTC element nears the cutoff so
+    // it holds just under it instead of tripping. Pure + host-tested; only ever cuts.
+    duty = pb_heater_foldback_duty(duty, ptc_c);
+
+    // Step 3 — time-proportion the zero-cross SSR (it can't phase-cut) via a first-order
+    // sigma-delta: the average of the on/off decisions tracks `duty`. At 0.5 it toggles
+    // each ~500 ms tick; at ~0.2 it fires ~1 tick in 5. Endpoints are exact on/off.
+    bool drive;
+    if (duty <= 0.0f) {
+        drive = false; s_duty_accum = 0.0f;
+    } else if (duty >= 1.0f) {
+        drive = true;  s_duty_accum = 0.0f;
+    } else {
+        s_duty_accum += duty;
+        if (s_duty_accum >= 1.0f) { drive = true;  s_duty_accum -= 1.0f; }
+        else                      { drive = false; }
+    }
+    if (drive != s_on) ssr_set(drive);
 }

--- a/tests/pb_heater_fault_host_test.c
+++ b/tests/pb_heater_fault_host_test.c
@@ -69,22 +69,21 @@ int main(void)
     // --- Element-temperature foldback limiter (pb_heater_foldback_duty) ---------
     // Below the foldback band the base demand passes through untouched.
     CHECK(FEQ(pb_heater_foldback_duty(1.0f, 25.0f), 1.0f));
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 99.0f), 1.0f));
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, PB_HEATER_PTC_FOLDBACK_START_C), 1.0f)); // 100 -> full
-    // Inside the band [100, 105) the duty ramps linearly to 0 (span = 5 C).
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 101.0f), 0.8f));
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 102.5f), 0.5f));
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 104.0f), 0.2f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 101.0f), 1.0f));                          // below 102 -> full
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, PB_HEATER_PTC_FOLDBACK_START_C), 1.0f));  // 102 -> full
+    // Inside the band [102, 105) the duty ramps linearly to 0 (span = 3 C).
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 103.5f), 0.5f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 104.0f), 1.0f / 3.0f));
     // At/above the cutoff the foldback duty is 0 (the hard latching trip owns >= cutoff).
     CHECK(FEQ(pb_heater_foldback_duty(1.0f, PB_HEATER_PTC_CUTOFF_C), 0.0f));          // 105 -> 0
     CHECK(FEQ(pb_heater_foldback_duty(1.0f, 110.0f), 0.0f));
     // It only ever REDUCES: a base demand of 0 (chamber satisfied) stays 0 even when
     // the element is cool, and the cap never exceeds the base demand.
     CHECK(FEQ(pb_heater_foldback_duty(0.0f, 25.0f), 0.0f));
-    CHECK(FEQ(pb_heater_foldback_duty(0.0f, 103.0f), 0.0f));
+    CHECK(FEQ(pb_heater_foldback_duty(0.0f, 104.0f), 0.0f));
     // A base demand already below the foldback cap is left as-is (min, not overwrite):
-    // at 102.5 C the cap is 0.5, so a base of 0.3 stays 0.3.
-    CHECK(FEQ(pb_heater_foldback_duty(0.3f, 102.5f), 0.3f));
+    // at 103.5 C the cap is 0.5, so a base of 0.3 stays 0.3.
+    CHECK(FEQ(pb_heater_foldback_duty(0.3f, 103.5f), 0.3f));
     puts("pb_heater element-foldback checks: PASS");
     return 0;
 }

--- a/tests/pb_heater_fault_host_test.c
+++ b/tests/pb_heater_fault_host_test.c
@@ -8,6 +8,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
 
 #define CHECK(expr) do { \
     if (!(expr)) { \
@@ -15,6 +16,9 @@
         exit(1); \
     } \
 } while (0)
+
+// Float-equality check for the foldback duty (values are exact-ish ratios of 5).
+#define FEQ(a, b) (fabsf((a) - (b)) < 1e-4f)
 
 int main(void)
 {
@@ -61,5 +65,26 @@ int main(void)
     CHECK(code == PB_FAULT_NVS_UNREADABLE);
 
     puts("pb_heater fault-restore checks: PASS");
+
+    // --- Element-temperature foldback limiter (pb_heater_foldback_duty) ---------
+    // Below the foldback band the base demand passes through untouched.
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 25.0f), 1.0f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 99.0f), 1.0f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, PB_HEATER_PTC_FOLDBACK_START_C), 1.0f)); // 100 -> full
+    // Inside the band [100, 105) the duty ramps linearly to 0 (span = 5 C).
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 101.0f), 0.8f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 102.5f), 0.5f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 104.0f), 0.2f));
+    // At/above the cutoff the foldback duty is 0 (the hard latching trip owns >= cutoff).
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, PB_HEATER_PTC_CUTOFF_C), 0.0f));          // 105 -> 0
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 110.0f), 0.0f));
+    // It only ever REDUCES: a base demand of 0 (chamber satisfied) stays 0 even when
+    // the element is cool, and the cap never exceeds the base demand.
+    CHECK(FEQ(pb_heater_foldback_duty(0.0f, 25.0f), 0.0f));
+    CHECK(FEQ(pb_heater_foldback_duty(0.0f, 103.0f), 0.0f));
+    // A base demand already below the foldback cap is left as-is (min, not overwrite):
+    // at 102.5 C the cap is 0.5, so a base of 0.3 stays 0.3.
+    CHECK(FEQ(pb_heater_foldback_duty(0.3f, 102.5f), 0.3f));
+    puts("pb_heater element-foldback checks: PASS");
     return 0;
 }

--- a/tests/pb_heater_fault_host_test.c
+++ b/tests/pb_heater_fault_host_test.c
@@ -67,23 +67,30 @@ int main(void)
     puts("pb_heater fault-restore checks: PASS");
 
     // --- Element-temperature foldback limiter (pb_heater_foldback_duty) ---------
+    // Expectations are DERIVED from the two defines so the single-source-of-truth
+    // #define PB_HEATER_PTC_FOLDBACK_START_C can be retuned without editing the test.
+    const float start = PB_HEATER_PTC_FOLDBACK_START_C;
+    const float cutoff = PB_HEATER_PTC_CUTOFF_C;
+    const float span = cutoff - start;
+    const float mid = start + span * 0.5f;   // duty 0.5
+    const float qtr = start + span * 0.25f;  // duty 0.75
     // Below the foldback band the base demand passes through untouched.
     CHECK(FEQ(pb_heater_foldback_duty(1.0f, 25.0f), 1.0f));
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 101.0f), 1.0f));                          // below 102 -> full
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, PB_HEATER_PTC_FOLDBACK_START_C), 1.0f));  // 102 -> full
-    // Inside the band [102, 105) the duty ramps linearly to 0 (span = 3 C).
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 103.5f), 0.5f));
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 104.0f), 1.0f / 3.0f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, start - 1.0f), 1.0f));   // just below band -> full
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, start), 1.0f));          // at start -> full
+    // Inside the band the duty ramps linearly to 0 across the span.
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, qtr), 0.75f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, mid), 0.5f));
     // At/above the cutoff the foldback duty is 0 (the hard latching trip owns >= cutoff).
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, PB_HEATER_PTC_CUTOFF_C), 0.0f));          // 105 -> 0
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 110.0f), 0.0f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, cutoff), 0.0f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, cutoff + 5.0f), 0.0f));
     // It only ever REDUCES: a base demand of 0 (chamber satisfied) stays 0 even when
     // the element is cool, and the cap never exceeds the base demand.
     CHECK(FEQ(pb_heater_foldback_duty(0.0f, 25.0f), 0.0f));
-    CHECK(FEQ(pb_heater_foldback_duty(0.0f, 104.0f), 0.0f));
+    CHECK(FEQ(pb_heater_foldback_duty(0.0f, mid), 0.0f));
     // A base demand already below the foldback cap is left as-is (min, not overwrite):
-    // at 103.5 C the cap is 0.5, so a base of 0.3 stays 0.3.
-    CHECK(FEQ(pb_heater_foldback_duty(0.3f, 103.5f), 0.3f));
+    // at the band midpoint the cap is 0.5, so a base of 0.3 stays 0.3.
+    CHECK(FEQ(pb_heater_foldback_duty(0.3f, mid), 0.3f));
     puts("pb_heater element-foldback checks: PASS");
     return 0;
 }

--- a/tests/run_heater_fault_host_test.sh
+++ b/tests/run_heater_fault_host_test.sh
@@ -11,6 +11,6 @@ cc -std=c11 -Wall -Wextra -Werror \
   -I"$root/components/pb_heater/include" \
   -I"$root/tests/stubs" \
   "$root/tests/pb_heater_fault_host_test.c" \
-  -o "$out"
+  -lm -o "$out"
 
 "$out"


### PR DESCRIPTION
## What

On a hot/marginal install, the bang-bang heater drives the PTC element full-power until it self-heats to the **105 °C cutoff**, which **latches a fault** and forces a manual clear — repeatedly, often before the chamber ever reaches set-point. (This is the customer "get to ~55, PTC hits 105, shut off, press clear 3–4×, repeat" report.)

This adds a **soft foldback layer strictly below the hard cutoff**: once the element enters `[100 °C, 105 °C)` the SSR duty is linearly reduced toward 0 as it approaches 105, so the element **holds just under the cutoff** and the chamber keeps warming instead of tripping.

```
duty
100% ┤━━━━━━━━━━━━●            (ptc ≤ 100 → full power)
     │            ╲
 50% ┤             ╲           (ptc 102.5 → 50%)
     │              ╲
  0% ┤               ●──       (ptc → 105 → 0%; hard cutoff owns ≥105)
     └──┬────┬────┬──┬──
      100  102 103 105 °C
```

Since the MGR GJ-5-L is a **zero-cross SSR** (on/off, no phase-cut), the duty is applied by **time-proportioning** — a first-order sigma-delta across the 2 Hz control ticks (at 50 % it toggles each ~500 ms tick; at ~30 % it fires ~1 tick in 3).

## Safety — unchanged, defense-in-depth preserved

- The **hard 105 °C PTC cutoff stays the first, unconditional, latching check** in `pb_heater_tick`. The foldback only shapes power *below* it.
- The foldback can **only ever reduce** the base bang-bang demand — it never adds heat and never delays the trip.
- If the element still reaches 105 °C (welded SSR, runaway, sensor fault), it **latches off exactly as before**. This only prevents *nuisance* trips on marginal-but-healthy setups.
- The 85 °C chamber cutoff, sensor-fault trips, and comms deadman are untouched and still evaluated first.

## How

- `pb_heater.h`: `PB_HEATER_PTC_FOLDBACK_START_C` (**100 °C**, the single compile-time tuning knob) + a **pure, host-testable** inline `pb_heater_foldback_duty(base_duty, ptc_c)`. Retuning the threshold is a one-line change; the tick, the duty math, and the host test all derive from it.
- `pb_heater.c`: split the chamber bang-bang into a steady **heat-intent latch** (`s_heat_intent`) vs the **momentary SSR state** (`s_on`); apply the foldback cap; drive the SSR via a **sigma-delta accumulator** (`s_duty_accum`). State resets when disarmed/latched. `pb_heater_heat_mode()` (fan/LED signal) stays steady — only `pb_heater_is_on()` (documented momentary) sees the modulation.

## Bench validation (v0.6.3-rc1…rc4 pre-releases, real hardware)

- **Board:** validated on a **Panda Breath V1.0.1** board (boot, OTA, heat cycle, and the foldback). A **V1.0** board looks functionally identical (same PSU/SSR/NTCs/pinout) and is expected to work, but that's **not yet hardware-confirmed** — awaiting feedback from a V1.0 user.
- **Normal heating works** after the bang-bang refactor — element self-limits ~82 °C with full airflow, SSR steady full-on below target; foldback correctly dormant below the band. ✅
- **Foldback engages on real silicon:** with the blower intake restricted, the element climbed into the band and the **instant it crossed the threshold the SSR started cutting (`out=False`)**, trimming it back. Under the hardest case tested — **100 °C heated bed loading the chamber + 70 °C chamber target** — the foldback held the element steady in-band **at ~73 % SSR duty with no 105 °C trip**. That same condition on the old bang-bang firmware drove the element straight to 105 and a latching fault. ✅
- **Threshold = 100 °C (5 °C band).** Bench testing at 102 °C held fine on the V1.0.1/82 kΩ board, but the V1.0/33 kΩ board was seen running closer to the cutoff, so the start is set to **100 °C** to give every board a 5 °C bleed-off margin — the small loss of top-end heating on the 82 kΩ board is negligible. (Kept a single global value rather than tying it to the Rref variant, so this PR stays independent of the strap-detection PR.)
- **Board coverage:** all of the above is on **V1.0.1**. V1.0 hardware confirmation is pending a user with that board.

## Testing

- Host tests: `pb_heater_foldback_duty` band edges / linear ramp / min-not-overwrite / base-0 passthrough, all **derived from the define** — PASS. All other host suites still pass.
- Full ESP-IDF build green; OTA'd to the bench and exercised live (see above).

## Notes for review

- Foldback start is a fixed 100 °C `#define`. Easy to promote to a persisted runtime setting (or a per-Rref-variant value) later if per-install tuning is wanted.
- The RE finding stands: stock does **not** modulate — it holds the **blower continuously** while heating. This foldback is complementary (nuisance-trip mitigation); ensuring continuous blower airflow at set-point is a separate lever worth its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
