### PR TITLE
Release v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+### Added
+- **Element-temperature foldback limiter.** Instead of driving the heater full-power
+  into the 105 °C PTC-element cutoff and hard-faulting, the SSR duty is now linearly
+  folded back once the element climbs into `[100 °C, 105 °C)`, so it *holds* just under
+  the cutoff and the chamber keeps warming instead of tripping. On a hot/marginal
+  install this replaces the "trip → clear → trip again" loop with a stable (if slower)
+  approach to set-point. Because the SSR is a zero-cross type, the duty is applied by
+  time-proportioning (a first-order sigma-delta) across the 2 Hz control ticks. **Safety
+  is unchanged:** the foldback can only ever *reduce* power, and the hard 105 °C cutoff
+  remains the first, unconditional, latching check — if the element still reaches it
+  (welded SSR, runaway, sensor fault) it latches off exactly as before. The pure
+  foldback curve is covered by host tests.
+
 ## [0.6.2] - 2026-07-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ below into the GitHub Release notes.
 ### Added
 - **Element-temperature foldback limiter (hysteresis).** Instead of driving the heater
   full-power into the 105 °C PTC-element cutoff and hard-faulting, the SSR is now cut off
-  when the element reaches **102 °C** and held off until it cools below **99 °C**, so the
+  when the element reaches **99 °C** and held off until it cools below **96 °C**, so the
   element repeatedly cools back down instead of pinning against the cutoff — the chamber
   keeps warming and a hot/marginal install no longer trips into the "clear → trip again"
   loop. (An earlier proportional-duty ramp proved too gentle on a hot-running board: ~50 %

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+### Changed
+- **Dashboard temperature chart overlays chamber + PTC element with labeled axes.** The
+  trend plotted only the chamber temperature (a faint sparkline behind the reading). It
+  now draws **both** the chamber and the PTC-element temperature on one shared, auto-scaled
+  graph with a **Y axis** (°C max/min) and an **X axis** (time span back from "now"), plus
+  a small legend — so you can see the element rising relative to the chamber set-point at a
+  glance (useful for watching the foldback hold the element under the cutoff). All from the
+  existing SSE telemetry; no API or firmware-behavior change.
+
 ## [0.6.2] - 2026-07-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ below into the GitHub Release notes.
 ### Added
 - **Element-temperature foldback limiter (hysteresis).** Instead of driving the heater
   full-power into the 105 °C PTC-element cutoff and hard-faulting, the SSR is now cut off
-  when the element reaches **99 °C** and held off until it cools below **96 °C**, so the
-  element repeatedly cools back down instead of pinning against the cutoff — the chamber
-  keeps warming and a hot/marginal install no longer trips into the "clear → trip again"
-  loop. (An earlier proportional-duty ramp proved too gentle on a hot-running board: ~50 %
+  when the element reaches a per-board **cut** point and held off until it cools below the
+  **resume** point, so the element repeatedly cools back down instead of pinning against
+  the cutoff — the chamber keeps warming and a hot/marginal install no longer trips into
+  the "clear → trip again" loop. Thresholds are selected by the board's Rref strap:
+  **82 kΩ (V1.0.1) cut 102 / resume 99**; **33 kΩ (V1.0, runs the element hotter) cut 99
+  / resume 96** (a floating strap defaults to the conservative 33 kΩ pair). (An earlier proportional-duty ramp proved too gentle on a hot-running board: ~50 %
   duty at 102–103 °C kept feeding the element so it ratcheted to ~104.8 °C; the hysteresis
   forces a genuine cool-down cycle instead.) **Safety is unchanged:** the foldback can
   only ever *remove* power, and the hard 105 °C cutoff remains the first, unconditional,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,17 @@ below into the GitHub Release notes.
 ## [Unreleased]
 
 ### Added
-- **Element-temperature foldback limiter.** Instead of driving the heater full-power
-  into the 105 °C PTC-element cutoff and hard-faulting, the SSR duty is now linearly
-  folded back once the element climbs into `[100 °C, 105 °C)`, so it *holds* just under
-  the cutoff and the chamber keeps warming instead of tripping. On a hot/marginal
-  install this replaces the "trip → clear → trip again" loop with a stable (if slower)
-  approach to set-point. Because the SSR is a zero-cross type, the duty is applied by
-  time-proportioning (a first-order sigma-delta) across the 2 Hz control ticks. **Safety
-  is unchanged:** the foldback can only ever *reduce* power, and the hard 105 °C cutoff
-  remains the first, unconditional, latching check — if the element still reaches it
-  (welded SSR, runaway, sensor fault) it latches off exactly as before. The pure
-  foldback curve is covered by host tests.
+- **Element-temperature foldback limiter (hysteresis).** Instead of driving the heater
+  full-power into the 105 °C PTC-element cutoff and hard-faulting, the SSR is now cut off
+  when the element reaches **102 °C** and held off until it cools below **99 °C**, so the
+  element repeatedly cools back down instead of pinning against the cutoff — the chamber
+  keeps warming and a hot/marginal install no longer trips into the "clear → trip again"
+  loop. (An earlier proportional-duty ramp proved too gentle on a hot-running board: ~50 %
+  duty at 102–103 °C kept feeding the element so it ratcheted to ~104.8 °C; the hysteresis
+  forces a genuine cool-down cycle instead.) **Safety is unchanged:** the foldback can
+  only ever *remove* power, and the hard 105 °C cutoff remains the first, unconditional,
+  latching check — if the element still reaches it (welded SSR, runaway, sensor fault) it
+  latches off exactly as before. The pure hysteresis decision is covered by host tests.
 
 ## [0.6.2] - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+### Fixed
+- **Rref strap misread on a floating GPIO19 (both NTC readings ~15 °C off).** The
+  thermistor divider's reference resistor (82 kΩ vs 33 kΩ) is selected by a strap on
+  GPIO19, read once at boot — previously with both internal pulls disabled. On a board
+  that doesn't firmly drive the pin it **floats** and can latch the wrong value,
+  **differently on a cold power-on vs a warm OTA reboot** — silently choosing the wrong
+  Rref and shifting **both** the chamber and PTC readings by ~15 °C (observed on a V1.0
+  board: 27 °C after a USB flash, 12 °C after an OTA update; a couple of hard resets read
+  27 °C again). The strap is now sampled under an internal pull-up **and** an internal
+  pull-down: a firmly strapped pin reads identically both ways and is trusted, while a
+  floating pin disagrees and falls back to the **fail-safe 33 kΩ** default (a smaller
+  Rref biases readings *warm*, so the fixed 105 °C/85 °C over-temp cutoffs trip early
+  rather than late). The resolved value is exposed at `GET /api/v2/info` as `rref_kohm`
+  for diagnostics. Firmly-strapped boards are unaffected (V1.0.1 bench verified: firm →
+  82 kΩ, reading unchanged).
+
 ## [0.6.2] - 2026-07-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+### Changed
+- **OTA update page shows upload progress and returns to the dashboard automatically.**
+  The firmware-update page (`/fw`) now streams the image via `XMLHttpRequest` and shows a
+  live **percent complete** while uploading/flashing (the device writes bytes as it
+  receives them, so the upload % tracks the flash), then — once the image is accepted —
+  **polls the rebooting device and redirects to the main screen** when it comes back on
+  the new firmware (with a ~2-minute fallback). A connection drop after the upload
+  finishes is treated as the expected reboot; a drop mid-upload is reported as a failure
+  so it can be retried.
+
 ## [0.6.2] - 2026-07-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ below into the GitHub Release notes.
 ### Added
 - **Element-temperature foldback limiter.** Instead of driving the heater full-power
   into the 105 °C PTC-element cutoff and hard-faulting, the SSR duty is now linearly
-  folded back once the element climbs into `[100 °C, 105 °C)`, so it *holds* just under
+  folded back once the element climbs into `[102 °C, 105 °C)`, so it *holds* just under
   the cutoff and the chamber keeps warming instead of tripping. On a hot/marginal
   install this replaces the "trip → clear → trip again" loop with a stable (if slower)
   approach to set-point. Because the SSR is a zero-cross type, the duty is applied by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ below into the GitHub Release notes.
 ### Added
 - **Element-temperature foldback limiter.** Instead of driving the heater full-power
   into the 105 °C PTC-element cutoff and hard-faulting, the SSR duty is now linearly
-  folded back once the element climbs into `[102 °C, 105 °C)`, so it *holds* just under
+  folded back once the element climbs into `[100 °C, 105 °C)`, so it *holds* just under
   the cutoff and the chamber keeps warming instead of tripping. On a hot/marginal
   install this replaces the "trip → clear → trip again" loop with a stable (if slower)
   approach to set-point. Because the SSR is a zero-cross type, the duty is applied by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-07-27
+
 ### Added
 - **Element-temperature foldback limiter (hysteresis).** Instead of driving the heater
   full-power into the 105 °C PTC-element cutoff and hard-faulting, the SSR is now cut off

--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ DragonBreath mirrors OpenVent's ESP-IDF + `components/` layout on purpose, so th
 shared core (WiFi, captive portal, Moonraker client) is lifted in rather than
 re-implemented.
 
-> ⚠️ **Hardware validated on board revisions V1.0.1 and V1.0.** The pin map,
-> sensor conversion, and heater/fan actuation were reverse-engineered on a V1.0.1
-> board and are **confirmed working on a V1.0 board** as well (boot, OTA, heat
-> cycle, and the element-foldback limiter all validated on V1.0). Other Panda
-> Breath revisions are untested — **verify the pinout against your own board
-> before flashing.** This is community firmware with no warranty — read
-> [`docs/SAFETY.md`](docs/SAFETY.md) and supervise early runs.
+> ⚠️ **Hardware validated on board revision V1.0.1 only.** The pin map, sensor
+> conversion, and heater/fan actuation were reverse-engineered and validated on a
+> V1.0.1 board (boot, OTA, heat cycle, and the element-foldback limiter). A V1.0
+> board appears functionally identical (same PSU, SSR, NTCs, and pinout) and is
+> **expected** to work, but that is **not yet confirmed on hardware** — feedback
+> from a V1.0 user is pending. Other Panda Breath revisions are untested —
+> **verify the pinout against your own board before flashing.** This is community
+> firmware with no warranty — read [`docs/SAFETY.md`](docs/SAFETY.md) and
+> supervise early runs.
 
 **Docs:** full feature set → [`docs/FEATURES.md`](docs/FEATURES.md) · control API →
 [`docs/api-v2.md`](docs/api-v2.md) · safety model → [`docs/SAFETY.md`](docs/SAFETY.md) ·
@@ -26,7 +28,7 @@ OEM parity → [`docs/OEM_PARITY.md`](docs/OEM_PARITY.md) · hardware →
 ## Status
 | Component | State |
 |---|---|
-| `pb_board` | ✅ Pinout RE'd (V1.0.1); boots on hardware (V1.0.1 + V1.0 confirmed) |
+| `pb_board` | ✅ Pinout RE'd (V1.0.1); boots on hardware (V1.0.1 confirmed; V1.0 pending) |
 | `pb_ntc` | ✅ Stock conversion ported; **hardware-validated** (reads chamber temp matching the printer) |
 | `pb_heater` | ✅ Bang-bang + full safety cutoffs; SSR confirmed, heat cycle validated on hardware |
 | `pb_fan` | ✅ TRIAC **on/off held-gate** (stock model — the gate is never PWM'd/phase-chopped) |
@@ -70,7 +72,8 @@ auto / light / dark toggle are built in.
 ESP32-C3-MINI-1, mains PSU, PTC heater via SSR (GPIO18), ~220 VAC blower switched
 by a **TRIAC held on/off** (GPIO3 gate + GPIO7 zero-cross — **never** phase-angle
 PWM'd), two NTCs on ADC1. Full map: [`docs/HARDWARE.md`](docs/HARDWARE.md).
-Reverse-engineered from a **V1.0.1** board; also confirmed working on **V1.0**.
+Reverse-engineered and validated on a **V1.0.1** board (**V1.0** looks identical
+but is not yet hardware-confirmed).
 
 ## Safety
 Two independent **hardware** over-temp backstops (a bonded thermal cutoff in the

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ DragonBreath mirrors OpenVent's ESP-IDF + `components/` layout on purpose, so th
 shared core (WiFi, captive portal, Moonraker client) is lifted in rather than
 re-implemented.
 
-> ⚠️ **Hardware tested on a single board revision (V1.0.1) only.** That is the
-> only unit available for testing; the pin map, sensor conversion, and
-> heater/fan actuation are validated against it and may differ on other Panda
-> Breath board revisions. **Verify the pinout against your own board before
-> flashing.** Heater control is functional and hardware-validated on V1.0.1, but
-> this is community firmware with no warranty — read [`docs/SAFETY.md`](docs/SAFETY.md)
-> and supervise early runs.
+> ⚠️ **Hardware validated on board revisions V1.0.1 and V1.0.** The pin map,
+> sensor conversion, and heater/fan actuation were reverse-engineered on a V1.0.1
+> board and are **confirmed working on a V1.0 board** as well (boot, OTA, heat
+> cycle, and the element-foldback limiter all validated on V1.0). Other Panda
+> Breath revisions are untested — **verify the pinout against your own board
+> before flashing.** This is community firmware with no warranty — read
+> [`docs/SAFETY.md`](docs/SAFETY.md) and supervise early runs.
 
 **Docs:** full feature set → [`docs/FEATURES.md`](docs/FEATURES.md) · control API →
 [`docs/api-v2.md`](docs/api-v2.md) · safety model → [`docs/SAFETY.md`](docs/SAFETY.md) ·
@@ -26,7 +26,7 @@ OEM parity → [`docs/OEM_PARITY.md`](docs/OEM_PARITY.md) · hardware →
 ## Status
 | Component | State |
 |---|---|
-| `pb_board` | ✅ Pinout RE'd (V1.0.1); boots on hardware |
+| `pb_board` | ✅ Pinout RE'd (V1.0.1); boots on hardware (V1.0.1 + V1.0 confirmed) |
 | `pb_ntc` | ✅ Stock conversion ported; **hardware-validated** (reads chamber temp matching the printer) |
 | `pb_heater` | ✅ Bang-bang + full safety cutoffs; SSR confirmed, heat cycle validated on hardware |
 | `pb_fan` | ✅ TRIAC **on/off held-gate** (stock model — the gate is never PWM'd/phase-chopped) |
@@ -70,7 +70,7 @@ auto / light / dark toggle are built in.
 ESP32-C3-MINI-1, mains PSU, PTC heater via SSR (GPIO18), ~220 VAC blower switched
 by a **TRIAC held on/off** (GPIO3 gate + GPIO7 zero-cross — **never** phase-angle
 PWM'd), two NTCs on ADC1. Full map: [`docs/HARDWARE.md`](docs/HARDWARE.md).
-Reverse-engineered from a **V1.0.1** board.
+Reverse-engineered from a **V1.0.1** board; also confirmed working on **V1.0**.
 
 ## Safety
 Two independent **hardware** over-temp backstops (a bonded thermal cutoff in the

--- a/components/pb_board/pb_board.c
+++ b/components/pb_board/pb_board.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include "pb_board.h"
 #include "esp_log.h"
+#include "esp_rom_sys.h"   // esp_rom_delay_us — let the strap settle before sampling
 
 static const char *TAG = "pb_board";
 
@@ -26,22 +27,61 @@ void pb_board_init(void)
 #endif
 }
 
+// Fail-safe Rref used when the strap can't be trusted (see below). 33 kOhm is the
+// SMALLER reference: a too-small Rref biases BOTH NTC readings WARM, so the fixed
+// 105 C / 85 C over-temp cutoffs trip early rather than late. (A too-large Rref would
+// read cold and let the element run hotter than the firmware believes.) It is also
+// the value the one observed floating board — Panda Breath V1.0 — actually needs.
+#define PB_RREF_FLOATING_DEFAULT_KOHM  33
+
 int pb_board_rref_kohm(void)
 {
 #ifdef CONFIG_PB_HIL_DEVBOARD
     return 82;
 #else
-    const gpio_config_t strap = {
+    // The Rref strap on GPIO19 selects the divider reference resistor (level 0 -> 82k,
+    // level 1 -> 33k) and is read once at boot. It MUST be read robustly: not every
+    // board firmly straps the pin, and a FLOATING input latches an arbitrary level
+    // that can differ between a cold power-on and a warm (OTA) reboot — silently
+    // picking the wrong Rref and shifting BOTH NTC readings by ~15 C (observed on a
+    // V1.0 board: 27 C after a cold flash, 12 C after an OTA reboot).
+    //
+    // Detect a floating pin by sampling it under an internal pull-up AND an internal
+    // pull-down: a FIRMLY strapped pin is driven by the board and reads the SAME both
+    // ways (trust it); a FLOATING pin follows whichever pull is enabled and the two
+    // reads DISAGREE (don't trust it — fall back to the fail-safe default).
+    gpio_config_t strap = {
         .pin_bit_mask = (1ULL << PB_GPIO_RREF_STRAP),
         .mode = GPIO_MODE_INPUT,
-        .pull_up_en = GPIO_PULLUP_DISABLE,
-        .pull_down_en = GPIO_PULLDOWN_DISABLE,
         .intr_type = GPIO_INTR_DISABLE,
     };
+
+    strap.pull_up_en = GPIO_PULLUP_ENABLE;
+    strap.pull_down_en = GPIO_PULLDOWN_DISABLE;
     gpio_config(&strap);
-    int level = gpio_get_level(PB_GPIO_RREF_STRAP);
-    int rref = (level == 0) ? 82 : 33;
-    ESP_LOGI(TAG, "Rref strap (GPIO19)=%d -> %d kOhm", level, rref);
-    return rref;
+    esp_rom_delay_us(2000);                       // settle through the ~45k internal pull
+    int with_pu = gpio_get_level(PB_GPIO_RREF_STRAP);
+
+    strap.pull_up_en = GPIO_PULLUP_DISABLE;
+    strap.pull_down_en = GPIO_PULLDOWN_ENABLE;
+    gpio_config(&strap);
+    esp_rom_delay_us(2000);
+    int with_pd = gpio_get_level(PB_GPIO_RREF_STRAP);
+
+    // Leave the pin as a plain high-Z input so we don't load the strap net at runtime.
+    strap.pull_up_en = GPIO_PULLUP_DISABLE;
+    strap.pull_down_en = GPIO_PULLDOWN_DISABLE;
+    gpio_config(&strap);
+
+    if (with_pu == with_pd) {
+        int level = with_pu;
+        int rref = (level == 0) ? 82 : 33;
+        ESP_LOGI(TAG, "Rref strap (GPIO19)=%d -> %d kOhm (firm)", level, rref);
+        return rref;
+    }
+
+    ESP_LOGW(TAG, "Rref strap (GPIO19) FLOATING (pu=%d pd=%d) -> defaulting to %d kOhm (fail-safe)",
+             with_pu, with_pd, PB_RREF_FLOATING_DEFAULT_KOHM);
+    return PB_RREF_FLOATING_DEFAULT_KOHM;
 #endif
 }

--- a/components/pb_heater/include/pb_heater.h
+++ b/components/pb_heater/include/pb_heater.h
@@ -67,36 +67,36 @@ static inline bool pb_heater_fault_decide(bool open_ok, bool ns_not_found,
 #define PB_HEATER_PTC_CUTOFF_C   105.0f   // element over-temp -> force off (stock parity)
 #define PB_HEATER_CHAMBER_MAX_C  85.0f    // chamber over-temp -> force off
 #define PB_HEATER_HYSTERESIS_C   1.0f
-// Soft element-temperature FOLDBACK, a layer strictly BELOW the hard cutoff: once the
-// PTC element climbs into [FOLDBACK_START, CUTOFF) the SSR duty is linearly reduced so
-// the element HOLDS just under the cutoff instead of slamming into the latching trip.
-// This never adds heat and never delays the hard cutoff — if the element still reaches
-// PB_HEATER_PTC_CUTOFF_C (welded SSR, runaway, sensor issue) the latching trip fires
-// exactly as before. It only shapes power below the wall so a marginal/hot install can
-// hold set-point instead of tripping and needing a manual clear.
-// Start point 100 C (5 C bleed-off band below the fixed 105 C cutoff). Bench testing at
-// 102 C held fine on the V1.0.1/82 kOhm board, but the V1.0/33 kOhm board was seen
-// running closer to the cutoff, so we give a wider 5 C margin for both — the small loss
-// of top-end heating on the 82 kOhm board is negligible.
-#define PB_HEATER_PTC_FOLDBACK_START_C  100.0f
+// Soft element-temperature FOLDBACK, a layer strictly BELOW the hard cutoff: it holds
+// the PTC element just under the 105 C trip so a marginal/hot install can reach set-point
+// instead of tripping and needing a manual clear. It never adds heat and never delays the
+// hard cutoff — if the element still reaches PB_HEATER_PTC_CUTOFF_C (welded SSR, runaway,
+// sensor issue) the latching trip fires exactly as before.
+//
+// Implemented as a HYSTERESIS hard-cut rather than a proportional duty ramp: a linear
+// ramp (full power at 100 C -> 0 only at 105 C) proved too gentle on a hot-running board
+// — ~50% duty at 102-103 C kept feeding the element so it ratcheted up to ~104.8 C (just
+// shy of the 105 C watchdog) with no real cool-down between the fast on/off ticks. The
+// hysteresis instead forces the SSR FULLY OFF at CUT_C and keeps it off until the element
+// cools below RESUME_C, giving a genuine cool-down cycle and capping the peak with margin.
+// Starting thresholds (to be tuned from field data); both stay below the 105 C cutoff.
+#define PB_HEATER_PTC_FOLDBACK_CUT_C     102.0f   // element >= this -> force SSR off
+#define PB_HEATER_PTC_FOLDBACK_RESUME_C   99.0f   // hold off until element cools below this
 
-// Pure element-temperature foldback, inline so it is host-testable without hardware.
-// Given the base demand duty `base_duty` (0..1, from the chamber bang-bang) and the
-// current PTC element temperature, returns the duty to apply: unchanged below
-// FOLDBACK_START, then linearly ramped to 0 as ptc_c -> CUTOFF. It can only ever
-// REDUCE base_duty (a cool element never boosts power). The hard cutoff (ptc >= CUTOFF)
-// is enforced separately as a latching trip; this shapes power strictly below it.
-static inline float pb_heater_foldback_duty(float base_duty, float ptc_c)
+// Pure element-foldback hysteresis, inline so it is host-testable without hardware.
+// Returns whether to FORCE the SSR off this tick given the element temperature, whether
+// its reading is valid, and the previous cut-latch state:
+//   ptc >= CUT_C               -> cut  (true)
+//   ptc <  RESUME_C            -> allow (false)
+//   RESUME_C <= ptc < CUT_C    -> hold the previous state (the hysteresis band)
+//   reading not OK             -> hold the previous state (a bad read is owned by the
+//                                 sensor-fault trip / hard cutoff, not by the foldback)
+static inline bool pb_heater_foldback_cut(bool ptc_ok, float ptc_c, bool prev_cut)
 {
-    float duty = base_duty;
-    if (ptc_c > PB_HEATER_PTC_FOLDBACK_START_C) {
-        const float span = PB_HEATER_PTC_CUTOFF_C - PB_HEATER_PTC_FOLDBACK_START_C;
-        float f = (PB_HEATER_PTC_CUTOFF_C - ptc_c) / span;   // 1 at start -> 0 at cutoff
-        if (f < 0.0f) f = 0.0f;
-        else if (f > 1.0f) f = 1.0f;
-        if (f < duty) duty = f;                              // only ever reduces
-    }
-    return duty;
+    if (!ptc_ok)                                    return prev_cut;
+    if (ptc_c >= PB_HEATER_PTC_FOLDBACK_CUT_C)      return true;
+    if (ptc_c <  PB_HEATER_PTC_FOLDBACK_RESUME_C)   return false;
+    return prev_cut;
 }
 // Settable set-point ceiling: default + absolute cap + floor. Raising the
 // production cap above 70 C is a separate hw-validation item (80 C leaves only

--- a/components/pb_heater/include/pb_heater.h
+++ b/components/pb_heater/include/pb_heater.h
@@ -74,7 +74,11 @@ static inline bool pb_heater_fault_decide(bool open_ok, bool ns_not_found,
 // PB_HEATER_PTC_CUTOFF_C (welded SSR, runaway, sensor issue) the latching trip fires
 // exactly as before. It only shapes power below the wall so a marginal/hot install can
 // hold set-point instead of tripping and needing a manual clear.
-#define PB_HEATER_PTC_FOLDBACK_START_C  100.0f
+// Start point bench-tuned to 102 C (3 C bleed-off band): a 100 C start trimmed power
+// noticeably earlier than needed given how fast the element responds to a duty cut,
+// costing chamber-heating performance; 102 keeps full power longer while still leaving
+// a 3 C margin to catch a hard-airflow-block climb before the 105 C trip.
+#define PB_HEATER_PTC_FOLDBACK_START_C  102.0f
 
 // Pure element-temperature foldback, inline so it is host-testable without hardware.
 // Given the base demand duty `base_duty` (0..1, from the chamber bang-bang) and the

--- a/components/pb_heater/include/pb_heater.h
+++ b/components/pb_heater/include/pb_heater.h
@@ -74,11 +74,11 @@ static inline bool pb_heater_fault_decide(bool open_ok, bool ns_not_found,
 // PB_HEATER_PTC_CUTOFF_C (welded SSR, runaway, sensor issue) the latching trip fires
 // exactly as before. It only shapes power below the wall so a marginal/hot install can
 // hold set-point instead of tripping and needing a manual clear.
-// Start point bench-tuned to 102 C (3 C bleed-off band): a 100 C start trimmed power
-// noticeably earlier than needed given how fast the element responds to a duty cut,
-// costing chamber-heating performance; 102 keeps full power longer while still leaving
-// a 3 C margin to catch a hard-airflow-block climb before the 105 C trip.
-#define PB_HEATER_PTC_FOLDBACK_START_C  102.0f
+// Start point 100 C (5 C bleed-off band below the fixed 105 C cutoff). Bench testing at
+// 102 C held fine on the V1.0.1/82 kOhm board, but the V1.0/33 kOhm board was seen
+// running closer to the cutoff, so we give a wider 5 C margin for both — the small loss
+// of top-end heating on the 82 kOhm board is negligible.
+#define PB_HEATER_PTC_FOLDBACK_START_C  100.0f
 
 // Pure element-temperature foldback, inline so it is host-testable without hardware.
 // Given the base demand duty `base_duty` (0..1, from the chamber bang-bang) and the

--- a/components/pb_heater/include/pb_heater.h
+++ b/components/pb_heater/include/pb_heater.h
@@ -77,25 +77,40 @@ static inline bool pb_heater_fault_decide(bool open_ok, bool ns_not_found,
 // ramp (full power at 100 C -> 0 only at 105 C) proved too gentle on a hot-running board
 // — ~50% duty at 102-103 C kept feeding the element so it ratcheted up to ~104.8 C (just
 // shy of the 105 C watchdog) with no real cool-down between the fast on/off ticks. The
-// hysteresis instead forces the SSR FULLY OFF at CUT_C and keeps it off until the element
-// cools below RESUME_C, giving a genuine cool-down cycle and capping the peak with margin.
-// Starting thresholds (to be tuned from field data); both stay below the 105 C cutoff.
-#define PB_HEATER_PTC_FOLDBACK_CUT_C      99.0f   // element >= this -> force SSR off
-#define PB_HEATER_PTC_FOLDBACK_RESUME_C   96.0f   // hold off until element cools below this
+// hysteresis instead forces the SSR FULLY OFF at the cut point and keeps it off until the
+// element cools below the resume point, giving a genuine cool-down cycle and capping the
+// peak with margin. The thresholds are PER BOARD VARIANT (selected by the Rref strap, see
+// pb_ntc_rref_kohm()): the 33 kOhm (V1.0) board runs the element hotter / ratchets, so it
+// gets a lower, more conservative cut; the 82 kOhm (V1.0.1) board tops out cooler and can
+// hold a higher cut without approaching 105. Both stay below the 105 C hard cutoff.
+#define PB_HEATER_PTC_FOLDBACK_CUT_82K_C     102.0f   // 82k board: element >= this -> cut
+#define PB_HEATER_PTC_FOLDBACK_RESUME_82K_C   99.0f   //           hold off until below this
+#define PB_HEATER_PTC_FOLDBACK_CUT_33K_C      99.0f   // 33k board: element >= this -> cut
+#define PB_HEATER_PTC_FOLDBACK_RESUME_33K_C   96.0f   //           hold off until below this
+
+// Resolve the foldback cut/resume thresholds for a board's Rref (kOhm). The 33 kOhm
+// variant (incl. a floating strap defaulted to 33k) gets the conservative pair; anything
+// else uses the 82 kOhm pair (the higher, more permissive default).
+static inline void pb_heater_foldback_thresholds(int rref_kohm, float *cut_c, float *resume_c)
+{
+    if (rref_kohm == 33) { *cut_c = PB_HEATER_PTC_FOLDBACK_CUT_33K_C; *resume_c = PB_HEATER_PTC_FOLDBACK_RESUME_33K_C; }
+    else                 { *cut_c = PB_HEATER_PTC_FOLDBACK_CUT_82K_C; *resume_c = PB_HEATER_PTC_FOLDBACK_RESUME_82K_C; }
+}
 
 // Pure element-foldback hysteresis, inline so it is host-testable without hardware.
 // Returns whether to FORCE the SSR off this tick given the element temperature, whether
-// its reading is valid, and the previous cut-latch state:
-//   ptc >= CUT_C               -> cut  (true)
-//   ptc <  RESUME_C            -> allow (false)
-//   RESUME_C <= ptc < CUT_C    -> hold the previous state (the hysteresis band)
+// its reading is valid, the previous cut-latch state, and the board's cut/resume points:
+//   ptc >= cut_c               -> cut  (true)
+//   ptc <  resume_c            -> allow (false)
+//   resume_c <= ptc < cut_c    -> hold the previous state (the hysteresis band)
 //   reading not OK             -> hold the previous state (a bad read is owned by the
 //                                 sensor-fault trip / hard cutoff, not by the foldback)
-static inline bool pb_heater_foldback_cut(bool ptc_ok, float ptc_c, bool prev_cut)
+static inline bool pb_heater_foldback_cut(bool ptc_ok, float ptc_c, bool prev_cut,
+                                          float cut_c, float resume_c)
 {
-    if (!ptc_ok)                                    return prev_cut;
-    if (ptc_c >= PB_HEATER_PTC_FOLDBACK_CUT_C)      return true;
-    if (ptc_c <  PB_HEATER_PTC_FOLDBACK_RESUME_C)   return false;
+    if (!ptc_ok)            return prev_cut;
+    if (ptc_c >= cut_c)     return true;
+    if (ptc_c <  resume_c)  return false;
     return prev_cut;
 }
 // Settable set-point ceiling: default + absolute cap + floor. Raising the

--- a/components/pb_heater/include/pb_heater.h
+++ b/components/pb_heater/include/pb_heater.h
@@ -80,8 +80,8 @@ static inline bool pb_heater_fault_decide(bool open_ok, bool ns_not_found,
 // hysteresis instead forces the SSR FULLY OFF at CUT_C and keeps it off until the element
 // cools below RESUME_C, giving a genuine cool-down cycle and capping the peak with margin.
 // Starting thresholds (to be tuned from field data); both stay below the 105 C cutoff.
-#define PB_HEATER_PTC_FOLDBACK_CUT_C     102.0f   // element >= this -> force SSR off
-#define PB_HEATER_PTC_FOLDBACK_RESUME_C   99.0f   // hold off until element cools below this
+#define PB_HEATER_PTC_FOLDBACK_CUT_C      99.0f   // element >= this -> force SSR off
+#define PB_HEATER_PTC_FOLDBACK_RESUME_C   96.0f   // hold off until element cools below this
 
 // Pure element-foldback hysteresis, inline so it is host-testable without hardware.
 // Returns whether to FORCE the SSR off this tick given the element temperature, whether

--- a/components/pb_heater/include/pb_heater.h
+++ b/components/pb_heater/include/pb_heater.h
@@ -67,6 +67,33 @@ static inline bool pb_heater_fault_decide(bool open_ok, bool ns_not_found,
 #define PB_HEATER_PTC_CUTOFF_C   105.0f   // element over-temp -> force off (stock parity)
 #define PB_HEATER_CHAMBER_MAX_C  85.0f    // chamber over-temp -> force off
 #define PB_HEATER_HYSTERESIS_C   1.0f
+// Soft element-temperature FOLDBACK, a layer strictly BELOW the hard cutoff: once the
+// PTC element climbs into [FOLDBACK_START, CUTOFF) the SSR duty is linearly reduced so
+// the element HOLDS just under the cutoff instead of slamming into the latching trip.
+// This never adds heat and never delays the hard cutoff — if the element still reaches
+// PB_HEATER_PTC_CUTOFF_C (welded SSR, runaway, sensor issue) the latching trip fires
+// exactly as before. It only shapes power below the wall so a marginal/hot install can
+// hold set-point instead of tripping and needing a manual clear.
+#define PB_HEATER_PTC_FOLDBACK_START_C  100.0f
+
+// Pure element-temperature foldback, inline so it is host-testable without hardware.
+// Given the base demand duty `base_duty` (0..1, from the chamber bang-bang) and the
+// current PTC element temperature, returns the duty to apply: unchanged below
+// FOLDBACK_START, then linearly ramped to 0 as ptc_c -> CUTOFF. It can only ever
+// REDUCE base_duty (a cool element never boosts power). The hard cutoff (ptc >= CUTOFF)
+// is enforced separately as a latching trip; this shapes power strictly below it.
+static inline float pb_heater_foldback_duty(float base_duty, float ptc_c)
+{
+    float duty = base_duty;
+    if (ptc_c > PB_HEATER_PTC_FOLDBACK_START_C) {
+        const float span = PB_HEATER_PTC_CUTOFF_C - PB_HEATER_PTC_FOLDBACK_START_C;
+        float f = (PB_HEATER_PTC_CUTOFF_C - ptc_c) / span;   // 1 at start -> 0 at cutoff
+        if (f < 0.0f) f = 0.0f;
+        else if (f > 1.0f) f = 1.0f;
+        if (f < duty) duty = f;                              // only ever reduces
+    }
+    return duty;
+}
 // Settable set-point ceiling: default + absolute cap + floor. Raising the
 // production cap above 70 C is a separate hw-validation item (80 C leaves only
 // 5 C below the fixed 85 C chamber trip — not enough margin without measured

--- a/components/pb_heater/pb_heater.c
+++ b/components/pb_heater/pb_heater.c
@@ -551,8 +551,11 @@ void pb_heater_tick(void)          // control-task context; sole writer of s_on
     // Step 2 — element-temperature foldback (hysteresis hard-cut). While the PTC element
     // is too hot we force the SSR fully OFF and hold it off until the element cools below
     // the resume point — a real cool-down cycle rather than half-power hovering near the
-    // 105 C hard cutoff. Pure + host-tested; ps==OK is guaranteed here (checked above).
-    s_fb_cut = pb_heater_foldback_cut(ps == PB_NTC_OK, ptc_c, s_fb_cut);
+    // 105 C hard cutoff. Thresholds are per board Rref variant (33k boards run hotter, so
+    // they get a lower cut). Pure + host-tested; ps==OK is guaranteed here (checked above).
+    float fb_cut, fb_resume;
+    pb_heater_foldback_thresholds(pb_ntc_rref_kohm(), &fb_cut, &fb_resume);
+    s_fb_cut = pb_heater_foldback_cut(ps == PB_NTC_OK, ptc_c, s_fb_cut, fb_cut, fb_resume);
 
     // Step 3 — drive the SSR: heat only when the chamber wants it AND the element is not
     // in foldback cut. (Zero-cross SSR: plain on/off, no phase-cut.)

--- a/components/pb_heater/pb_heater.c
+++ b/components/pb_heater/pb_heater.c
@@ -36,9 +36,10 @@ static int64_t     s_persist_retry_us; // guarded by s_mux — last persist-retr
 static bool        s_on;            // written only by the control task; atomic read
 static bool        s_heat_intent;   // control-task only — chamber-hysteresis latch (the
                                     // "want heat at all" decision, distinct from the
-                                    // momentary SSR state s_on which the foldback modulates)
-static float       s_duty_accum;    // control-task only — sigma-delta accumulator for the
-                                    // element-foldback time-proportioning of the zero-cross SSR
+                                    // momentary SSR state s_on)
+static bool        s_fb_cut;        // control-task only — element-foldback hysteresis latch:
+                                    // true while the SSR is force-cut for element over-temp
+                                    // (holds until the element cools below the resume point)
 static float       s_max_target_c;      // guarded by s_mux — settable set-point ceiling
 static int64_t     s_comms_timeout_us;  // guarded by s_mux — comms deadman (microseconds)
 static float       s_cool_release_c;    // guarded by s_mux — residual-heat purge "cool down to" temp
@@ -532,8 +533,8 @@ void pb_heater_tick(void)          // control-task context; sole writer of s_on
 
     if (latched || !armed) {
         if (s_on) ssr_set(false);
-        s_heat_intent = false;   // drop hysteresis + foldback state so the next arm
-        s_duty_accum  = 0.0f;    // starts clean rather than mid-modulation
+        s_heat_intent = false;   // drop the chamber + foldback latches so the next arm
+        s_fb_cut      = false;   // starts clean rather than mid-cycle
         return;
     }
 
@@ -546,24 +547,15 @@ void pb_heater_tick(void)          // control-task context; sole writer of s_on
     } else if (chamber_c >= target) {
         s_heat_intent = false;
     }
-    float duty = s_heat_intent ? 1.0f : 0.0f;
 
-    // Step 2 — element foldback: reduce the duty as the PTC element nears the cutoff so
-    // it holds just under it instead of tripping. Pure + host-tested; only ever cuts.
-    duty = pb_heater_foldback_duty(duty, ptc_c);
+    // Step 2 — element-temperature foldback (hysteresis hard-cut). While the PTC element
+    // is too hot we force the SSR fully OFF and hold it off until the element cools below
+    // the resume point — a real cool-down cycle rather than half-power hovering near the
+    // 105 C hard cutoff. Pure + host-tested; ps==OK is guaranteed here (checked above).
+    s_fb_cut = pb_heater_foldback_cut(ps == PB_NTC_OK, ptc_c, s_fb_cut);
 
-    // Step 3 — time-proportion the zero-cross SSR (it can't phase-cut) via a first-order
-    // sigma-delta: the average of the on/off decisions tracks `duty`. At 0.5 it toggles
-    // each ~500 ms tick; at ~0.2 it fires ~1 tick in 5. Endpoints are exact on/off.
-    bool drive;
-    if (duty <= 0.0f) {
-        drive = false; s_duty_accum = 0.0f;
-    } else if (duty >= 1.0f) {
-        drive = true;  s_duty_accum = 0.0f;
-    } else {
-        s_duty_accum += duty;
-        if (s_duty_accum >= 1.0f) { drive = true;  s_duty_accum -= 1.0f; }
-        else                      { drive = false; }
-    }
+    // Step 3 — drive the SSR: heat only when the chamber wants it AND the element is not
+    // in foldback cut. (Zero-cross SSR: plain on/off, no phase-cut.)
+    bool drive = s_heat_intent && !s_fb_cut;
     if (drive != s_on) ssr_set(drive);
 }

--- a/components/pb_heater/pb_heater.c
+++ b/components/pb_heater/pb_heater.c
@@ -34,6 +34,11 @@ static bool        s_persist_pending;  // guarded by s_mux — a latch persist n
                                        // to NVS; retried from pb_heater_tick until it lands
 static int64_t     s_persist_retry_us; // guarded by s_mux — last persist-retry timestamp
 static bool        s_on;            // written only by the control task; atomic read
+static bool        s_heat_intent;   // control-task only — chamber-hysteresis latch (the
+                                    // "want heat at all" decision, distinct from the
+                                    // momentary SSR state s_on which the foldback modulates)
+static float       s_duty_accum;    // control-task only — sigma-delta accumulator for the
+                                    // element-foldback time-proportioning of the zero-cross SSR
 static float       s_max_target_c;      // guarded by s_mux — settable set-point ceiling
 static int64_t     s_comms_timeout_us;  // guarded by s_mux — comms deadman (microseconds)
 static float       s_cool_release_c;    // guarded by s_mux — residual-heat purge "cool down to" temp
@@ -527,13 +532,38 @@ void pb_heater_tick(void)          // control-task context; sole writer of s_on
 
     if (latched || !armed) {
         if (s_on) ssr_set(false);
+        s_heat_intent = false;   // drop hysteresis + foldback state so the next arm
+        s_duty_accum  = 0.0f;    // starts clean rather than mid-modulation
         return;
     }
 
-    // Here: armed && !latched && cs==OK && ps==OK — bang-bang with hysteresis.
-    if (!s_on && chamber_c < (target - PB_HEATER_HYSTERESIS_C)) {
-        ssr_set(true);
-    } else if (s_on && chamber_c >= target) {
-        ssr_set(false);
+    // Here: armed && !latched && cs==OK && ps==OK.
+    // Step 1 — chamber bang-bang with hysteresis decides the BASE demand (do we want
+    // heat at all). s_heat_intent holds across the hysteresis band; it is the steady
+    // "want heat" latch, distinct from the momentary SSR state s_on.
+    if (chamber_c < (target - PB_HEATER_HYSTERESIS_C)) {
+        s_heat_intent = true;
+    } else if (chamber_c >= target) {
+        s_heat_intent = false;
     }
+    float duty = s_heat_intent ? 1.0f : 0.0f;
+
+    // Step 2 — element foldback: reduce the duty as the PTC element nears the cutoff so
+    // it holds just under it instead of tripping. Pure + host-tested; only ever cuts.
+    duty = pb_heater_foldback_duty(duty, ptc_c);
+
+    // Step 3 — time-proportion the zero-cross SSR (it can't phase-cut) via a first-order
+    // sigma-delta: the average of the on/off decisions tracks `duty`. At 0.5 it toggles
+    // each ~500 ms tick; at ~0.2 it fires ~1 tick in 5. Endpoints are exact on/off.
+    bool drive;
+    if (duty <= 0.0f) {
+        drive = false; s_duty_accum = 0.0f;
+    } else if (duty >= 1.0f) {
+        drive = true;  s_duty_accum = 0.0f;
+    } else {
+        s_duty_accum += duty;
+        if (s_duty_accum >= 1.0f) { drive = true;  s_duty_accum -= 1.0f; }
+        else                      { drive = false; }
+    }
+    if (drive != s_on) ssr_set(drive);
 }

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -257,6 +257,9 @@ static esp_err_t info_get(httpd_req_t *req)
     cJSON_AddStringToObject(o, "boot_id", s_boot_id);
     cJSON_AddStringToObject(o, "firmware", esp_app_get_description()->version);
     cJSON_AddStringToObject(o, "project", esp_app_get_description()->project_name);
+    // Divider reference resistor resolved from the GPIO19 strap (diagnostic): 82 or
+    // 33 kOhm; a board whose strap floats comes up at the fail-safe 33 kOhm default.
+    cJSON_AddNumberToObject(o, "rref_kohm", pb_ntc_rref_kohm());
     cJSON *cap = cJSON_AddArrayToObject(o, "capabilities");
     cJSON_AddItemToArray(cap, cJSON_CreateString("power_on"));
     cJSON_AddItemToArray(cap, cJSON_CreateString("auto"));

--- a/components/pb_ntc/include/pb_ntc.h
+++ b/components/pb_ntc/include/pb_ntc.h
@@ -27,6 +27,11 @@ typedef enum {
 // Rref from the board strap. Returns ESP_OK on success.
 esp_err_t pb_ntc_init(void);
 
+// The divider reference resistor (82 or 33 kOhm) resolved from the GPIO19 strap at
+// init. Exposed for diagnostics — confirms which Rref branch a board came up on (a
+// floating strap resolves to the fail-safe default). 0 before pb_ntc_init().
+int pb_ntc_rref_kohm(void);
+
 // Take one calibrated reading of the given channel. Returns the status; on
 // PB_NTC_OK *out_c holds the INSTANTANEOUS temperature in C (NAN on any fault),
 // so safety cutoffs act on the freshest sample. A successful read also feeds the

--- a/components/pb_ntc/pb_ntc.c
+++ b/components/pb_ntc/pb_ntc.c
@@ -275,6 +275,11 @@ esp_err_t pb_ntc_init(void)
     return ESP_OK;
 }
 
+// The divider reference resistor resolved at init (82 or 33 kOhm). Exposed for
+// diagnostics: a board whose GPIO19 strap floats comes up at the fail-safe default,
+// and seeing this value confirms which branch was selected. 0 before pb_ntc_init().
+int pb_ntc_rref_kohm(void) { return s_rref_kohm; }
+
 // Returns the INSTANTANEOUS temperature in *out_c (NAN on any fault) so the
 // heater over-temp cutoffs act on the freshest sample, not a lagged average.
 // A successful read still feeds the moving-average filter that backs

--- a/components/pb_portal/pb_portal.c
+++ b/components/pb_portal/pb_portal.c
@@ -196,19 +196,36 @@ static const char FW_BODY[] =
     // Stream the chosen .bin to /update with the auth header; device validates,
     // reports the SHA-256 it computed over the received image, and reboots. A
     // dropped connection on .catch is the expected reboot path.
+    // XHR (not fetch) so upload.onprogress can show a live %; the device writes bytes to
+    // flash as it receives them, so upload progress tracks flashing. On success we poll
+    // the rebooting device and return to the main screen automatically (waitBack).
     "function doUpdate(){var f=document.getElementById('fw').files[0];"
     "var m=document.getElementById('fwmsg');"
     "if(!f){m.innerHTML='<small>Choose a .bin file first.</small>';return;}"
-    "m.innerHTML='<small>Uploading &amp; flashing\\u2026 do not power off.</small>';"
-    "fetch('/update',{method:'POST',headers:hdr(),body:f})"
-    ".then(function(r){return r.json().then(function(j){return {s:r.status,j:j};})"
-    ".catch(function(){return {s:r.status,j:{}};});})"
-    ".then(function(x){if(x.j&&x.j.ok){m.innerHTML='<h3>Flashed \\u2713</h3>"
-    "<small>SHA-256 of uploaded image:<br><code>'+(x.j.sha256||'?')+'</code><br>"
-    "Rebooting into the new firmware\\u2026</small>';}"
-    "else{m.innerHTML='<small>Update failed: '+((x.j&&x.j.error)||('HTTP '+x.s))+'</small>';}})"
-    ".catch(function(){m.innerHTML='<small>Connection lost \\u2014 if it was flashing, "
-    "the device is rebooting into the new firmware.</small>';});}"
+    "document.getElementById('fwbtn').disabled=true;"
+    "m.innerHTML='<small>Uploading &amp; flashing\\u2026 0%<br>do not power off.</small>';"
+    "var up=false;var x=new XMLHttpRequest();x.open('POST','/update');"
+    "x.setRequestHeader('X-DragonBreath-Auth',tok());"
+    "x.upload.onprogress=function(e){if(e.lengthComputable){var p=Math.round(e.loaded/e.total*100);"
+    "m.innerHTML='<small>Uploading &amp; flashing\\u2026 '+p+'%<br>do not power off.</small>';}};"
+    "x.upload.onload=function(){up=true;m.innerHTML='<small>Verifying image\\u2026 do not power off.</small>';};"
+    "x.onload=function(){var j={};try{j=JSON.parse(x.responseText);}catch(e){}"
+    "if(j&&j.ok){m.innerHTML='<h3>Flashed \\u2713</h3><small>SHA-256 of uploaded image:<br>"
+    "<code>'+(j.sha256||'?')+'</code><br>Rebooting into the new firmware\\u2026 reconnecting.</small>';waitBack();}"
+    "else{document.getElementById('fwbtn').disabled=false;"
+    "m.innerHTML='<small>Update failed: '+((j&&j.error)||('HTTP '+x.status))+'</small>';}};"
+    // A dropped connection AFTER the upload finished is the expected reboot; before it,
+    // it's a genuine upload failure.
+    "x.onerror=function(){if(up){m.innerHTML='<h3>Flashed \\u2713</h3><small>Connection lost \\u2014 the "
+    "device is rebooting into the new firmware\\u2026 reconnecting.</small>';waitBack();}"
+    "else{document.getElementById('fwbtn').disabled=false;"
+    "m.innerHTML='<small>Update failed: connection lost during upload \\u2014 try again.</small>';}};"
+    "x.send(f);}"
+    // Poll the rebooting device until it answers on the new firmware, then go to the main
+    // screen automatically. ~2 min fallback if we can't confirm (redirect anyway).
+    "function waitBack(){var n=0;var iv=setInterval(function(){n++;"
+    "fetch('/api/v2/info',{cache:'no-store'}).then(function(r){if(r.ok){clearInterval(iv);location.href='/';}})"
+    ".catch(function(){});if(n>60){clearInterval(iv);location.href='/';}},2000);}"
     // Update check (Flow A): only on OFFICIAL builds (clean vX.Y.Z), ask GitHub for
     // the latest release; if newer, show a download link + expected SHA-256. The
     // browser can't read release-asset bytes (no CORS), so the user downloads then

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -178,11 +178,24 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
   transition: width .3s ease; }
 .target{ color: var(--muted-foreground); font-size: 12px; }
 
-.temp-chart{ position: absolute; inset: 28px 7px 7px; width: calc(100% - 14px);
-  height: calc(100% - 35px); color: var(--viz-series-1); opacity: .28; pointer-events: none; }
+.temp-head{ display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.legend{ display: flex; gap: 10px; font-size: 10px; color: var(--muted-foreground);
+  text-transform: uppercase; letter-spacing: .02em; }
+.legend .lg{ display: inline-flex; align-items: center; gap: 4px; }
+.legend .lg::before{ content: ''; width: 10px; height: 2px; border-radius: 1px; background: currentColor; }
+.legend .lg-ch::before{ background: var(--viz-series-1); }
+.legend .lg-ptc::before{ background: var(--viz-series-3); }
+.chart-wrap{ display: flex; align-items: stretch; gap: 5px; height: 96px; margin-top: 8px; }
+.y-axis{ display: flex; flex-direction: column; justify-content: space-between; padding: 1px 0;
+  min-width: 26px; text-align: right; font-size: 10px; color: var(--muted-foreground); }
+.x-axis{ display: flex; justify-content: space-between; margin: 3px 0 0 31px;
+  font-size: 10px; color: var(--muted-foreground); }
+.temp-chart{ flex: 1; min-width: 0; height: 100%; pointer-events: none; }
 .temp-chart .gridline{ stroke: var(--border); stroke-width: 1; }
-.temp-chart .area{ fill: color-mix(in srgb, var(--viz-series-1) 18%, transparent); stroke: none; }
-.temp-chart .line{ fill: none; stroke: currentColor; stroke-width: 2.2; vector-effect: non-scaling-stroke; }
+.temp-chart .area{ fill: color-mix(in srgb, var(--viz-series-1) 14%, transparent); stroke: none; }
+.temp-chart .line{ fill: none; stroke-width: 2; vector-effect: non-scaling-stroke; }
+.temp-chart .line-ch{ stroke: var(--viz-series-1); }
+.temp-chart .line-ptc{ stroke: var(--viz-series-3); }
 
 .status-card{ display: flex; flex-direction: column; gap: 8px; }
 .state{ display: flex; align-items: center; gap: 8px; margin-top: 2px; font-size: 17px; font-weight: 700; }
@@ -383,16 +396,24 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
       <!-- Dashboard (home). Live-bound to /api/v2/state + /api/v2/events. -->
       <div class="grid">
         <section class="card">
-          <h3>Chamber temperature</h3>
-          <svg class="temp-chart" viewBox="0 0 320 120" preserveAspectRatio="none" role="img" aria-label="Chamber temperature trend">
-            <path class="gridline" d="M0 30H320M0 70H320M0 110H320"/>
-            <path class="area" id="db-area" d=""/>
-            <path class="line" id="db-trend" d=""/>
-          </svg>
+          <div class="temp-head">
+            <h3>Chamber temperature</h3>
+            <div class="legend"><span class="lg lg-ch">Chamber</span><span class="lg lg-ptc">PTC</span></div>
+          </div>
           <div class="temperature">
             <div class="chamber-reading"><strong id="db-temp">--</strong><span>°C</span></div>
             <div class="ptc-reading"><span>PTC</span><strong id="db-ptc">--</strong></div>
           </div>
+          <div class="chart-wrap">
+            <div class="y-axis"><span id="db-ymax">--</span><span id="db-ymin">--</span></div>
+            <svg class="temp-chart" viewBox="0 0 320 120" preserveAspectRatio="none" role="img" aria-label="Chamber and PTC element temperature trend">
+              <path class="gridline" d="M0 30H320M0 70H320M0 110H320"/>
+              <path class="area" id="db-area" d=""/>
+              <path class="line line-ch" id="db-trend" d=""/>
+              <path class="line line-ptc" id="db-trend-ptc" d=""/>
+            </svg>
+          </div>
+          <div class="x-axis"><span id="db-xspan">—</span><span>now</span></div>
           <div class="bar"><span id="db-progress"></span></div>
           <div class="target">Target <strong id="db-target">--</strong></div>
         </section>
@@ -736,21 +757,43 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
 
   /* ---- Temperature trend: client-side ring buffer of chamber samples from the
      2 s telemetry (cap 120 ~ 4 min), rendered into the SVG area chart. ---- */
-  var buf = [];
-  function pushTemp(t){ if(t==null || !isFinite(t)) return; buf.push(t); if(buf.length>120) buf.shift(); drawTrend(); }
-  function drawTrend(){
-    var W=320,H=120, line=$('db-trend'), area=$('db-area');
-    if(buf.length<2){ line.setAttribute('d',''); area.setAttribute('d',''); return; }
-    var min=Math.min.apply(null,buf), max=Math.max.apply(null,buf);
-    if(max-min<1) max=min+1;
-    var pad=(max-min)*0.15; min-=pad; max+=pad;
-    var n=buf.length, d='';
-    for(var i=0;i<n;i++){
-      var x=(i/(n-1))*W, y=H-((buf[i]-min)/(max-min))*H;
-      d += (i?'L':'M')+x.toFixed(1)+' '+y.toFixed(1);
+  var buf = [], bufP = [];   // chamber + PTC-element parallel ring buffers (2 s samples)
+  function pushTemp(ch, pt){
+    buf.push((ch==null||!isFinite(ch))?null:ch);
+    bufP.push((pt==null||!isFinite(pt))?null:pt);
+    if(buf.length>120){ buf.shift(); bufP.shift(); }
+    drawTrend();
+  }
+  /* Build an SVG path for one series against a shared [min,max] scale; a null value
+     breaks the line (starts a fresh sub-path) so gaps don't draw through zero. */
+  function seriesPath(arr,min,max,W,H){
+    var d='', pen=false, span=Math.max(1,arr.length-1);
+    for(var i=0;i<arr.length;i++){
+      if(arr[i]==null){ pen=false; continue; }
+      var x=(i/span)*W, y=H-((arr[i]-min)/(max-min))*H;
+      d += (pen?'L':'M')+x.toFixed(1)+' '+y.toFixed(1); pen=true;
     }
-    line.setAttribute('d', d);
-    area.setAttribute('d', d+'L'+W+' '+H+'L0 '+H+'Z');
+    return d;
+  }
+  function drawTrend(){
+    var W=320,H=120;
+    var line=$('db-trend'), lineP=$('db-trend-ptc'), area=$('db-area');
+    var all=buf.concat(bufP).filter(function(v){return v!=null;});
+    if(all.length<2){ line.setAttribute('d',''); lineP.setAttribute('d',''); area.setAttribute('d','');
+      u('db-ymax','--'); u('db-ymin','--'); return; }
+    var min=Math.min.apply(null,all), max=Math.max.apply(null,all);
+    if(max-min<1) max=min+1;
+    var pad=(max-min)*0.12; min-=pad; max+=pad;
+    var dch=seriesPath(buf,min,max,W,H), dpt=seriesPath(bufP,min,max,W,H);
+    line.setAttribute('d', dch);
+    lineP.setAttribute('d', dpt);
+    /* faint fill under the chamber line (single contiguous run only, to avoid
+       artefacts when there are gaps). */
+    area.setAttribute('d', (dch && dch.indexOf('M',1)<0) ? (dch+'L'+W+' '+H+'L0 '+H+'Z') : '');
+    u('db-ymax', Math.round(max)+'°');
+    u('db-ymin', Math.round(min)+'°');
+    var mins=Math.round(buf.length*2/60);
+    u('db-xspan', mins>=1 ? ('−'+mins+' min') : ('−'+(buf.length*2)+' s'));
   }
 
   /* ---- Map a snapshot to a display state (drives the status light + labels). ---- */
@@ -843,7 +886,7 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
       pct = Math.max(0, Math.min(100, (c.temperature_c/s.target.effective_c)*100));
     $('db-progress').style.width = pct.toFixed(0)+'%';
 
-    pushTemp(c.status==='ok' ? c.temperature_c : null);
+    pushTemp(c.status==='ok' ? c.temperature_c : null, p.status==='ok' ? p.temperature_c : null);
 
     /* Stop enabled only while a mode is running. */
     $('db-stop').disabled = s.mode==='off';

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -185,7 +185,8 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
 .legend .lg::before{ content: ''; width: 10px; height: 2px; border-radius: 1px; background: currentColor; }
 .legend .lg-ch::before{ background: var(--viz-series-1); }
 .legend .lg-ptc::before{ background: var(--viz-series-3); }
-.chart-wrap{ display: flex; align-items: stretch; gap: 5px; height: 96px; margin-top: 8px; }
+.temp-card{ display: flex; flex-direction: column; }
+.chart-wrap{ display: flex; align-items: stretch; gap: 5px; flex: 1; min-height: 96px; margin-top: 8px; }
 .y-axis{ display: flex; flex-direction: column; justify-content: space-between; padding: 1px 0;
   min-width: 26px; text-align: right; font-size: 10px; color: var(--muted-foreground); }
 .x-axis{ display: flex; justify-content: space-between; margin: 3px 0 0 31px;
@@ -193,6 +194,7 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
 .temp-chart{ flex: 1; min-width: 0; height: 100%; pointer-events: none; }
 .temp-chart .gridline{ stroke: var(--border); stroke-width: 1; }
 .temp-chart .area{ fill: color-mix(in srgb, var(--viz-series-1) 14%, transparent); stroke: none; }
+.temp-chart .area-ptc{ fill: color-mix(in srgb, var(--viz-series-3) 12%, transparent); stroke: none; }
 .temp-chart .line{ fill: none; stroke-width: 2; vector-effect: non-scaling-stroke; }
 .temp-chart .line-ch{ stroke: var(--viz-series-1); }
 .temp-chart .line-ptc{ stroke: var(--viz-series-3); }
@@ -395,7 +397,7 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
 
       <!-- Dashboard (home). Live-bound to /api/v2/state + /api/v2/events. -->
       <div class="grid">
-        <section class="card">
+        <section class="card temp-card">
           <div class="temp-head">
             <h3>Chamber temperature</h3>
             <div class="legend"><span class="lg lg-ch">Chamber</span><span class="lg lg-ptc">PTC</span></div>
@@ -408,6 +410,7 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
             <div class="y-axis"><span id="db-ymax">--</span><span id="db-ymin">--</span></div>
             <svg class="temp-chart" viewBox="0 0 320 120" preserveAspectRatio="none" role="img" aria-label="Chamber and PTC element temperature trend">
               <path class="gridline" d="M0 30H320M0 70H320M0 110H320"/>
+              <path class="area area-ptc" id="db-area-ptc" d=""/>
               <path class="area" id="db-area" d=""/>
               <path class="line line-ch" id="db-trend" d=""/>
               <path class="line line-ptc" id="db-trend-ptc" d=""/>
@@ -777,10 +780,10 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
   }
   function drawTrend(){
     var W=320,H=120;
-    var line=$('db-trend'), lineP=$('db-trend-ptc'), area=$('db-area');
+    var line=$('db-trend'), lineP=$('db-trend-ptc'), area=$('db-area'), areaP=$('db-area-ptc');
     var all=buf.concat(bufP).filter(function(v){return v!=null;});
     if(all.length<2){ line.setAttribute('d',''); lineP.setAttribute('d',''); area.setAttribute('d','');
-      u('db-ymax','--'); u('db-ymin','--'); return; }
+      areaP.setAttribute('d',''); u('db-ymax','--'); u('db-ymin','--'); return; }
     var min=Math.min.apply(null,all), max=Math.max.apply(null,all);
     if(max-min<1) max=min+1;
     var pad=(max-min)*0.12; min-=pad; max+=pad;
@@ -790,6 +793,7 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
     /* faint fill under the chamber line (single contiguous run only, to avoid
        artefacts when there are gaps). */
     area.setAttribute('d', (dch && dch.indexOf('M',1)<0) ? (dch+'L'+W+' '+H+'L0 '+H+'Z') : '');
+    areaP.setAttribute('d', (dpt && dpt.indexOf('M',1)<0) ? (dpt+'L'+W+' '+H+'L0 '+H+'Z') : '');
     u('db-ymax', Math.round(max)+'°');
     u('db-ymin', Math.round(min)+'°');
     var mins=Math.round(buf.length*2/60);

--- a/tests/pb_heater_fault_host_test.c
+++ b/tests/pb_heater_fault_host_test.c
@@ -69,22 +69,21 @@ int main(void)
     // --- Element-temperature foldback limiter (pb_heater_foldback_duty) ---------
     // Below the foldback band the base demand passes through untouched.
     CHECK(FEQ(pb_heater_foldback_duty(1.0f, 25.0f), 1.0f));
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 99.0f), 1.0f));
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, PB_HEATER_PTC_FOLDBACK_START_C), 1.0f)); // 100 -> full
-    // Inside the band [100, 105) the duty ramps linearly to 0 (span = 5 C).
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 101.0f), 0.8f));
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 102.5f), 0.5f));
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 104.0f), 0.2f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 101.0f), 1.0f));                          // below 102 -> full
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, PB_HEATER_PTC_FOLDBACK_START_C), 1.0f));  // 102 -> full
+    // Inside the band [102, 105) the duty ramps linearly to 0 (span = 3 C).
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 103.5f), 0.5f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 104.0f), 1.0f / 3.0f));
     // At/above the cutoff the foldback duty is 0 (the hard latching trip owns >= cutoff).
     CHECK(FEQ(pb_heater_foldback_duty(1.0f, PB_HEATER_PTC_CUTOFF_C), 0.0f));          // 105 -> 0
     CHECK(FEQ(pb_heater_foldback_duty(1.0f, 110.0f), 0.0f));
     // It only ever REDUCES: a base demand of 0 (chamber satisfied) stays 0 even when
     // the element is cool, and the cap never exceeds the base demand.
     CHECK(FEQ(pb_heater_foldback_duty(0.0f, 25.0f), 0.0f));
