### PR TITLE
Release v0.6.4 — configurable element-foldback cut (advanced)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+## [0.6.4] - 2026-07-27
+
+### Added
+- **Configurable element-foldback cut (advanced).** The soft over-temp foldback cut
+  temperature is now user-settable in **Settings → Foldback cut** (`GET/POST
+  /settings?fb_cut=`), bounded to **90–104 °C**. It defaults to **auto** — the board's
+  per-Rref value (99 °C on 33 kΩ / V1.0, 102 °C on 82 kΩ / V1.0.1) — and the slider shows
+  that default; setting it back to the default clears the override (0 = auto). Lower it if
+  the element runs hot/slow, raise it for more chamber temperature. This only shifts where
+  the **soft** foldback engages; the fixed **105 °C hardware cutoff is unaffected** and the
+  override can never exceed 104 °C, so it can't defeat over-temp protection.
+
 ## [0.6.3] - 2026-07-27
 
 ### Added

--- a/components/pb_heater/include/pb_heater.h
+++ b/components/pb_heater/include/pb_heater.h
@@ -97,6 +97,24 @@ static inline void pb_heater_foldback_thresholds(int rref_kohm, float *cut_c, fl
     else                 { *cut_c = PB_HEATER_PTC_FOLDBACK_CUT_82K_C; *resume_c = PB_HEATER_PTC_FOLDBACK_RESUME_82K_C; }
 }
 
+// Optional user override of the foldback CUT (advanced setting; see the settable API
+// below). The resume point always trails the cut by one hysteresis band. The override
+// is bounded well under the fixed 105 C hard cutoff, so it can never defeat over-temp
+// protection — it only shifts where the SOFT foldback engages. 0 = "auto" (use the
+// board's per-Rref default from pb_heater_foldback_thresholds).
+#define PB_HEATER_PTC_FOLDBACK_BAND_C   3.0f    // resume = cut - band
+#define PB_HEATER_FB_CUT_MIN_C          90.0f
+#define PB_HEATER_FB_CUT_MAX_C         104.0f   // < 105 hard cutoff, always
+
+// Resolve the EFFECTIVE cut/resume: a positive user override wins (resume = cut - band),
+// otherwise fall back to the board's per-Rref default. Pure/inline for host testing.
+static inline void pb_heater_effective_foldback(float user_cut_c, int rref_kohm,
+                                                 float *cut_c, float *resume_c)
+{
+    if (user_cut_c > 0.0f) { *cut_c = user_cut_c; *resume_c = user_cut_c - PB_HEATER_PTC_FOLDBACK_BAND_C; }
+    else                     pb_heater_foldback_thresholds(rref_kohm, cut_c, resume_c);
+}
+
 // Pure element-foldback hysteresis, inline so it is host-testable without hardware.
 // Returns whether to FORCE the SSR off this tick given the element temperature, whether
 // its reading is valid, the previous cut-latch state, and the board's cut/resume points:
@@ -174,6 +192,12 @@ uint32_t  pb_heater_get_comms_timeout_ms(void);
 // residual-heat purge (pb_purge_decide).
 esp_err_t pb_heater_set_cool_release_c(float c);
 float     pb_heater_get_cool_release_c(void);
+// Advanced: user override of the element-foldback CUT temperature. Setter clamps a
+// positive value to [FB_CUT_MIN_C, FB_CUT_MAX_C] and persists it; pass <= 0 to clear
+// the override and return to the board's per-Rref default. Getter returns the raw
+// stored value (0 = auto). The resume point always trails by one hysteresis band.
+esp_err_t pb_heater_set_fb_cut_c(float c);
+float     pb_heater_get_fb_cut_c(void);
 
 // Feed the comms watchdog: call whenever a live controller link is confirmed
 // (Moonraker connected, or a fresh command). If not called within

