### PR TITLE
fix(board): robust Rref strap read — tolerate a floating GPIO19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+### Fixed
+- **Rref strap misread on a floating GPIO19 (both NTC readings ~15 °C off).** The
+  thermistor divider's reference resistor (82 kΩ vs 33 kΩ) is selected by a strap on
+  GPIO19, read once at boot — previously with both internal pulls disabled. On a board
+  that doesn't firmly drive the pin it **floats** and can latch the wrong value,
+  **differently on a cold power-on vs a warm OTA reboot** — silently choosing the wrong
+  Rref and shifting **both** the chamber and PTC readings by ~15 °C (observed on a V1.0
+  board: 27 °C after a USB flash, 12 °C after an OTA update; a couple of hard resets read
+  27 °C again). The strap is now sampled under an internal pull-up **and** an internal
+  pull-down: a firmly strapped pin reads identically both ways and is trusted, while a
+  floating pin disagrees and falls back to the **fail-safe 33 kΩ** default (a smaller
+  Rref biases readings *warm*, so the fixed 105 °C/85 °C over-temp cutoffs trip early
+  rather than late). The resolved value is exposed at `GET /api/v2/info` as `rref_kohm`
+  for diagnostics. Firmly-strapped boards are unaffected (V1.0.1 bench verified: firm →
+  82 kΩ, reading unchanged).
+
 ## [0.6.2] - 2026-07-26
 
 ### Added

--- a/components/pb_board/pb_board.c
+++ b/components/pb_board/pb_board.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include "pb_board.h"
 #include "esp_log.h"
+#include "esp_rom_sys.h"   // esp_rom_delay_us — let the strap settle before sampling
 
 static const char *TAG = "pb_board";
 
@@ -26,22 +27,61 @@ void pb_board_init(void)
 #endif
 }
 