-    CHECK(FEQ(pb_heater_foldback_duty(0.0f, 103.0f), 0.0f));
+    CHECK(FEQ(pb_heater_foldback_duty(0.0f, 104.0f), 0.0f));
     // A base demand already below the foldback cap is left as-is (min, not overwrite):
-    // at 102.5 C the cap is 0.5, so a base of 0.3 stays 0.3.
-    CHECK(FEQ(pb_heater_foldback_duty(0.3f, 102.5f), 0.3f));
+    // at 103.5 C the cap is 0.5, so a base of 0.3 stays 0.3.
+    CHECK(FEQ(pb_heater_foldback_duty(0.3f, 103.5f), 0.3f));
     puts("pb_heater element-foldback checks: PASS");
     return 0;
 }

--- a/tests/pb_heater_fault_host_test.c
+++ b/tests/pb_heater_fault_host_test.c
@@ -8,6 +8,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
 
 #define CHECK(expr) do { \
     if (!(expr)) { \
@@ -15,6 +16,9 @@
         exit(1); \
     } \
 } while (0)
+
+// Float-equality check for the foldback duty (values are exact-ish ratios of 5).
+#define FEQ(a, b) (fabsf((a) - (b)) < 1e-4f)
 
 int main(void)
 {
@@ -61,5 +65,26 @@ int main(void)
     CHECK(code == PB_FAULT_NVS_UNREADABLE);
 
     puts("pb_heater fault-restore checks: PASS");
+
+    // --- Element-temperature foldback limiter (pb_heater_foldback_duty) ---------
+    // Below the foldback band the base demand passes through untouched.
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 25.0f), 1.0f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 99.0f), 1.0f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, PB_HEATER_PTC_FOLDBACK_START_C), 1.0f)); // 100 -> full
+    // Inside the band [100, 105) the duty ramps linearly to 0 (span = 5 C).
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 101.0f), 0.8f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 102.5f), 0.5f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 104.0f), 0.2f));
+    // At/above the cutoff the foldback duty is 0 (the hard latching trip owns >= cutoff).
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, PB_HEATER_PTC_CUTOFF_C), 0.0f));          // 105 -> 0
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 110.0f), 0.0f));
+    // It only ever REDUCES: a base demand of 0 (chamber satisfied) stays 0 even when
+    // the element is cool, and the cap never exceeds the base demand.
+    CHECK(FEQ(pb_heater_foldback_duty(0.0f, 25.0f), 0.0f));
+    CHECK(FEQ(pb_heater_foldback_duty(0.0f, 103.0f), 0.0f));
+    // A base demand already below the foldback cap is left as-is (min, not overwrite):
+    // at 102.5 C the cap is 0.5, so a base of 0.3 stays 0.3.
+    CHECK(FEQ(pb_heater_foldback_duty(0.3f, 102.5f), 0.3f));
+    puts("pb_heater element-foldback checks: PASS");
     return 0;
 }