--- a/components/pb_heater/pb_heater.c
+++ b/components/pb_heater/pb_heater.c
@@ -43,12 +43,14 @@ static bool        s_fb_cut;        // control-task only — element-foldback hy
 static float       s_max_target_c;      // guarded by s_mux — settable set-point ceiling
 static int64_t     s_comms_timeout_us;  // guarded by s_mux — comms deadman (microseconds)
 static float       s_cool_release_c;    // guarded by s_mux — residual-heat purge "cool down to" temp
+static float       s_fb_cut_c;          // guarded by s_mux — user foldback-cut override (0 = auto/per-Rref)
 
 // Persisted settings live in the shared app_nvs namespace (centi-°C / ms u32).
 #define NVS_NS             "app_nvs"
 #define KEY_HEAT_MAX_C     "heat_max_c"      // u32 centi-°C
 #define KEY_HEAT_COMMS_MS  "heat_comms_ms"   // u32 ms
 #define KEY_COOL_REL_C     "cool_rel_c"      // u32 centi-°C — cooldown-purge release temp
+#define KEY_FB_CUT_C       "fb_cut_c"        // u32 centi-°C — foldback-cut override (0 = auto)
 #define KEY_FAULT_LATCH    "fault_latch"     // u8 0/1 — persisted safety-fault latch
 #define KEY_FAULT_CODE     "fault_code"      // u8 pb_fault_reason_t
 
@@ -118,6 +120,7 @@ esp_err_t pb_heater_init(void)
     s_max_target_c = PB_HEATER_MAX_TARGET_C_DEFAULT;
     s_comms_timeout_us = (int64_t)PB_HEATER_COMMS_TIMEOUT_MS_DEFAULT * 1000;
     s_cool_release_c = PB_HEATER_COOL_RELEASE_C_DEFAULT;
+    s_fb_cut_c = 0.0f;   // auto (per-Rref default) until a user override is loaded/set
     taskEXIT_CRITICAL(&s_mux);
 #ifdef CONFIG_PB_HIL_DEVBOARD
     ESP_LOGW(TAG, "HIL dev-board backend: relay GPIO compiled out");
@@ -166,12 +169,14 @@ void pb_heater_load_config(void)
     float    max_c    = PB_HEATER_MAX_TARGET_C_DEFAULT;
     uint32_t comms_ms = PB_HEATER_COMMS_TIMEOUT_MS_DEFAULT;
     float    cool_c   = PB_HEATER_COOL_RELEASE_C_DEFAULT;
+    float    fb_cut   = 0.0f;   // 0 = auto (per-Rref default)
     nvs_handle_t h;
     if (nvs_open(NVS_NS, NVS_READONLY, &h) == ESP_OK) {
         uint32_t v;
         if (nvs_get_u32(h, KEY_HEAT_MAX_C, &v) == ESP_OK)    max_c    = centi_to_c(v);
         if (nvs_get_u32(h, KEY_HEAT_COMMS_MS, &v) == ESP_OK) comms_ms = v;
         if (nvs_get_u32(h, KEY_COOL_REL_C, &v) == ESP_OK)    cool_c   = centi_to_c(v);
+        if (nvs_get_u32(h, KEY_FB_CUT_C, &v) == ESP_OK)      fb_cut   = centi_to_c(v);
         nvs_close(h);
     }
     // Clamp to the safe envelope regardless of what NVS held (defends against a
@@ -182,14 +187,20 @@ void pb_heater_load_config(void)
     if (comms_ms > PB_HEATER_COMMS_TIMEOUT_MS_MAX) comms_ms = PB_HEATER_COMMS_TIMEOUT_MS_MAX;
     if (cool_c < PB_HEATER_COOL_RELEASE_MIN_C) cool_c = PB_HEATER_COOL_RELEASE_MIN_C;
     if (cool_c > PB_HEATER_COOL_RELEASE_MAX_C) cool_c = PB_HEATER_COOL_RELEASE_MAX_C;