+// Fail-safe Rref used when the strap can't be trusted (see below). 33 kOhm is the
+// SMALLER reference: a too-small Rref biases BOTH NTC readings WARM, so the fixed
+// 105 C / 85 C over-temp cutoffs trip early rather than late. (A too-large Rref would
+// read cold and let the element run hotter than the firmware believes.) It is also
+// the value the one observed floating board — Panda Breath V1.0 — actually needs.
+#define PB_RREF_FLOATING_DEFAULT_KOHM  33
+
 int pb_board_rref_kohm(void)
 {
 #ifdef CONFIG_PB_HIL_DEVBOARD
     return 82;
 #else
-    const gpio_config_t strap = {
+    // The Rref strap on GPIO19 selects the divider reference resistor (level 0 -> 82k,
+    // level 1 -> 33k) and is read once at boot. It MUST be read robustly: not every
+    // board firmly straps the pin, and a FLOATING input latches an arbitrary level
+    // that can differ between a cold power-on and a warm (OTA) reboot — silently
+    // picking the wrong Rref and shifting BOTH NTC readings by ~15 C (observed on a
+    // V1.0 board: 27 C after a cold flash, 12 C after an OTA reboot).
+    //
+    // Detect a floating pin by sampling it under an internal pull-up AND an internal
+    // pull-down: a FIRMLY strapped pin is driven by the board and reads the SAME both
+    // ways (trust it); a FLOATING pin follows whichever pull is enabled and the two
+    // reads DISAGREE (don't trust it — fall back to the fail-safe default).
+    gpio_config_t strap = {
         .pin_bit_mask = (1ULL << PB_GPIO_RREF_STRAP),
         .mode = GPIO_MODE_INPUT,
-        .pull_up_en = GPIO_PULLUP_DISABLE,
-        .pull_down_en = GPIO_PULLDOWN_DISABLE,
         .intr_type = GPIO_INTR_DISABLE,
     };
+
+    strap.pull_up_en = GPIO_PULLUP_ENABLE;
+    strap.pull_down_en = GPIO_PULLDOWN_DISABLE;
     gpio_config(&strap);
-    int level = gpio_get_level(PB_GPIO_RREF_STRAP);
-    int rref = (level == 0) ? 82 : 33;
-    ESP_LOGI(TAG, "Rref strap (GPIO19)=%d -> %d kOhm", level, rref);
-    return rref;
+    esp_rom_delay_us(2000);                       // settle through the ~45k internal pull
+    int with_pu = gpio_get_level(PB_GPIO_RREF_STRAP);
+
+    strap.pull_up_en = GPIO_PULLUP_DISABLE;
+    strap.pull_down_en = GPIO_PULLDOWN_ENABLE;
+    gpio_config(&strap);
+    esp_rom_delay_us(2000);
+    int with_pd = gpio_get_level(PB_GPIO_RREF_STRAP);
+
+    // Leave the pin as a plain high-Z input so we don't load the strap net at runtime.
+    strap.pull_up_en = GPIO_PULLUP_DISABLE;
+    strap.pull_down_en = GPIO_PULLDOWN_DISABLE;
+    gpio_config(&strap);
+
+    if (with_pu == with_pd) {
+        int level = with_pu;
+        int rref = (level == 0) ? 82 : 33;
+        ESP_LOGI(TAG, "Rref strap (GPIO19)=%d -> %d kOhm (firm)", level, rref);
+        return rref;
+    }
+
+    ESP_LOGW(TAG, "Rref strap (GPIO19) FLOATING (pu=%d pd=%d) -> defaulting to %d kOhm (fail-safe)",
+             with_pu, with_pd, PB_RREF_FLOATING_DEFAULT_KOHM);
+    return PB_RREF_FLOATING_DEFAULT_KOHM;
 #endif
 }

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -257,6 +257,9 @@ static esp_err_t info_get(httpd_req_t *req)
     cJSON_AddStringToObject(o, "boot_id", s_boot_id);
     cJSON_AddStringToObject(o, "firmware", esp_app_get_description()->version);
     cJSON_AddStringToObject(o, "project", esp_app_get_description()->project_name);
+    // Divider reference resistor resolved from the GPIO19 strap (diagnostic): 82 or
+    // 33 kOhm; a board whose strap floats comes up at the fail-safe 33 kOhm default.
+    cJSON_AddNumberToObject(o, "rref_kohm", pb_ntc_rref_kohm());
     cJSON *cap = cJSON_AddArrayToObject(o, "capabilities");
     cJSON_AddItemToArray(cap, cJSON_CreateString("power_on"));
     cJSON_AddItemToArray(cap, cJSON_CreateString("auto"));

--- a/components/pb_ntc/include/pb_ntc.h
+++ b/components/pb_ntc/include/pb_ntc.h
@@ -27,6 +27,11 @@ typedef enum {
 // Rref from the board strap. Returns ESP_OK on success.
 esp_err_t pb_ntc_init(void);
 
+// The divider reference resistor (82 or 33 kOhm) resolved from the GPIO19 strap at
+// init. Exposed for diagnostics — confirms which Rref branch a board came up on (a
+// floating strap resolves to the fail-safe default). 0 before pb_ntc_init().
+int pb_ntc_rref_kohm(void);
+
 // Take one calibrated reading of the given channel. Returns the status; on
 // PB_NTC_OK *out_c holds the INSTANTANEOUS temperature in C (NAN on any fault),
 // so safety cutoffs act on the freshest sample. A successful read also feeds the

--- a/components/pb_ntc/pb_ntc.c
+++ b/components/pb_ntc/pb_ntc.c
@@ -275,6 +275,11 @@ esp_err_t pb_ntc_init(void)
     return ESP_OK;
 }
 
+// The divider reference resistor resolved at init (82 or 33 kOhm). Exposed for
+// diagnostics: a board whose GPIO19 strap floats comes up at the fail-safe default,
+// and seeing this value confirms which branch was selected. 0 before pb_ntc_init().
+int pb_ntc_rref_kohm(void) { return s_rref_kohm; }
+
 // Returns the INSTANTANEOUS temperature in *out_c (NAN on any fault) so the
 // heater over-temp cutoffs act on the freshest sample, not a lagged average.
 // A successful read still feeds the moving-average filter that backs


### PR DESCRIPTION
## Symptom

A user flashed the firmware and the DragonBreath chamber reading **instantly dropped from ~27 °C to 12 °C** while the room and every other printer thermistor stayed at 26–27 °C. **Both** the chamber and PTC sensors read the *same* wrong value simultaneously. A couple of **hard resets** restored the correct 27 °C.

## Root cause — a floating Rref strap, not a firmware change

`pb_ntc` and `pb_board` are **byte-identical** across the versions involved (verified: zero commits touch them between v0.6.1 and the flashed build) — no calibration, R25, beta, or conversion change. The tell is that **both channels shift by the same amount**: the only thing they share is the **reference resistor** `Rref`, selected by a strap on **GPIO19** and read once at boot.

That read had **both internal pulls disabled**, so on a board that doesn't firmly drive GPIO19 the pin **floats** and latches an arbitrary level — and it can latch **differently on a cold power-on vs a warm OTA reboot**:

- v0.6.1 installed by **USB flash (cold boot)** → right Rref → 27 °C
- newer build installed by **OTA (warm reboot)** → wrong Rref → 12 °C
- **2× hard reset (cold)** → right Rref → 27 °C again

"Hard reset fixes it" rules out any *stored* value (NVS survives a power cycle); it's re-evaluated every boot. A too-large Rref (82 kΩ used where 33 kΩ is correct) computes the NTC resistance ~2.5× high → reads cold, ~15 °C low. This also mildly **degrades safety** on the affected board: cold-biased readings make the over-temp cutoffs trip *late*.

## Fix — dual-pull float detection

Sample GPIO19 under an internal **pull-up** and an internal **pull-down**:

- **Firmly strapped** pin → driven by the board → reads the **same** both ways → **trust it** (unchanged behavior).
- **Floating** pin → follows the pull → the two reads **disagree** → **don't trust it** → fall back to the **fail-safe 33 kΩ** default.

33 kΩ is deliberate: a *smaller* Rref biases both readings **warm**, so the fixed 105 °C/85 °C cutoffs trip **early, not late** — the safe direction — and it's the value the observed V1.0 board actually needs.

Also exposes the resolved reference at **`GET /api/v2/info` → `rref_kohm`** so a board's Rref (and whether it floated) is visible for diagnostics.

## Validation

- **V1.0.1 bench (firm strap):** dual-pull reads identically → `rref_kohm = 82` (documented value); temperature **unchanged across the flash** (40.9→40.7 °C, smooth) — the fix is a no-op on firmly-strapped boards. ✅
- A **floating V1.0 board** will now resolve deterministically to `rref_kohm = 33` regardless of cold/warm boot.
- Full ESP-IDF build green.

**For the affected user:** after flashing this, check `http://<device>/api/v2/info` — `rref_kohm` should read `33` and the chamber temp should track the room again, consistently across both cold and OTA reboots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)