--- a/tests/pb_heater_fault_host_test.c
+++ b/tests/pb_heater_fault_host_test.c
@@ -66,31 +66,29 @@ int main(void)
 
     puts("pb_heater fault-restore checks: PASS");
 
-    // --- Element-temperature foldback limiter (pb_heater_foldback_duty) ---------
-    // Expectations are DERIVED from the two defines so the single-source-of-truth
-    // #define PB_HEATER_PTC_FOLDBACK_START_C can be retuned without editing the test.
-    const float start = PB_HEATER_PTC_FOLDBACK_START_C;
-    const float cutoff = PB_HEATER_PTC_CUTOFF_C;
-    const float span = cutoff - start;
-    const float mid = start + span * 0.5f;   // duty 0.5
-    const float qtr = start + span * 0.25f;  // duty 0.75
-    // Below the foldback band the base demand passes through untouched.
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 25.0f), 1.0f));
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, start - 1.0f), 1.0f));   // just below band -> full
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, start), 1.0f));          // at start -> full
-    // Inside the band the duty ramps linearly to 0 across the span.
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, qtr), 0.75f));
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, mid), 0.5f));
-    // At/above the cutoff the foldback duty is 0 (the hard latching trip owns >= cutoff).
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, cutoff), 0.0f));
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, cutoff + 5.0f), 0.0f));
-    // It only ever REDUCES: a base demand of 0 (chamber satisfied) stays 0 even when
-    // the element is cool, and the cap never exceeds the base demand.
-    CHECK(FEQ(pb_heater_foldback_duty(0.0f, 25.0f), 0.0f));
-    CHECK(FEQ(pb_heater_foldback_duty(0.0f, mid), 0.0f));
-    // A base demand already below the foldback cap is left as-is (min, not overwrite):
-    // at the band midpoint the cap is 0.5, so a base of 0.3 stays 0.3.
-    CHECK(FEQ(pb_heater_foldback_duty(0.3f, mid), 0.3f));
+    // --- Element-foldback hysteresis (pb_heater_foldback_cut) -------------------
+    // Thresholds derived from the defines so they can be retuned without editing the
+    // test. cut >= CUT_C, resume < RESUME_C, hold in the band, hold on a bad read.
+    const float cut_c = PB_HEATER_PTC_FOLDBACK_CUT_C;
+    const float resume_c = PB_HEATER_PTC_FOLDBACK_RESUME_C;
+    const float band_mid = (cut_c + resume_c) * 0.5f;    // inside the hysteresis band
+    // At/above CUT_C -> cut, regardless of previous state.
+    CHECK(pb_heater_foldback_cut(true, cut_c,        false) == true);
+    CHECK(pb_heater_foldback_cut(true, cut_c + 5.0f, false) == true);
+    CHECK(pb_heater_foldback_cut(true, cut_c,        true)  == true);
+    // Below RESUME_C -> allow (release the cut), regardless of previous state.
+    CHECK(pb_heater_foldback_cut(true, resume_c - 0.1f, true)  == false);
+    CHECK(pb_heater_foldback_cut(true, 25.0f,           true)  == false);
+    CHECK(pb_heater_foldback_cut(true, resume_c - 0.1f, false) == false);
+    // Inside [RESUME_C, CUT_C) -> HOLD the previous state (this is the hysteresis).
+    CHECK(pb_heater_foldback_cut(true, band_mid, true)  == true);    // still cutting
+    CHECK(pb_heater_foldback_cut(true, band_mid, false) == false);   // still allowing
+    CHECK(pb_heater_foldback_cut(true, resume_c, true)  == true);    // resume is exclusive
+    // A bad/unknown PTC read holds the previous state (sensor-fault trip owns bad reads).
+    CHECK(pb_heater_foldback_cut(false, 0.0f, true)  == true);
+    CHECK(pb_heater_foldback_cut(false, 0.0f, false) == false);
+    // Sanity: both thresholds sit below the hard cutoff so a cut always precedes a trip.
+    CHECK(cut_c < PB_HEATER_PTC_CUTOFF_C && resume_c < cut_c);
     puts("pb_heater element-foldback checks: PASS");
     return 0;
 }