+    // fb_cut: 0 stays "auto"; any positive value is clamped to the safe soft-foldback band.
+    if (fb_cut > 0.0f) {
+        if (fb_cut < PB_HEATER_FB_CUT_MIN_C) fb_cut = PB_HEATER_FB_CUT_MIN_C;
+        if (fb_cut > PB_HEATER_FB_CUT_MAX_C) fb_cut = PB_HEATER_FB_CUT_MAX_C;
+    }
     taskENTER_CRITICAL(&s_mux);
     s_max_target_c = max_c;
     s_comms_timeout_us = (int64_t)comms_ms * 1000;
     s_cool_release_c = cool_c;
+    s_fb_cut_c = fb_cut;
     if (s_target_c > s_max_target_c) s_target_c = s_max_target_c;
     taskEXIT_CRITICAL(&s_mux);
-    ESP_LOGI(TAG, "config: max_target=%.1fC comms_timeout=%ums cool_release=%.1fC",
-             max_c, (unsigned)comms_ms, cool_c);
+    ESP_LOGI(TAG, "config: max_target=%.1fC comms_timeout=%ums cool_release=%.1fC fb_cut=%.1fC",
+             max_c, (unsigned)comms_ms, cool_c, fb_cut);
 }
 
 esp_err_t pb_heater_set_max_target_c(float max_c)
@@ -266,6 +277,37 @@ float pb_heater_get_cool_release_c(void)
 {
     taskENTER_CRITICAL(&s_mux);
     float c = s_cool_release_c;
+    taskEXIT_CRITICAL(&s_mux);
+    return c;
+}
+
+esp_err_t pb_heater_set_fb_cut_c(float c)
+{
+    if (!isfinite(c)) return ESP_ERR_INVALID_ARG;
+    if (c <= 0.0f) {
+        c = 0.0f;                                   // clear override -> auto (per-Rref)
+    } else {
+        if (c < PB_HEATER_FB_CUT_MIN_C) c = PB_HEATER_FB_CUT_MIN_C;
+        if (c > PB_HEATER_FB_CUT_MAX_C) c = PB_HEATER_FB_CUT_MAX_C;
+    }
+    taskENTER_CRITICAL(&s_mux);
+    s_fb_cut_c = c;
+    taskEXIT_CRITICAL(&s_mux);
+    nvs_handle_t h;                                 // persist outside the lock
+    if (nvs_open(NVS_NS, NVS_READWRITE, &h) == ESP_OK) {
+        nvs_set_u32(h, KEY_FB_CUT_C, c_to_centi(c));   // 0 = auto
+        nvs_commit(h);
+        nvs_close(h);
+    }
+    if (c > 0.0f) ESP_LOGI(TAG, "foldback cut override set to %.1f C", c);
+    else          ESP_LOGI(TAG, "foldback cut override cleared (auto/per-Rref)");
+    return ESP_OK;
+}
+
+float pb_heater_get_fb_cut_c(void)
+{
+    taskENTER_CRITICAL(&s_mux);
+    float c = s_fb_cut_c;
     taskEXIT_CRITICAL(&s_mux);
     return c;
 }
@@ -554,7 +596,7 @@ void pb_heater_tick(void)          // control-task context; sole writer of s_on
     // 105 C hard cutoff. Thresholds are per board Rref variant (33k boards run hotter, so
     // they get a lower cut). Pure + host-tested; ps==OK is guaranteed here (checked above).
     float fb_cut, fb_resume;
-    pb_heater_foldback_thresholds(pb_ntc_rref_kohm(), &fb_cut, &fb_resume);
+    pb_heater_effective_foldback(pb_heater_get_fb_cut_c(), pb_ntc_rref_kohm(), &fb_cut, &fb_resume);
     s_fb_cut = pb_heater_foldback_cut(ps == PB_NTC_OK, ptc_c, s_fb_cut, fb_cut, fb_resume);
 
     // Step 3 — drive the SSR: heat only when the chamber wants it AND the element is not

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -627,11 +627,15 @@ static esp_err_t events_get(httpd_req_t *req)
 // the response to a successful POST /settings).
 static esp_err_t settings_send(httpd_req_t *req)
 {
-    char buf[352];
+    // Board's per-Rref foldback-cut default (shown as the slider's "auto" value).
+    float fbdef_cut, fbdef_resume;
+    pb_heater_foldback_thresholds(pb_ntc_rref_kohm(), &fbdef_cut, &fbdef_resume);
+    char buf[480];
     int n = snprintf(buf, sizeof buf,
         "{\"max\":%.1f,\"max_min\":%.1f,\"max_abs\":%.1f,"
         "\"comms_ms\":%u,\"comms_ms_min\":%u,\"comms_ms_max\":%u,"
         "\"cool_release\":%.1f,\"cool_release_min\":%.1f,\"cool_release_max\":%.1f,"
+        "\"fb_cut\":%.1f,\"fb_cut_default\":%.1f,\"fb_cut_min\":%.1f,\"fb_cut_max\":%.1f,"
         "\"leds_enabled\":%s}",
         (double)pb_heater_get_max_target_c(),
         (double)PB_HEATER_MIN_TARGET_C,
@@ -642,6 +646,10 @@ static esp_err_t settings_send(httpd_req_t *req)
         (double)pb_heater_get_cool_release_c(),
         (double)PB_HEATER_COOL_RELEASE_MIN_C,
         (double)PB_HEATER_COOL_RELEASE_MAX_C,
+        (double)pb_heater_get_fb_cut_c(),      // 0 = auto (using fb_cut_default below)
+        (double)fbdef_cut,
+        (double)PB_HEATER_FB_CUT_MIN_C,
+        (double)PB_HEATER_FB_CUT_MAX_C,
         pb_leds_get_enabled() ? "true" : "false");
     httpd_resp_set_type(req, "application/json");
     return httpd_resp_send(req, buf, n);
@@ -681,7 +689,7 @@ static bool parse_u32(const char *s, uint32_t *out)
     return true;
 }
 
-// POST /settings?max=<C>&comms_ms=<ms>&cool_release=<C>&leds_enabled=<0|1> —
+// POST /settings?max=<C>&comms_ms=<ms>&cool_release=<C>&fb_cut=<C>&leds_enabled=<0|1> —
 // update any subset. Auth-gated. Each field is optional; the safety values are
 // clamped to the safe envelope by pb_heater's setters (the ceiling can never
 // exceed 70 C; the comms deadman stays within [10s, 5min]; cool_release within
@@ -719,6 +727,12 @@ static esp_err_t settings_post(httpd_req_t *req)
         pb_heater_set_cool_release_c(c);   // clamps + persists
         applied = true;
     }
+    if (httpd_query_key_value(q, "fb_cut", v, sizeof v) == ESP_OK) {
+        float c;
+        if (!parse_temp(v, &c)) { httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "bad fb_cut"); return ESP_FAIL; }
+        pb_heater_set_fb_cut_c(c);   // 0 clears override -> auto; else clamps [90,104] + persists
+        applied = true;
+    }
     if (httpd_query_key_value(q, "leds_enabled", v, sizeof v) == ESP_OK) {
         uint32_t on;
         if (!parse_u32(v, &on)) { httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "bad leds_enabled"); return ESP_FAIL; }