--- a/tests/pb_heater_fault_host_test.c
+++ b/tests/pb_heater_fault_host_test.c
@@ -67,28 +67,32 @@ int main(void)
     puts("pb_heater fault-restore checks: PASS");
 
     // --- Element-foldback hysteresis (pb_heater_foldback_cut) -------------------
-    // Thresholds derived from the defines so they can be retuned without editing the
-    // test. cut >= CUT_C, resume < RESUME_C, hold in the band, hold on a bad read.
-    const float cut_c = PB_HEATER_PTC_FOLDBACK_CUT_C;
-    const float resume_c = PB_HEATER_PTC_FOLDBACK_RESUME_C;
-    const float band_mid = (cut_c + resume_c) * 0.5f;    // inside the hysteresis band
-    // At/above CUT_C -> cut, regardless of previous state.
-    CHECK(pb_heater_foldback_cut(true, cut_c,        false) == true);
-    CHECK(pb_heater_foldback_cut(true, cut_c + 5.0f, false) == true);
-    CHECK(pb_heater_foldback_cut(true, cut_c,        true)  == true);
-    // Below RESUME_C -> allow (release the cut), regardless of previous state.
-    CHECK(pb_heater_foldback_cut(true, resume_c - 0.1f, true)  == false);
-    CHECK(pb_heater_foldback_cut(true, 25.0f,           true)  == false);
-    CHECK(pb_heater_foldback_cut(true, resume_c - 0.1f, false) == false);
-    // Inside [RESUME_C, CUT_C) -> HOLD the previous state (this is the hysteresis).
-    CHECK(pb_heater_foldback_cut(true, band_mid, true)  == true);    // still cutting
-    CHECK(pb_heater_foldback_cut(true, band_mid, false) == false);   // still allowing
-    CHECK(pb_heater_foldback_cut(true, resume_c, true)  == true);    // resume is exclusive
-    // A bad/unknown PTC read holds the previous state (sensor-fault trip owns bad reads).
-    CHECK(pb_heater_foldback_cut(false, 0.0f, true)  == true);
-    CHECK(pb_heater_foldback_cut(false, 0.0f, false) == false);
-    // Sanity: both thresholds sit below the hard cutoff so a cut always precedes a trip.
-    CHECK(cut_c < PB_HEATER_PTC_CUTOFF_C && resume_c < cut_c);
+    // Per-Rref thresholds: 33k board gets the conservative pair, anything else the 82k
+    // pair. Resolve both via the helper and exercise the hysteresis on each.
+    float cut82, res82, cut33, res33;
+    pb_heater_foldback_thresholds(82, &cut82, &res82);
+    pb_heater_foldback_thresholds(33, &cut33, &res33);
+    CHECK(cut82 == PB_HEATER_PTC_FOLDBACK_CUT_82K_C && res82 == PB_HEATER_PTC_FOLDBACK_RESUME_82K_C);
+    CHECK(cut33 == PB_HEATER_PTC_FOLDBACK_CUT_33K_C && res33 == PB_HEATER_PTC_FOLDBACK_RESUME_33K_C);
+    CHECK(cut33 < cut82);                                   // 33k board cuts earlier
+    // Unknown/other Rref (incl. 0) falls back to the 82k pair.
+    float cutx, resx; pb_heater_foldback_thresholds(0, &cutx, &resx);
+    CHECK(cutx == cut82 && resx == res82);
+    // Hysteresis behavior against each board's own thresholds.
+    for (int b = 0; b < 2; b++) {
+        float cut_c    = b ? cut33 : cut82;
+        float resume_c = b ? res33 : res82;
+        float band_mid = (cut_c + resume_c) * 0.5f;
+        CHECK(pb_heater_foldback_cut(true, cut_c,        false, cut_c, resume_c) == true);   // at cut -> cut
+        CHECK(pb_heater_foldback_cut(true, cut_c + 5.0f, false, cut_c, resume_c) == true);
+        CHECK(pb_heater_foldback_cut(true, resume_c-0.1f, true, cut_c, resume_c) == false);  // below resume -> allow
+        CHECK(pb_heater_foldback_cut(true, band_mid,      true,  cut_c, resume_c) == true);  // band holds prev
+        CHECK(pb_heater_foldback_cut(true, band_mid,      false, cut_c, resume_c) == false);
+        CHECK(pb_heater_foldback_cut(false, 0.0f,         true,  cut_c, resume_c) == true);  // bad read holds prev
+        CHECK(pb_heater_foldback_cut(false, 0.0f,         false, cut_c, resume_c) == false);
+        // Every board's cut/resume stays below the hard cutoff.
+        CHECK(cut_c < PB_HEATER_PTC_CUTOFF_C && resume_c < cut_c);
+    }
     puts("pb_heater element-foldback checks: PASS");
     return 0;
 }

--- a/tests/pb_heater_fault_host_test.c
+++ b/tests/pb_heater_fault_host_test.c
@@ -67,23 +67,30 @@ int main(void)
     puts("pb_heater fault-restore checks: PASS");
 
     // --- Element-temperature foldback limiter (pb_heater_foldback_duty) ---------
+    // Expectations are DERIVED from the two defines so the single-source-of-truth
+    // #define PB_HEATER_PTC_FOLDBACK_START_C can be retuned without editing the test.
+    const float start = PB_HEATER_PTC_FOLDBACK_START_C;
+    const float cutoff = PB_HEATER_PTC_CUTOFF_C;
+    const float span = cutoff - start;
+    const float mid = start + span * 0.5f;   // duty 0.5
+    const float qtr = start + span * 0.25f;  // duty 0.75
     // Below the foldback band the base demand passes through untouched.
     CHECK(FEQ(pb_heater_foldback_duty(1.0f, 25.0f), 1.0f));
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 101.0f), 1.0f));                          // below 102 -> full
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, PB_HEATER_PTC_FOLDBACK_START_C), 1.0f));  // 102 -> full
-    // Inside the band [102, 105) the duty ramps linearly to 0 (span = 3 C).
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 103.5f), 0.5f));
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 104.0f), 1.0f / 3.0f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, start - 1.0f), 1.0f));   // just below band -> full
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, start), 1.0f));          // at start -> full
+    // Inside the band the duty ramps linearly to 0 across the span.
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, qtr), 0.75f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, mid), 0.5f));
     // At/above the cutoff the foldback duty is 0 (the hard latching trip owns >= cutoff).
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, PB_HEATER_PTC_CUTOFF_C), 0.0f));          // 105 -> 0
-    CHECK(FEQ(pb_heater_foldback_duty(1.0f, 110.0f), 0.0f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, cutoff), 0.0f));
+    CHECK(FEQ(pb_heater_foldback_duty(1.0f, cutoff + 5.0f), 0.0f));
     // It only ever REDUCES: a base demand of 0 (chamber satisfied) stays 0 even when
     // the element is cool, and the cap never exceeds the base demand.
     CHECK(FEQ(pb_heater_foldback_duty(0.0f, 25.0f), 0.0f));