@@ -728,7 +742,7 @@ static esp_err_t settings_post(httpd_req_t *req)
         applied = true;
     }
     if (!applied) {
-        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "no known settings (max, comms_ms, cool_release, leds_enabled)");
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "no known settings (max, comms_ms, cool_release, fb_cut, leds_enabled)");
         return ESP_FAIL;
     }
     return settings_send(req);   // echo the clamped result

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -284,6 +284,13 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
 .set-head-row{ display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .set-note{ margin: 0; color: var(--muted-foreground); font-size: 12px; }
 .set-note.is-warn{ color: var(--destructive); }
+.set-warn{ display: flex; gap: 8px; align-items: flex-start; margin: 0 0 11px;
+  padding: 9px 11px; border-radius: 5px; font-size: 12px; line-height: 1.45;
+  color: var(--destructive);
+  background: color-mix(in srgb, var(--destructive) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--destructive) 40%, transparent); }
+.set-warn svg{ width: 17px; height: 17px; flex: none; margin-top: 1px; }
+.set-warn code{ color: inherit; }
 .set-row{ display: flex; flex-wrap: wrap; gap: 8px; }
 .set-row .btn{ flex: 1; min-width: 120px; }
 .form-input{ appearance: none; display: block; width: 100%; min-height: 34px;
@@ -611,6 +618,29 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
           <p class="set-note">After a heat session the fan keeps running until the chamber and heater element drop below this. Raise it for a hot room where they can't reach the default 40&nbsp;°C — otherwise the fan runs indefinitely.</p>
           <button class="btn btn-primary btn-block" type="button" id="s-cool-save"><svg class="icon"><use href="#i-wind"/></svg> <span>Save cooldown</span></button>
           <div class="mode-feedback" id="s-cool-msg" role="status" aria-live="polite"></div>
+        </div>
+
+        <!-- Advanced: element-foldback cut temperature (GET/POST /settings?fb_cut=). -->
+        <div class="set-card">
+          <h3>Foldback cut (advanced)</h3>
+          <div class="set-warn"><svg class="icon"><use href="#i-alert"/></svg>
+            <span><strong>Danger — experts only.</strong> Changing this will likely cause the element to trip the <strong>105&nbsp;°C thermal protection</strong> (a latched over-temp fault needing a manual clear) — especially if raised. Only adjust it if you know <em>exactly</em> what you're doing, and always in conjunction with the diagnostic tool in the repo (<code>tools/diag.py</code>) so you can watch the real element temperature while you tune. The fixed 105&nbsp;°C hardware cutoff still protects the hardware regardless. If unsure, leave it on <strong>auto</strong>.</span>
+          </div>
+          <div class="ctl-group">
+            <div class="ctl-head">
+              <span class="form-label">Element cut temperature</span>
+              <button class="btn btn-sm" type="button" id="s-fb-auto" aria-pressed="true"><span>Auto</span></button>
+            </div>
+            <div class="touch-adjust">
+              <button class="btn step-btn" type="button" data-sstep="fb,-1" aria-label="Decrease foldback cut temperature"><svg class="icon"><use href="#i-minus"/></svg></button>
+              <output class="touch-value" id="s-fb-value">99 <span>°C</span></output>
+              <button class="btn step-btn" type="button" data-sstep="fb,1" aria-label="Increase foldback cut temperature"><svg class="icon"><use href="#i-plus"/></svg></button>
+            </div>
+            <input class="form-range" id="s-fb-range" type="range" min="90" max="104" step="1" value="99" aria-label="Foldback cut temperature">
+          </div>
+          <p class="set-note">The soft over-temp foldback holds the heater element just below this by cutting power, so it can't ratchet into the fixed 105&nbsp;°C cutoff. <strong id="s-fb-default">Board default is auto</strong> — lower it if your element runs hot/slow, raise it (up to 104) for more chamber temperature. The fixed 105&nbsp;°C hardware cutoff is unaffected. Turn <strong>Auto</strong> off to set a manual value, or back on to use the board default.</p>
+          <button class="btn btn-primary btn-block" type="button" id="s-fb-save"><svg class="icon"><use href="#i-thermometer"/></svg> <span>Save foldback</span></button>
+          <div class="mode-feedback" id="s-fb-msg" role="status" aria-live="polite"></div>
         </div>
 
         <!-- Sensor calibration (GET/POST /api/v2/calibration). Per-channel offset,
@@ -1118,8 +1148,10 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
   var sset = {
     max:   { val:70,  min:30, max:70,  vId:'s-max-value',   rId:'s-max-range',   hId:'s-max-hint',   unit:'°C' },
     comms: { val:300, min:10, max:300, vId:'s-comms-value', rId:'s-comms-range', hId:'s-comms-hint', unit:'s'  },
-    cool:  { val:40,  min:30, max:65,  vId:'s-cool-value',  rId:'s-cool-range',  hId:'s-cool-hint',  unit:'°C' }
+    cool:  { val:40,  min:30, max:65,  vId:'s-cool-value',  rId:'s-cool-range',  hId:'s-cool-hint',  unit:'°C' },
+    fb:    { val:99,  min:90, max:104, vId:'s-fb-value',    rId:'s-fb-range',    hId:'s-fb-hint',    unit:'°C' }
   };
+  var fbDefault = 99;   // board's per-Rref foldback-cut default (from /settings); slider at this = auto
   function renderSset(k){
     var f=sset[k], v=$(f.vId), r=$(f.rId), h=$(f.hId);
     if(v && v.firstChild) v.firstChild.textContent = f.val+' ';
@@ -1143,17 +1175,38 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
       if(isFinite(s.comms_ms_max)) sset.comms.max = Math.round(s.comms_ms_max/1000);
       if(isFinite(s.cool_release_min)) sset.cool.min = Math.round(s.cool_release_min);
       if(isFinite(s.cool_release_max)) sset.cool.max = Math.round(s.cool_release_max);
+      if(isFinite(s.fb_cut_min)) sset.fb.min = Math.round(s.fb_cut_min);
+      if(isFinite(s.fb_cut_max)) sset.fb.max = Math.round(s.fb_cut_max);
       if(isFinite(s.max)) setSset('max', s.max);
       if(isFinite(s.comms_ms)) setSset('comms', Math.round(s.comms_ms/1000));
       if(isFinite(s.cool_release)) setSset('cool', s.cool_release);
+      // Foldback: slider shows the effective cut (user override if set, else the board
+      // per-Rref default). Setting it back to the default posts 0 = auto.
+      if(isFinite(s.fb_cut_default)){ fbDefault = Math.round(s.fb_cut_default);
+        var d=$('s-fb-default'); if(d) d.textContent = 'Board default is '+fbDefault+' °C (auto)'; }
+      var fbManual = isFinite(s.fb_cut) && s.fb_cut>0;
+      setSset('fb', fbManual ? s.fb_cut : fbDefault);
+      setFbAuto(!fbManual);
       if(typeof s.leds_enabled==='boolean') setLedToggle(s.leds_enabled);
     }).catch(function(){});
   }
   document.querySelectorAll('[data-sstep]').forEach(function(b){
     b.addEventListener('click', function(){ var p=b.dataset.sstep.split(','); setSset(p[0], sset[p[0]].val+Number(p[1])); });
   });
-  [['max','s-max-range'],['comms','s-comms-range'],['cool','s-cool-range']].forEach(function(p){
+  [['max','s-max-range'],['comms','s-comms-range'],['cool','s-cool-range'],['fb','s-fb-range']].forEach(function(p){
     var r=$(p[1]); if(r) r.addEventListener('input', function(){ setSset(p[0], Number(r.value)); });
+  });
+  /* Foldback Auto toggle: Auto disables the slider/steppers and uses the board default
+     (posts 0); turn it off to set a manual override. */
+  function setFbAuto(on){
+    var b=$('s-fb-auto');
+    if(b){ b.setAttribute('aria-pressed', on?'true':'false'); b.querySelector('span').textContent = on?'Auto':'Manual'; }
+    var r=$('s-fb-range'); if(r) r.disabled = on;
+    document.querySelectorAll('[data-sstep^="fb,"]').forEach(function(x){ x.disabled = on; });
+    if(on) setSset('fb', fbDefault);
+  }
+  if($('s-fb-auto')) $('s-fb-auto').addEventListener('click', function(){
+    setFbAuto($('s-fb-auto').getAttribute('aria-pressed')!=='true');
   });
   /* Save via the existing auth-gated POST /settings (query form). request() carries
      the auth header + the one-shot 403 token retry; the device clamps + echoes. */
@@ -1177,6 +1230,20 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
         flash('s-cool-msg', 'Saved.', 'is-ok');
       })
       .catch(function(j){ flash('s-cool-msg', 'Save failed: '+((j&&(j.message||j.error))||'error'), 'is-error'); });