-    CHECK(FEQ(pb_heater_foldback_duty(0.0f, 104.0f), 0.0f));
+    CHECK(FEQ(pb_heater_foldback_duty(0.0f, mid), 0.0f));
     // A base demand already below the foldback cap is left as-is (min, not overwrite):
-    // at 103.5 C the cap is 0.5, so a base of 0.3 stays 0.3.
-    CHECK(FEQ(pb_heater_foldback_duty(0.3f, 103.5f), 0.3f));
+    // at the band midpoint the cap is 0.5, so a base of 0.3 stays 0.3.
+    CHECK(FEQ(pb_heater_foldback_duty(0.3f, mid), 0.3f));
     puts("pb_heater element-foldback checks: PASS");
     return 0;
 }

--- a/tests/run_heater_fault_host_test.sh
+++ b/tests/run_heater_fault_host_test.sh
@@ -11,6 +11,6 @@ cc -std=c11 -Wall -Wextra -Werror \
   -I"$root/components/pb_heater/include" \
   -I"$root/tests/stubs" \
   "$root/tests/pb_heater_fault_host_test.c" \
-  -o "$out"
+  -lm -o "$out"
 
 "$out"


### PR DESCRIPTION
Final v0.6.3 — the fully-tested rc6 integration.

**Contents:**
- Element-temperature **foldback hysteresis**, per-Rref: 82 kΩ cut 102/resume 99, 33 kΩ cut 99/resume 96
- **Floating-Rref-strap fix** + `rref_kohm` diagnostic
- **OTA update page**: upload % + auto-return to dashboard
- **Dashboard chart**: chamber + PTC dual line, labeled axes

**Validated on 3 boards**, incl. the hot customer V1.0 that **tripped at 105.1 °C on rc4** but **holds at 101.6 °C peak, 0 faults on rc6** (40 min run). Supersedes #30; folds in #31/#35/#36.