+  });
+  /* Foldback cut -> POST /settings?fb_cut= (°C). Slider at the board default posts 0 = auto. */
+  $('s-fb-save').addEventListener('click', function(){
+    flash('s-fb-msg', 'Saving…');
+    var auto = $('s-fb-auto').getAttribute('aria-pressed')==='true';
+    var post = auto ? 0 : sset.fb.val;
+    request('/settings?fb_cut='+post, {})
+      .then(function(s){
+        if(s){ if(isFinite(s.fb_cut_default)) fbDefault=Math.round(s.fb_cut_default);
+          var man = isFinite(s.fb_cut) && s.fb_cut>0;
+          setSset('fb', man ? s.fb_cut : fbDefault); setFbAuto(!man); }
+        flash('s-fb-msg', post ? ('Saved — cut at '+post+' °C.') : 'Saved — auto (board default).', 'is-ok');
+      })
+      .catch(function(j){ flash('s-fb-msg', 'Save failed: '+((j&&(j.message||j.error))||'error'), 'is-error'); });
   });
 
   /* ===== U4: Sensor calibration (GET/POST /api/v2/calibration) ================

--- a/tests/pb_heater_fault_host_test.c
+++ b/tests/pb_heater_fault_host_test.c
@@ -93,6 +93,17 @@ int main(void)
         // Every board's cut/resume stays below the hard cutoff.
         CHECK(cut_c < PB_HEATER_PTC_CUTOFF_C && resume_c < cut_c);
     }
+    // Effective-foldback resolver: 0/negative user override -> per-Rref default; a
+    // positive override wins with resume = cut - band. Stays below the hard cutoff.
+    float ec, er;
+    pb_heater_effective_foldback(0.0f, 33, &ec, &er);    // auto -> 33k pair
+    CHECK(ec == cut33 && er == res33);
+    pb_heater_effective_foldback(-1.0f, 82, &ec, &er);   // <=0 also auto -> 82k pair
+    CHECK(ec == cut82 && er == res82);
+    pb_heater_effective_foldback(95.0f, 33, &ec, &er);   // override wins over per-Rref
+    CHECK(ec == 95.0f && er == 95.0f - PB_HEATER_PTC_FOLDBACK_BAND_C);
+    CHECK(ec < PB_HEATER_PTC_CUTOFF_C && er < ec);
+    CHECK(PB_HEATER_FB_CUT_MAX_C < PB_HEATER_PTC_CUTOFF_C);   // override ceiling < hard cutoff
     puts("pb_heater element-foldback checks: PASS");
     return 0;
 }


### PR DESCRIPTION
Adds an **advanced, opt-in** override of the soft element-foldback cut temperature.

- **Settings → Foldback cut** with an explicit **Auto** toggle (default = board per-Rref value: 99 on 33 kΩ / 102 on 82 kΩ). `GET/POST /settings?fb_cut=`, persisted in NVS.
- **Bounded 90–104 °C** — only shifts the *soft* foldback; the fixed **105 °C hardware cutoff is untouched** and the override can never exceed 104 °C, so it can't defeat over-temp protection.
- **Prominent danger warning** in the UI (experts only, likely to trip thermal protection, use with `tools/diag.py`).

Pure resolver host-tested; firmware/API/UI validated on the bench. Built on v0.6.3.