### PR TITLE
feat: fan-only chamber filtration (AUTO band + manual out-of-band) — v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ below into the GitHub Release notes.
     Filtration (auto mode)** / `GET/POST /settings?filter_temp=&filter_auto=`.
   - **Manual, out-of-band.** A new `filter` API v2 command runs the blower fan-only
     **independent of mode** — not cleared by OFF, additive over any heat airflow,
-    and safe (no heat path). Surfaced as a **Filtration** toggle on the dashboard.
+    and safe (no heat path). Surfaced as an **on-only Filtration button** on the
+    dashboard — like the temperature presets, a click activates it and it lights up
+    (turns blue) while active; **Stop** is the single control that turns it off.
     **Enabling** it is idle-only: while the heater is heating or the cooldown purge
     is running, turning filtration *on* is rejected (`heater_busy`, HTTP 409) and the
     dashboard button dims, so a status-page toggle can't disturb an active heat cycle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+## [0.6.5] - 2026-07-28
+
+### Added
+- **Fan-only chamber filtration (two ways).** The chamber blower can now run
+  fan-only — heater untouched — to filter/circulate chamber air:
+  - **Automatic in AUTO mode (stock-like).** When enabled (default **on**), AUTO
+    runs the blower alone once the printer bed reaches a configurable **filter
+    temperature** (default **30 °C**, range 20–60 °C), filtering before the heater
+    engages at the higher auto bed threshold. Hysteresis mirrors the engage band;
+    it fails to no-airflow if disabled or Moonraker drops. Set in **Settings →
+    Filtration (auto mode)** / `GET/POST /settings?filter_temp=&filter_auto=`.
+  - **Manual, out-of-band.** A new `filter` API v2 command runs the blower fan-only
+    **independent of mode** — not cleared by OFF, additive over any heat airflow,
+    and safe (no heat path, so it is accepted regardless of revision and even aids
+    cooling while faulted). Surfaced as a **Filtration** toggle on the dashboard.
+  - State adds `environment.auto_filtering` and `params.filter_temp_c` /
+    `params.filter_auto_enable`; the manual fan drives the existing (previously
+    unused) `requested_fan_percent` blower path. The heater and every over-temp
+    cutoff are unaffected.
+
 ## [0.6.4] - 2026-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@ below into the GitHub Release notes.
   - **Manual, out-of-band.** A new `filter` API v2 command runs the blower fan-only
     **independent of mode** — not cleared by OFF, additive over any heat airflow,
     and safe (no heat path). Surfaced as a **Filtration** toggle on the dashboard.
-    It is **idle-only**: while the heater is heating or the cooldown purge is running
-    the blower is owned by the safety-airflow logic, so manual changes are rejected
-    (`heater_busy`, HTTP 409) and the dashboard button dims — a status-page toggle
-    can't disturb an active heat cycle.
+    **Enabling** it is idle-only: while the heater is heating or the cooldown purge
+    is running, turning filtration *on* is rejected (`heater_busy`, HTTP 409) and the
+    dashboard button dims, so a status-page toggle can't disturb an active heat cycle.
+    Turning it *off* is always allowed, and **Stop stops all** — the dashboard Stop
+    button clears filtration alongside the heater (and is clickable whenever
+    filtration is on), so filtration never lingers or "comes back" after a heat cycle.
   - State adds `environment.auto_filtering` and `params.filter_temp_c` /
     `params.filter_auto_enable`; the manual fan drives the existing (previously
     unused) `requested_fan_percent` blower path. The heater and every over-temp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,11 @@ below into the GitHub Release notes.
     Filtration (auto mode)** / `GET/POST /settings?filter_temp=&filter_auto=`.
   - **Manual, out-of-band.** A new `filter` API v2 command runs the blower fan-only
     **independent of mode** — not cleared by OFF, additive over any heat airflow,
-    and safe (no heat path, so it is accepted regardless of revision and even aids
-    cooling while faulted). Surfaced as a **Filtration** toggle on the dashboard.
+    and safe (no heat path). Surfaced as a **Filtration** toggle on the dashboard.
+    It is **idle-only**: while the heater is heating or the cooldown purge is running
+    the blower is owned by the safety-airflow logic, so manual changes are rejected
+    (`heater_busy`, HTTP 409) and the dashboard button dims — a status-page toggle
+    can't disturb an active heat cycle.
   - State adds `environment.auto_filtering` and `params.filter_temp_c` /
     `params.filter_auto_enable`; the manual fan drives the existing (previously
     unused) `requested_fan_percent` blower path. The heater and every over-temp

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -153,6 +153,7 @@ static cJSON *state_json(const pb_policy_snapshot_t *s)
     cJSON_AddBoolToObject(environment, "moonraker_connected", s->moonraker_connected);
     add_num1(environment, "bed_temperature_c", s->bed_c);
     cJSON_AddBoolToObject(environment, "auto_engaged", s->auto_engaged);
+    cJSON_AddBoolToObject(environment, "auto_filtering", s->auto_filtering);
     add_num1(environment, "auto_bed_threshold_c", s->auto_bed_threshold_c);
 
     cJSON *drying = cJSON_AddObjectToObject(o, "drying");
@@ -179,6 +180,8 @@ static cJSON *state_json(const pb_policy_snapshot_t *s)
     add_num1(pj, "auto_bed_threshold_c", s->params.auto_bed_threshold_c);
     add_num1(pj, "dry_target_c", s->params.dry_target_c);
     cJSON_AddNumberToObject(pj, "dry_hours", s->params.dry_hours);
+    add_num1(pj, "filter_temp_c", s->params.filter_temp_c);
+    cJSON_AddBoolToObject(pj, "filter_auto_enable", s->params.filter_auto_enable);
 
     cJSON *safety = cJSON_AddObjectToObject(o, "safety");
     cJSON_AddBoolToObject(safety, "fault_latched", s->fault_latched);
@@ -411,7 +414,8 @@ static esp_err_t command_post(httpd_req_t *req)
 
     const char *cmd = name->valuestring;
     bool cacheable = strcmp(cmd, "off") != 0
-        && strcmp(cmd, "drying_stop") != 0;
+        && strcmp(cmd, "drying_stop") != 0
+        && strcmp(cmd, "filter") != 0;
     replay_entry_t *prior = cacheable
         ? replay_find(actor_id_buf, request_id) : NULL;
     if (prior) {
@@ -436,11 +440,17 @@ static esp_err_t command_post(httpd_req_t *req)
         revision = (uint32_t)expected->valuedouble;
 
     pb_policy_result_t result = PB_POLICY_INVALID;
-    double target = 0.0, threshold = 0.0, hours = 0.0;
+    double target = 0.0, threshold = 0.0, hours = 0.0, fan_percent = 0.0;
     pb_policy_lease_t issued_lease = {0};
     if (strcmp(cmd, "off") == 0) {
         pb_policy_set_mode_off(source);
         result = PB_POLICY_OK; // revision intentionally ignored for safer action
+    } else if (strcmp(cmd, "filter") == 0
+            && json_number(command, "percent", &fan_percent)) {
+        // Fan-only filtration: safe (no heat), idempotent, revision-independent.
+        if (fan_percent < 0.0) fan_percent = 0.0;
+        if (fan_percent > 100.0) fan_percent = 100.0;
+        result = pb_policy_set_fan((uint8_t)(fan_percent + 0.5), source);
     } else if (!revision_valid) {
         result = PB_POLICY_INVALID;
     } else if (strcmp(cmd, "power_on") == 0
@@ -630,12 +640,14 @@ static esp_err_t settings_send(httpd_req_t *req)
     // Board's per-Rref foldback-cut default (shown as the slider's "auto" value).
     float fbdef_cut, fbdef_resume;
     pb_heater_foldback_thresholds(pb_ntc_rref_kohm(), &fbdef_cut, &fbdef_resume);
-    char buf[480];
+    char buf[600];
     int n = snprintf(buf, sizeof buf,
         "{\"max\":%.1f,\"max_min\":%.1f,\"max_abs\":%.1f,"
         "\"comms_ms\":%u,\"comms_ms_min\":%u,\"comms_ms_max\":%u,"
         "\"cool_release\":%.1f,\"cool_release_min\":%.1f,\"cool_release_max\":%.1f,"
         "\"fb_cut\":%.1f,\"fb_cut_default\":%.1f,\"fb_cut_min\":%.1f,\"fb_cut_max\":%.1f,"
+        "\"filter_temp\":%.1f,\"filter_temp_min\":%.1f,\"filter_temp_max\":%.1f,"
+        "\"filter_auto\":%s,"
         "\"leds_enabled\":%s}",
         (double)pb_heater_get_max_target_c(),
         (double)PB_HEATER_MIN_TARGET_C,
@@ -650,6 +662,10 @@ static esp_err_t settings_send(httpd_req_t *req)
         (double)fbdef_cut,
         (double)PB_HEATER_FB_CUT_MIN_C,
         (double)PB_HEATER_FB_CUT_MAX_C,
+        (double)pb_policy_get_filter_temp_c(),
+        (double)PB_POLICY_FILTER_TEMP_MIN_C,
+        (double)PB_POLICY_FILTER_TEMP_MAX_C,
+        pb_policy_get_filter_auto_enable() ? "true" : "false",
         pb_leds_get_enabled() ? "true" : "false");
     httpd_resp_set_type(req, "application/json");
     return httpd_resp_send(req, buf, n);
@@ -733,6 +749,26 @@ static esp_err_t settings_post(httpd_req_t *req)
         pb_heater_set_fb_cut_c(c);   // 0 clears override -> auto; else clamps [90,104] + persists
         applied = true;
     }
+    // AUTO fan-only filtration band. filter_temp and filter_auto may arrive
+    // together or singly; keep the unspecified half at its current value and apply
+    // both through the one policy setter (which range-checks + persists).
+    {
+        char v2[24];
+        bool have_ft = httpd_query_key_value(q, "filter_temp", v, sizeof v) == ESP_OK;
+        bool have_fa = httpd_query_key_value(q, "filter_auto", v2, sizeof v2) == ESP_OK;
+        if (have_ft || have_fa) {
+            float ft = pb_policy_get_filter_temp_c();
+            bool fa = pb_policy_get_filter_auto_enable();
+            if (have_ft && !parse_temp(v, &ft)) { httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "bad filter_temp"); return ESP_FAIL; }
+            if (have_fa) {
+                uint32_t on;
+                if (!parse_u32(v2, &on)) { httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "bad filter_auto"); return ESP_FAIL; }
+                fa = on != 0;
+            }
+            if (pb_policy_set_filter_config(ft, fa) != PB_POLICY_OK) { httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "filter_temp out of range"); return ESP_FAIL; }
+            applied = true;
+        }
+    }
     if (httpd_query_key_value(q, "leds_enabled", v, sizeof v) == ESP_OK) {
         uint32_t on;
         if (!parse_u32(v, &on)) { httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "bad leds_enabled"); return ESP_FAIL; }
@@ -742,7 +778,7 @@ static esp_err_t settings_post(httpd_req_t *req)
         applied = true;
     }
     if (!applied) {
-        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "no known settings (max, comms_ms, cool_release, fb_cut, leds_enabled)");
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "no known settings (max, comms_ms, cool_release, fb_cut, filter_temp, filter_auto, leds_enabled)");
         return ESP_FAIL;
     }
     return settings_send(req);   // echo the clamped result

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -350,6 +350,9 @@ static esp_err_t policy_error(
     if (result == PB_POLICY_INVALID) {
         status = "400 Bad Request";
         message = "command rejected by authoritative policy";
+    } else if (result == PB_POLICY_BUSY) {
+        status = "409 Conflict";
+        message = "manual filtration is idle-only; the heater is heating or cooling down";
     } else if (result == PB_POLICY_PERSIST_FAILED) {
         status = "500 Internal Server Error";
         message = "fault cleared in RAM but persisting it failed; the latch remains";

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -105,6 +105,7 @@ static const char *fan_reason(const pb_policy_snapshot_t *s)
     if (s->fault_latched || s->inhibited) return "fault";
     if (s->thermal_purge) return "thermal_purge";
     if (s->heater_demand) return "heater";
+    if (s->auto_filtering) return "auto_filter";   // AUTO fan-only band (no heat)
     if (s->effective_fan_percent) return "requested";
     return "off";
 }

--- a/components/pb_policy/include/pb_policy.h
+++ b/components/pb_policy/include/pb_policy.h
@@ -46,6 +46,7 @@ typedef enum {
     PB_POLICY_INHIBITED,
     PB_POLICY_STALE_LEASE,
     PB_POLICY_PERSIST_FAILED,   // action succeeded in RAM path but NVS persist failed -> HTTP 500
+    PB_POLICY_BUSY,             // rejected: heater is heating / cooling down (e.g. manual fan is idle-only)
 } pb_policy_result_t;
 
 typedef struct {
@@ -154,6 +155,8 @@ void pb_policy_stop_drying(pb_source_t source);
 // hardware fan is on/off, so any non-zero runs it). Heater is untouched.
 // Independent of mode — not cleared by OFF, additive over any heat airflow — and
 // safe (no heat path), so it is accepted regardless of revision. Cleared on reboot.
+// IDLE-ONLY: returns PB_POLICY_BUSY (no change) while the heater is heating or the
+// cooldown purge is running, so a manual toggle can't disturb the heat cycle.
 pb_policy_result_t pb_policy_set_fan(uint8_t percent, pb_source_t source);
 
 // AUTO fan-only filtration band (persisted): when enabled, AUTO runs the blower

--- a/components/pb_policy/include/pb_policy.h
+++ b/components/pb_policy/include/pb_policy.h
@@ -155,8 +155,10 @@ void pb_policy_stop_drying(pb_source_t source);
 // hardware fan is on/off, so any non-zero runs it). Heater is untouched.
 // Independent of mode — not cleared by OFF, additive over any heat airflow — and
 // safe (no heat path), so it is accepted regardless of revision. Cleared on reboot.
-// IDLE-ONLY: returns PB_POLICY_BUSY (no change) while the heater is heating or the
-// cooldown purge is running, so a manual toggle can't disturb the heat cycle.
+// ENABLE is idle-only: turning it ON (percent > 0) returns PB_POLICY_BUSY while the
+// heater is heating or the cooldown purge is running, so a manual toggle can't
+// disturb the heat cycle. Turning it OFF (percent == 0) is always allowed, so
+// "Stop" can clear a lingering filtration request mid-cycle.
 pb_policy_result_t pb_policy_set_fan(uint8_t percent, pb_source_t source);
 
 // AUTO fan-only filtration band (persisted): when enabled, AUTO runs the blower

--- a/components/pb_policy/include/pb_policy.h
+++ b/components/pb_policy/include/pb_policy.h
@@ -64,6 +64,8 @@ typedef struct {
     float auto_bed_threshold_c;   // last accepted AUTO bed threshold
     float dry_target_c;           // last accepted drying target
     uint8_t dry_hours;            // last accepted drying duration
+    float filter_temp_c;          // AUTO fan-only band: blower runs alone at bed>=this
+    bool filter_auto_enable;      // enable the AUTO fan-only (filtration) band
 } pb_policy_params_t;
 
 typedef struct {
@@ -88,6 +90,7 @@ typedef struct {
     bool moonraker_connected;
     float bed_c;
     bool auto_engaged;
+    bool auto_filtering;          // AUTO fan-only band active (blower on, no heat)
     float auto_bed_threshold_c;
     pb_policy_params_t params;
 
@@ -146,6 +149,22 @@ pb_policy_result_t pb_policy_start_drying(
 // from making the device safer.
 void pb_policy_set_mode_off(pb_source_t source);
 void pb_policy_stop_drying(pb_source_t source);
+
+// Manual filtration blower: run the blower fan-only (0 = off, 1..100 = on; the
+// hardware fan is on/off, so any non-zero runs it). Heater is untouched.
+// Independent of mode — not cleared by OFF, additive over any heat airflow — and
+// safe (no heat path), so it is accepted regardless of revision. Cleared on reboot.
+pb_policy_result_t pb_policy_set_fan(uint8_t percent, pb_source_t source);
+
+// AUTO fan-only filtration band (persisted): when enabled, AUTO runs the blower
+// alone once the printer bed reaches filter_temp_c, before the heater engages at
+// the (higher) auto bed threshold — mirroring the stock Panda's filtration band.
+// Fan-only, so it never adds heat. Persists across reboot (a config setting).
+#define PB_POLICY_FILTER_TEMP_MIN_C  20.0f
+#define PB_POLICY_FILTER_TEMP_MAX_C  60.0f
+pb_policy_result_t pb_policy_set_filter_config(float filter_temp_c, bool enable);
+float pb_policy_get_filter_temp_c(void);
+bool  pb_policy_get_filter_auto_enable(void);
 
 // Update printer environment used by AUTO.  This is observer input, not a
 // control command, and therefore never creates or refreshes a control lease.

--- a/components/pb_policy/pb_policy.c
+++ b/components/pb_policy/pb_policy.c
@@ -559,12 +559,15 @@ pb_policy_result_t pb_policy_set_fan(uint8_t percent, pb_source_t source)
     if (!s_lock) return PB_POLICY_INVALID;
     if (percent > 100) percent = 100;
     xSemaphoreTake(s_lock, portMAX_DELAY);
-    // Manual filtration is an IDLE-ONLY control. While the heater is heating
+    // Manual filtration may only be ENABLED while idle. While the heater is heating
     // (armed and not tripped, incl. through foldback cycling) or the residual-heat
-    // cooldown purge is running, the blower is owned by the safety-airflow logic —
-    // reject manual changes so a status-page toggle can't disturb the heat cycle.
-    // (pb_heater_heat_mode() is called under s_lock exactly as pb_policy_tick does.)
-    if (pb_heater_heat_mode() || s.last_cooldown) {
+    // cooldown purge is running, the blower is owned by the safety-airflow logic, so
+    // a status-page toggle can't switch it ON and disturb the heat cycle. Turning it
+    // OFF (percent == 0) is always allowed — it can't reduce required airflow (the
+    // heat/cooldown path forces the fan on regardless) and it lets "Stop" clear a
+    // lingering filtration request mid-cycle. (heat_mode() called under s_lock, as
+    // pb_policy_tick does.)
+    if (percent > 0 && (pb_heater_heat_mode() || s.last_cooldown)) {
         xSemaphoreGive(s_lock);
         return PB_POLICY_BUSY;
     }

--- a/components/pb_policy/pb_policy.c
+++ b/components/pb_policy/pb_policy.c
@@ -559,6 +559,15 @@ pb_policy_result_t pb_policy_set_fan(uint8_t percent, pb_source_t source)
     if (!s_lock) return PB_POLICY_INVALID;
     if (percent > 100) percent = 100;
     xSemaphoreTake(s_lock, portMAX_DELAY);
+    // Manual filtration is an IDLE-ONLY control. While the heater is heating
+    // (armed and not tripped, incl. through foldback cycling) or the residual-heat
+    // cooldown purge is running, the blower is owned by the safety-airflow logic —
+    // reject manual changes so a status-page toggle can't disturb the heat cycle.
+    // (pb_heater_heat_mode() is called under s_lock exactly as pb_policy_tick does.)
+    if (pb_heater_heat_mode() || s.last_cooldown) {
+        xSemaphoreGive(s_lock);
+        return PB_POLICY_BUSY;
+    }
     if (s.requested_fan_percent != percent) {
         s.requested_fan_percent = percent;
         revision_advance_locked(source);
@@ -1085,6 +1094,7 @@ const char *pb_policy_result_str(pb_policy_result_t result)
         case PB_POLICY_INHIBITED:         return "inhibited";
         case PB_POLICY_STALE_LEASE:       return "stale_lease";
         case PB_POLICY_PERSIST_FAILED:    return "persist_failed";
+        case PB_POLICY_BUSY:              return "heater_busy";
         default:                          return "unknown";
     }
 }

--- a/components/pb_policy/pb_policy.c
+++ b/components/pb_policy/pb_policy.c
@@ -1049,9 +1049,11 @@ void pb_policy_get_snapshot(pb_policy_snapshot_t *out)
     out->ptc_c = out->ptc_status == PB_NTC_OK
         ? pb_ntc_smoothed_c(PB_NTC_PTC) : NAN;
 
-    out->thermal_purge = !out->heater_demand
-        && !out->fault_latched
-        && out->effective_fan_percent > out->requested_fan_percent;
+    // Report the ACTUAL residual-heat purge state, not an inference from fan
+    // levels. The old "effective fan > requested fan" heuristic also matched the
+    // AUTO fan-only filtration band (effective 100, requested 0), which made the
+    // API report thermal_purge and the UI show "Cooling down" during filtration.
+    out->thermal_purge = s.last_cooldown;
 }
 
 pb_mode_t pb_policy_get_mode(void)

--- a/components/pb_policy/pb_policy.c
+++ b/components/pb_policy/pb_policy.c
@@ -41,15 +41,22 @@ static const char *TAG = "pb_policy";
 #define PB_NVS_KEY_AUTO_BED         "md_auto_bed"
 #define PB_NVS_KEY_DRY_TGT          "md_dry_tgt"
 #define PB_NVS_KEY_DRY_HRS          "md_dry_hrs"
+#define PB_NVS_KEY_FILT_TMP         "md_filt_tmp"
+#define PB_NVS_KEY_FILT_EN          "md_filt_en"
 
 #define PB_AUTO_BED_MIN_C           40.0f
 #define PB_AUTO_BED_MAX_C          120.0f
 
+// AUTO fan-only filtration band bounds live in pb_policy.h (shared with the HTTP
+// settings JSON). Stock default is 30 C; the range sits below the AUTO heat-engage
+// threshold (min 40 C) so the band never demands heat.
 #define PB_DEFAULT_MANUAL_TARGET_C  50.0f
 #define PB_DEFAULT_AUTO_TARGET_C    60.0f
 #define PB_DEFAULT_AUTO_BED_C      100.0f
 #define PB_DEFAULT_DRY_TARGET_C     60.0f
 #define PB_DEFAULT_DRY_HOURS        12U
+#define PB_DEFAULT_FILTER_TEMP_C    30.0f
+#define PB_DEFAULT_FILTER_AUTO_EN   true
 
 typedef struct {
     pb_mode_t mode;
@@ -63,6 +70,7 @@ typedef struct {
     float bed_c;
     float auto_bed_threshold_c;
     bool auto_engaged;
+    bool auto_filtering;         // AUTO fan-only band latch (blower on, no heat)
 
     int64_t drying_deadline_us;
     int64_t local_power_deadline_us;
@@ -218,6 +226,9 @@ static void params_clamp(pb_policy_params_t *p)
         max_target_c, PB_DEFAULT_DRY_TARGET_C);
     if (p->dry_hours == 0 || p->dry_hours > PB_DRYING_MAX_HOURS)
         p->dry_hours = PB_DEFAULT_DRY_HOURS;
+    p->filter_temp_c = clamp_or_default(
+        p->filter_temp_c, PB_POLICY_FILTER_TEMP_MIN_C,
+        PB_POLICY_FILTER_TEMP_MAX_C, PB_DEFAULT_FILTER_TEMP_C);
 }
 
 static void params_defaults_locked(void)
@@ -227,6 +238,8 @@ static void params_defaults_locked(void)
     s.params.auto_bed_threshold_c = PB_DEFAULT_AUTO_BED_C;
     s.params.dry_target_c         = PB_DEFAULT_DRY_TARGET_C;
     s.params.dry_hours            = PB_DEFAULT_DRY_HOURS;
+    s.params.filter_temp_c        = PB_DEFAULT_FILTER_TEMP_C;
+    s.params.filter_auto_enable   = PB_DEFAULT_FILTER_AUTO_EN;
 }
 
 // Wake the persistence worker. Call AFTER releasing s_lock: NVS writes must
@@ -252,6 +265,10 @@ static esp_err_t persist_params(const pb_policy_params_t *p)
         { PB_NVS_KEY_DRY_TGT,  c_to_centi(p->dry_target_c),
                                c_to_centi(s_written.dry_target_c) },
         { PB_NVS_KEY_DRY_HRS,  p->dry_hours, s_written.dry_hours },
+        { PB_NVS_KEY_FILT_TMP, c_to_centi(p->filter_temp_c),
+                               c_to_centi(s_written.filter_temp_c) },
+        { PB_NVS_KEY_FILT_EN,  p->filter_auto_enable ? 1u : 0u,
+                               s_written.filter_auto_enable ? 1u : 0u },
     };
     const size_t n = sizeof kv / sizeof kv[0];
 
@@ -334,6 +351,10 @@ void pb_policy_load_params(void)
             p.dry_target_c = centi_to_c(v);
         if (nvs_get_u32(h, PB_NVS_KEY_DRY_HRS, &v) == ESP_OK)
             p.dry_hours = v > UINT8_MAX ? UINT8_MAX : (uint8_t)v;
+        if (nvs_get_u32(h, PB_NVS_KEY_FILT_TMP, &v) == ESP_OK)
+            p.filter_temp_c = centi_to_c(v);
+        if (nvs_get_u32(h, PB_NVS_KEY_FILT_EN, &v) == ESP_OK)
+            p.filter_auto_enable = (v != 0);
         nvs_close(h);
     }
     params_clamp(&p);
@@ -465,6 +486,7 @@ pb_policy_result_t pb_policy_set_auto(
         target_c > max_target_c ? max_target_c : target_c;
     s.auto_bed_threshold_c = bed_threshold_c;
     s.auto_engaged = false;
+    s.auto_filtering = false;
     s.drying_deadline_us = 0;
     s.local_power_deadline_us = 0;
     (void)pb_heater_set_target_c(0.0f);
@@ -524,6 +546,60 @@ void pb_policy_set_mode_off(pb_source_t source)
     set_off_locked(source);
     xSemaphoreGive(s_lock);
     wake_control_task();
+}
+
+// Manual filtration blower — run the chamber blower fan-only, heater untouched.
+// This is deliberately INDEPENDENT of the heat mode: it is not cleared by OFF and
+// does not change s.mode, so it can filter/purge air "out of band" while OFF, or
+// add airflow on top of any heat mode (whichever wants more air wins in the tick).
+// Fan-only has no heat path, so it is safe even while faulted (extra cooling) and
+// needs no revision gate. It never persists: the device always boots OFF, fan 0.
+pb_policy_result_t pb_policy_set_fan(uint8_t percent, pb_source_t source)
+{
+    if (!s_lock) return PB_POLICY_INVALID;
+    if (percent > 100) percent = 100;
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    if (s.requested_fan_percent != percent) {
+        s.requested_fan_percent = percent;
+        revision_advance_locked(source);
+    }
+    xSemaphoreGive(s_lock);
+    wake_control_task();
+    return PB_POLICY_OK;
+}
+
+pb_policy_result_t pb_policy_set_filter_config(float filter_temp_c, bool enable)
+{
+    if (!s_lock || !isfinite(filter_temp_c)
+            || filter_temp_c < PB_POLICY_FILTER_TEMP_MIN_C
+            || filter_temp_c > PB_POLICY_FILTER_TEMP_MAX_C)
+        return PB_POLICY_INVALID;
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    s.params.filter_temp_c = filter_temp_c;
+    s.params.filter_auto_enable = enable;
+    s.params_dirty = true;
+    xSemaphoreGive(s_lock);
+    params_notify();
+    wake_control_task();      // re-evaluate the AUTO band on the next tick
+    return PB_POLICY_OK;
+}
+
+float pb_policy_get_filter_temp_c(void)
+{
+    if (!s_lock) return PB_DEFAULT_FILTER_TEMP_C;
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    float v = s.params.filter_temp_c;
+    xSemaphoreGive(s_lock);
+    return v;
+}
+
+bool pb_policy_get_filter_auto_enable(void)
+{
+    if (!s_lock) return PB_DEFAULT_FILTER_AUTO_EN;
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    bool v = s.params.filter_auto_enable;
+    xSemaphoreGive(s_lock);
+    return v;
 }
 
 void pb_policy_stop_drying(pb_source_t source)
@@ -792,7 +868,21 @@ void pb_policy_tick(void)
                                       - PB_AUTO_BED_HYSTERESIS_C) {
                 s.auto_engaged = false;
             }
-            if (s.auto_engaged != was_engaged)
+            // Fan-only filtration band (stock-like): once the bed reaches
+            // filter_temp_c the blower runs ALONE — before the heater engages at
+            // the higher auto bed threshold. Same hysteresis shape as engage;
+            // gated off if disabled or Moonraker is down (fail to no-airflow).
+            bool was_filtering = s.auto_filtering;
+            if (!s.mk_connected || !s.params.filter_auto_enable) {
+                s.auto_filtering = false;
+            } else if (!s.auto_filtering && s.bed_c >= s.params.filter_temp_c) {
+                s.auto_filtering = true;
+            } else if (s.auto_filtering
+                       && s.bed_c < s.params.filter_temp_c
+                                      - PB_AUTO_BED_HYSTERESIS_C) {
+                s.auto_filtering = false;
+            }
+            if (s.auto_engaged != was_engaged || s.auto_filtering != was_filtering)
                 revision_advance_locked(s.source);
             if (s.auto_engaged) {
                 target = s.requested_target_c;
@@ -867,7 +957,12 @@ void pb_policy_tick(void)
     }
     s.last_faulted = faulted;
 
-    bool want_airflow = heat || faulted || cooldown;
+    // AUTO fan-only filtration band forces airflow with no heat. Mode-gated so a
+    // stale latch never spins the fan outside AUTO. The manual filtration fan
+    // (requested_fan_percent) is independent and additive — whichever wants more
+    // air wins, since want_airflow only raises a low request up to the 30% floor.
+    bool auto_filter = (s.mode == PB_MODE_AUTO) && s.auto_filtering;
+    bool want_airflow = heat || faulted || cooldown || auto_filter;
     uint8_t fan = s.requested_fan_percent;
     if (want_airflow && fan < 30) fan = 30;
     pb_fan_set_level(fan);
@@ -909,6 +1004,7 @@ void pb_policy_get_snapshot(pb_policy_snapshot_t *out)
     out->moonraker_connected = s.mk_connected;
     out->bed_c = s.bed_c;
     out->auto_engaged = s.auto_engaged;
+    out->auto_filtering = (s.mode == PB_MODE_AUTO) && s.auto_filtering;
     out->auto_bed_threshold_c = s.auto_bed_threshold_c;
     out->params = s.params;
     out->drying = s.mode == PB_MODE_DRYING;

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -454,6 +454,11 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
             <button class="btn" type="button" data-quick-temp="60"><svg class="icon"><use href="#i-thermometer"/></svg> 60 °C</button>
             <button class="btn" type="button" data-quick-temp="70"><svg class="icon"><use href="#i-thermometer"/></svg> 70 °C</button>
           </div>
+          <!-- Manual filtration blower: fan-only, out-of-band (works in any mode,
+               heater untouched). Mirrors the Klipper fan_generic control. -->
+          <div class="quick-actions">
+            <button class="btn" type="button" id="db-filter" aria-pressed="false"><svg class="icon"><use href="#i-wind"/></svg> <span id="db-filter-label">Filtration</span></button>
+          </div>
         </section>
       </div>
 
@@ -641,6 +646,26 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
           <p class="set-note">The soft over-temp foldback holds the heater element just below this by cutting power, so it can't ratchet into the fixed 105&nbsp;°C cutoff. <strong id="s-fb-default">Board default is auto</strong> — lower it if your element runs hot/slow, raise it (up to 104) for more chamber temperature. The fixed 105&nbsp;°C hardware cutoff is unaffected. Turn <strong>Auto</strong> off to set a manual value, or back on to use the board default.</p>
           <button class="btn btn-primary btn-block" type="button" id="s-fb-save"><svg class="icon"><use href="#i-thermometer"/></svg> <span>Save foldback</span></button>
           <div class="mode-feedback" id="s-fb-msg" role="status" aria-live="polite"></div>
+        </div>
+
+        <!-- Auto-mode fan-only filtration band (GET/POST /settings?filter_temp=&filter_auto=). -->
+        <div class="set-card">
+          <h3>Filtration (auto mode)</h3>
+          <div class="ctl-group">
+            <div class="ctl-head">
+              <span class="form-label">Filter at bed temperature</span>
+              <button class="btn btn-sm" type="button" id="s-filt-en" aria-pressed="true"><span>On</span></button>
+            </div>
+            <div class="touch-adjust">
+              <button class="btn step-btn" type="button" data-sstep="filt,-1" aria-label="Decrease filtration bed temperature"><svg class="icon"><use href="#i-minus"/></svg></button>
+              <output class="touch-value" id="s-filt-value">30 <span>°C</span></output>
+              <button class="btn step-btn" type="button" data-sstep="filt,1" aria-label="Increase filtration bed temperature"><svg class="icon"><use href="#i-plus"/></svg></button>
+            </div>
+            <input class="form-range" id="s-filt-range" type="range" min="20" max="60" step="1" value="30" aria-label="Filtration bed temperature">
+          </div>
+          <p class="set-note">In <strong>Auto</strong> mode, the blower runs on its own once the printer bed reaches this temperature — filtering/circulating chamber air before the heater engages at the (higher) auto bed threshold. Fan-only: it never adds heat. Turn <strong>Off</strong> to disable the band. For on-demand filtration in any mode, use the <strong>Filtration</strong> button on the dashboard (or the <code>dragonbreath_filter</code> fan in Fluidd).</p>
+          <button class="btn btn-primary btn-block" type="button" id="s-filt-save"><svg class="icon"><use href="#i-wind"/></svg> <span>Save filtration</span></button>
+          <div class="mode-feedback" id="s-filt-msg" role="status" aria-live="polite"></div>
         </div>
 
         <!-- Sensor calibration (GET/POST /api/v2/calibration). Per-channel offset,
@@ -901,10 +926,16 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
     /* At-a-glance detail rows — all from the SSE snapshot. */
     u('db-fan', fanLabel(s));
     u('db-controller', controllerLabel(s));
+    /* Manual filtration blower toggle reflects requested (not effective) fan. */
+    var filtOn = !!(s.fan && s.fan.requested_percent>0);
+    var fbtn=$('db-filter'); if(fbtn) fbtn.setAttribute('aria-pressed', filtOn?'true':'false');
+    u('db-filter-label', filtOn ? 'Filtration: on' : 'Filtration');
     var autoRow = s.mode==='auto';
     $('db-auto-row').hidden = !autoRow;
-    if(autoRow) u('db-auto', (s.environment.auto_engaged?'engaged':'waiting')
-      +' @ bed ≥'+Math.round(s.environment.auto_bed_threshold_c)+' °C');
+    if(autoRow) u('db-auto', s.environment.auto_engaged
+      ? 'heating @ bed ≥'+Math.round(s.environment.auto_bed_threshold_c)+' °C'
+      : s.environment.auto_filtering ? 'filtering (fan only)'
+      : 'waiting @ bed ≥'+Math.round(s.environment.auto_bed_threshold_c)+' °C');
     var dryRow = s.drying.active;
     $('db-drying-row').hidden = !dryRow;
     if(dryRow) u('db-drying', fmtDur(s.drying.remaining_seconds)+' left');
@@ -1009,6 +1040,14 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
      status area is Stop-only). */
   $('db-stop').addEventListener('click', setOff);
   $('db-clear').addEventListener('click', function(){ command('clear_fault', {}).catch(function(){}); });
+
+  /* Manual filtration blower toggle -> command('filter', {percent}). Fan-only,
+     out-of-band (heater untouched), so it works in any mode. Optimistic UI; the
+     next state snapshot is authoritative. */
+  if($('db-filter')) $('db-filter').addEventListener('click', function(){
+    var on = $('db-filter').getAttribute('aria-pressed')!=='true';
+    command('filter', {percent: on?100:0}).catch(function(){});
+  });
 
   /* ===== U2: Manual / Automatic / Dry control screens =========================
      Client edit-state for the touch steppers/sliders. Each field re-syncs from the
@@ -1149,7 +1188,8 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
     max:   { val:70,  min:30, max:70,  vId:'s-max-value',   rId:'s-max-range',   hId:'s-max-hint',   unit:'°C' },
     comms: { val:300, min:10, max:300, vId:'s-comms-value', rId:'s-comms-range', hId:'s-comms-hint', unit:'s'  },
     cool:  { val:40,  min:30, max:65,  vId:'s-cool-value',  rId:'s-cool-range',  hId:'s-cool-hint',  unit:'°C' },
-    fb:    { val:99,  min:90, max:104, vId:'s-fb-value',    rId:'s-fb-range',    hId:'s-fb-hint',    unit:'°C' }
+    fb:    { val:99,  min:90, max:104, vId:'s-fb-value',    rId:'s-fb-range',    hId:'s-fb-hint',    unit:'°C' },
+    filt:  { val:30,  min:20, max:60,  vId:'s-filt-value',  rId:'s-filt-range',  hId:'s-filt-hint',  unit:'°C' }
   };
   var fbDefault = 99;   // board's per-Rref foldback-cut default (from /settings); slider at this = auto
   function renderSset(k){
@@ -1187,13 +1227,18 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
       var fbManual = isFinite(s.fb_cut) && s.fb_cut>0;
       setSset('fb', fbManual ? s.fb_cut : fbDefault);
       setFbAuto(!fbManual);
+      // Auto-mode filtration band.
+      if(isFinite(s.filter_temp_min)) sset.filt.min = Math.round(s.filter_temp_min);
+      if(isFinite(s.filter_temp_max)) sset.filt.max = Math.round(s.filter_temp_max);
+      if(isFinite(s.filter_temp)) setSset('filt', s.filter_temp);
+      if(typeof s.filter_auto==='boolean') setFiltEn(s.filter_auto);
       if(typeof s.leds_enabled==='boolean') setLedToggle(s.leds_enabled);
     }).catch(function(){});
   }
   document.querySelectorAll('[data-sstep]').forEach(function(b){
     b.addEventListener('click', function(){ var p=b.dataset.sstep.split(','); setSset(p[0], sset[p[0]].val+Number(p[1])); });
   });
-  [['max','s-max-range'],['comms','s-comms-range'],['cool','s-cool-range'],['fb','s-fb-range']].forEach(function(p){
+  [['max','s-max-range'],['comms','s-comms-range'],['cool','s-cool-range'],['fb','s-fb-range'],['filt','s-filt-range']].forEach(function(p){
     var r=$(p[1]); if(r) r.addEventListener('input', function(){ setSset(p[0], Number(r.value)); });
   });
   /* Foldback Auto toggle: Auto disables the slider/steppers and uses the board default
@@ -1244,6 +1289,29 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
         flash('s-fb-msg', post ? ('Saved — cut at '+post+' °C.') : 'Saved — auto (board default).', 'is-ok');
       })
       .catch(function(j){ flash('s-fb-msg', 'Save failed: '+((j&&(j.message||j.error))||'error'), 'is-error'); });
+  });
+  /* Auto-mode filtration band enable toggle (On/Off). Disables the threshold
+     controls when off; the band only runs in AUTO regardless. */
+  function setFiltEn(on){
+    var b=$('s-filt-en');
+    if(b){ b.setAttribute('aria-pressed', on?'true':'false'); b.querySelector('span').textContent = on?'On':'Off'; }
+    var r=$('s-filt-range'); if(r) r.disabled = !on;
+    document.querySelectorAll('[data-sstep^="filt,"]').forEach(function(x){ x.disabled = !on; });
+  }
+  if($('s-filt-en')) $('s-filt-en').addEventListener('click', function(){
+    setFiltEn($('s-filt-en').getAttribute('aria-pressed')!=='true');
+  });
+  /* Filtration band -> POST /settings?filter_temp=&filter_auto=. */
+  $('s-filt-save').addEventListener('click', function(){
+    flash('s-filt-msg', 'Saving…');
+    var en = $('s-filt-en').getAttribute('aria-pressed')==='true';
+    request('/settings?filter_temp='+sset.filt.val+'&filter_auto='+(en?1:0), {})
+      .then(function(s){
+        if(s){ if(isFinite(s.filter_temp)) setSset('filt', s.filter_temp);
+          if(typeof s.filter_auto==='boolean') setFiltEn(s.filter_auto); }
+        flash('s-filt-msg', en ? ('Saved — blower at bed ≥ '+sset.filt.val+' °C.') : 'Saved — band off.', 'is-ok');
+      })
+      .catch(function(j){ flash('s-filt-msg', 'Save failed: '+((j&&(j.message||j.error))||'error'), 'is-error'); });
   });
 
   /* ===== U4: Sensor calibration (GET/POST /api/v2/calibration) ================

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -975,7 +975,9 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
     pushTemp(c.status==='ok' ? c.temperature_c : null, p.status==='ok' ? p.temperature_c : null);
 
     /* Stop enabled only while a mode is running. */
-    $('db-stop').disabled = s.mode==='off';
+    // Stop is available whenever a mode is running OR manual filtration is on
+    // (filtration keeps mode 'off', but Stop must still be able to stop it).
+    $('db-stop').disabled = (s.mode==='off') && !filtOn;
     /* Clear-fault affordance appears only while a fault is latched. */
     $('db-clear').hidden = !s.safety.fault_latched;
 
@@ -1013,7 +1015,13 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
     lease=null;
     command('power_on', {target_c:t}).then(function(r){ lease=r.lease_id||null; }).catch(function(){ lease=null; });
   }
-  function setOff(){ lease=null; command('off', {}).catch(function(){}); }
+  function setOff(){
+    lease=null;
+    command('off', {}).catch(function(){});
+    // Stop = stop all: also clear any manual filtration (turning OFF is always
+    // allowed, even mid-cycle) so it can't linger or "come back" after heating.
+    command('filter', {percent:0}).catch(function(){});
+  }
 
   /* Heartbeat only the exact POWER_ON lease this tab created (never a passive one). */
   function heartbeat(){

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -955,11 +955,13 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
     var filtLocked = (st==='heating' || st==='cooldown');
     var fbtn=$('db-filter');
     if(fbtn){
+      // On-only + lit when active (like the presets); dimmed while heating/cooling
+      // since enabling is blocked then (Stop is the only off).
       fbtn.setAttribute('aria-pressed', filtOn?'true':'false');
-      fbtn.disabled = filtLocked;
-      fbtn.title = filtLocked ? 'Filtration is locked while heating or cooling down' : '';
+      fbtn.disabled = filtLocked;   // lit if active, but not clickable during a cycle
+      fbtn.title = filtLocked ? 'Filtration is locked while heating or cooling down — use Stop' : '';
     }
-    u('db-filter-label', filtLocked ? 'Filtration locked' : filtOn ? 'Filtration: on' : 'Filtration');
+    u('db-filter-label', 'Filtration');
     var autoRow = s.mode==='auto';
     $('db-auto-row').hidden = !autoRow;
     if(autoRow) u('db-auto', s.environment.auto_engaged
@@ -1079,12 +1081,12 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
   $('db-stop').addEventListener('click', setOff);
   $('db-clear').addEventListener('click', function(){ command('clear_fault', {}).catch(function(){}); });
 
-  /* Manual filtration blower toggle -> command('filter', {percent}). Fan-only,
-     out-of-band (heater untouched), so it works in any mode. Optimistic UI; the
-     next state snapshot is authoritative. */
+  /* Manual filtration blower — ON-ONLY, like the temperature presets: a click
+     turns it on, and Stop is the single control that turns it (and everything)
+     off. Fan-only, out-of-band (heater untouched). Optimistic UI; the next state
+     snapshot is authoritative. */
   if($('db-filter')) $('db-filter').addEventListener('click', function(){
-    var on = $('db-filter').getAttribute('aria-pressed')!=='true';
-    command('filter', {percent: on?100:0}).catch(function(){});
+    command('filter', {percent:100}).catch(function(){});
   });
 
   /* ===== U2: Manual / Automatic / Dry control screens =========================

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -939,10 +939,18 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
     /* At-a-glance detail rows — all from the SSE snapshot. */
     u('db-fan', fanLabel(s));
     u('db-controller', controllerLabel(s));
-    /* Manual filtration blower toggle reflects requested (not effective) fan. */
+    /* Manual filtration blower toggle reflects requested (not effective) fan.
+       Idle-only: locked (dimmed) while heating or cooling down, since the blower is
+       owned by the safety-airflow logic then — the firmware rejects changes too. */
     var filtOn = !!(s.fan && s.fan.requested_percent>0);
-    var fbtn=$('db-filter'); if(fbtn) fbtn.setAttribute('aria-pressed', filtOn?'true':'false');
-    u('db-filter-label', filtOn ? 'Filtration: on' : 'Filtration');
+    var filtLocked = (st==='heating' || st==='cooldown');
+    var fbtn=$('db-filter');
+    if(fbtn){
+      fbtn.setAttribute('aria-pressed', filtOn?'true':'false');
+      fbtn.disabled = filtLocked;
+      fbtn.title = filtLocked ? 'Filtration is locked while heating or cooling down' : '';
+    }
+    u('db-filter-label', filtLocked ? 'Filtration locked' : filtOn ? 'Filtration: on' : 'Filtration');
     var autoRow = s.mode==='auto';
     $('db-auto-row').hidden = !autoRow;
     if(autoRow) u('db-auto', s.environment.auto_engaged

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -80,6 +80,9 @@ body{
 .btn:not(.btn-primary).is-selected{
   border-color: var(--primary); color: var(--primary-foreground); background: var(--primary);
 }
+/* The active (pressed) choice is disabled — there's no reason to re-select it. Keep
+   it looking selected (solid blue, normal cursor) rather than faded "unavailable". */
+.btn:not(.btn-primary)[aria-pressed="true"]:disabled{ opacity: 1; cursor: default; }
 .form-range{
   appearance: none; display: block; width: 100%; height: 28px; flex: 1;
   margin: 0; padding: 0; border: 0; accent-color: var(--primary);
@@ -936,8 +939,9 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
     var activeTemp = (s.mode==='power_on')
       ? Math.round(s.target.effective_c || s.target.requested_c || 0) : null;
     document.querySelectorAll('[data-quick-temp]').forEach(function(b){
-      b.setAttribute('aria-pressed',
-        String(Number(b.dataset.quickTemp) === activeTemp));
+      var active = Number(b.dataset.quickTemp) === activeTemp;
+      b.setAttribute('aria-pressed', String(active));
+      b.disabled = active;   // already at this target — no reason to re-click it
     });
 
     var st = displayState(s);
@@ -958,8 +962,11 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
       // On-only + lit when active (like the presets); dimmed while heating/cooling
       // since enabling is blocked then (Stop is the only off).
       fbtn.setAttribute('aria-pressed', filtOn?'true':'false');
-      fbtn.disabled = filtLocked;   // lit if active, but not clickable during a cycle
-      fbtn.title = filtLocked ? 'Filtration is locked while heating or cooling down — use Stop' : '';
+      // On-only: once active (blue) there's nothing to re-click — Stop turns it off.
+      // Also locked (dimmed) while heating/cooling, when enabling is blocked.
+      fbtn.disabled = filtOn || filtLocked;
+      fbtn.title = filtLocked ? 'Filtration is locked while heating or cooling down — use Stop'
+                 : filtOn ? 'Filtration on — use Stop to turn it off' : '';
     }
     u('db-filter-label', 'Filtration');
     var autoRow = s.mode==='auto';

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -912,7 +912,8 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
   }
   function fanLabel(s){
     var f=s.fan||{}, why=({heater:'heating', thermal_purge:'cooldown purge',
-                           requested:'manual', fault:'safety airflow'})[f.reason];
+                           requested:'manual', auto_filter:'auto filtration',
+                           fault:'safety airflow'})[f.reason];
     if(f.reason==='off' || (!why && !f.effective_percent)) return 'Off';
     return 'On — '+(why||f.reason)+(f.effective_percent? ' ('+f.effective_percent+'%)':'');
   }

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -204,7 +204,9 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
 .state-light{ width: 11px; height: 11px; flex: none; border-radius: 50%; background: var(--muted-foreground); }
 .app[data-state="heating"] .state-light,
 .app[data-state="drying"] .state-light{ background: var(--viz-series-1); }
-.app[data-state="waiting"] .state-light{ background: var(--viz-series-3); }
+.app[data-state="waiting"] .state-light,
+.app[data-state="filtering"] .state-light,
+.app[data-state="cooldown"] .state-light{ background: var(--viz-series-3); }
 .app[data-state="fault"] .state-light{ background: var(--destructive); }
 .summary{ min-height: 18px; color: var(--muted-foreground); font-size: 12px; }
 .status-detail{ margin: 4px 0; min-height: 0; flex: 1 1 auto; overflow: auto;
@@ -860,8 +862,14 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
   function displayState(s){
     if(s.safety.fault_latched || s.safety.inhibited) return 'fault';
     if(s.mode==='drying') return 'drying';
-    if(s.mode==='auto' && !s.environment.auto_engaged) return 'waiting';
     if(s.heater.output || s.heater.demand) return 'heating';
+    // Fan-only cases (no heat): cooldown purge, then filtration (manual or the
+    // AUTO band). Checked before AUTO 'waiting' so an active filter band isn't
+    // reported as merely waiting.
+    var f=s.fan||{};
+    if(f.reason==='thermal_purge') return 'cooldown';
+    if((f.effective_percent||0) > 0) return 'filtering';
+    if(s.mode==='auto' && !s.environment.auto_engaged) return 'waiting';
     return 'off';
   }
   function statusLabel(st, s){
@@ -869,6 +877,8 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
     if(st==='drying') return 'Dry cycle';
     if(st==='waiting') return 'Waiting';
     if(st==='heating') return 'Heating';
+    if(st==='cooldown') return 'Cooling down';
+    if(st==='filtering') return 'Filtering';
     return 'Idle';
   }
   function modeLabel(m){
@@ -879,6 +889,8 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
     if(st==='drying'){ var m=Math.round((s.drying.remaining_seconds||0)/60); return 'Filament drying — '+m+' min left. Safety chain healthy.'; }
     if(st==='waiting') return 'Armed. Waiting for the printer bed threshold.';
     if(st==='heating') return s.heater.output ? 'Output active. Safety chain healthy.' : 'Heater demand — waiting on the safety chain.';
+    if(st==='cooldown') return 'Residual-heat purge — fan clearing heat, heater off.';
+    if(st==='filtering') return 'Fan-only filtration — heater off, monitoring active.';
     return 'Heater disabled. Monitoring remains active.';
   }
 

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -931,6 +931,15 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
     u('db-target', s.target.effective_c>0 ? Math.round(s.target.effective_c)+' °C' : 'Off');
     u('db-mode', modeLabel(s.mode));
 
+    /* Light up the quick preset matching the active manual target, the same way the
+       Filtration button shows its state (.btn[aria-pressed="true"]). */
+    var activeTemp = (s.mode==='power_on')
+      ? Math.round(s.target.effective_c || s.target.requested_c || 0) : null;
+    document.querySelectorAll('[data-quick-temp]').forEach(function(b){
+      b.setAttribute('aria-pressed',
+        String(Number(b.dataset.quickTemp) === activeTemp));
+    });
+
     var st = displayState(s);
     app.setAttribute('data-state', st);
     u('db-status', statusLabel(st, s));

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -360,6 +360,7 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
   <symbol id="i-flame" viewBox="0 0 24 24"><path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.07-2.14-.22-4.05 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.15.43-2.29 1-3a2.5 2.5 0 0 0 2.5 2.5z"/></symbol>
   <symbol id="i-refresh" viewBox="0 0 24 24"><path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"/><path d="M21 21v-5h-5"/></symbol>
   <symbol id="i-wind" viewBox="0 0 24 24"><path d="M12.8 19.6A2 2 0 1 0 14 16H2"/><path d="M17.5 8A2.5 2.5 0 1 1 19.5 12H2"/><path d="M9.8 4.4A2 2 0 1 1 11 8H2"/></symbol>
+  <symbol id="i-fan" viewBox="0 0 24 24"><path d="M10.827 16.379a6.082 6.082 0 0 1-8.618-7.002l5.412 1.45a6.082 6.082 0 0 1 7.002-8.618l-1.45 5.412a6.082 6.082 0 0 1 8.618 7.002l-5.412-1.45a6.082 6.082 0 0 1-7.002 8.618l1.45-5.412Z"/><path d="M12 12v.01"/></symbol>
   <symbol id="i-settings" viewBox="0 0 24 24"><path d="M20 7h-9"/><path d="M14 17H5"/><circle cx="17" cy="17" r="3"/><circle cx="7" cy="7" r="3"/></symbol>
   <symbol id="i-thermometer" viewBox="0 0 24 24"><path d="M14 4v10.54a4 4 0 1 1-4 0V4a2 2 0 0 1 4 0z"/></symbol>
   <symbol id="i-power" viewBox="0 0 24 24"><path d="M12 2v10"/><path d="M18.4 6.6a9 9 0 1 1-12.8 0"/></symbol>
@@ -457,7 +458,7 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
           <!-- Manual filtration blower: fan-only, out-of-band (works in any mode,
                heater untouched). Mirrors the Klipper fan_generic control. -->
           <div class="quick-actions">
-            <button class="btn" type="button" id="db-filter" aria-pressed="false"><svg class="icon"><use href="#i-wind"/></svg> <span id="db-filter-label">Filtration</span></button>
+            <button class="btn" type="button" id="db-filter" aria-pressed="false"><svg class="icon"><use href="#i-fan"/></svg> <span id="db-filter-label">Filtration</span></button>
           </div>
         </section>
       </div>
@@ -664,7 +665,7 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
             <input class="form-range" id="s-filt-range" type="range" min="20" max="60" step="1" value="30" aria-label="Filtration bed temperature">
           </div>
           <p class="set-note">In <strong>Auto</strong> mode, the blower runs on its own once the printer bed reaches this temperature — filtering/circulating chamber air before the heater engages at the (higher) auto bed threshold. Fan-only: it never adds heat. Turn <strong>Off</strong> to disable the band. For on-demand filtration in any mode, use the <strong>Filtration</strong> button on the dashboard (or the <code>dragonbreath_filter</code> fan in Fluidd).</p>
-          <button class="btn btn-primary btn-block" type="button" id="s-filt-save"><svg class="icon"><use href="#i-wind"/></svg> <span>Save filtration</span></button>
+          <button class="btn btn-primary btn-block" type="button" id="s-filt-save"><svg class="icon"><use href="#i-fan"/></svg> <span>Save filtration</span></button>
           <div class="mode-feedback" id="s-filt-msg" role="status" aria-live="polite"></div>
         </div>
 

--- a/docs/OEM_PARITY.md
+++ b/docs/OEM_PARITY.md
@@ -4,13 +4,13 @@ DragonBreath is not intended to reproduce the stock firmware byte-for-byte. This
 matrix records which user-visible Panda Breath behaviors are implemented, still
 planned, deliberately changed for safety, or intentionally omitted.
 
-Current as of **v0.6.0**.
+Current as of **v0.6.5** (drying validated on hardware 2026-07-27; fan-only filtration added 2026-07-28).
 
 | Stock/OEM behavior | DragonBreath status | Notes |
 |---|---|---|
 | Manual chamber target | **Implemented** | Local Web UI and Klipper `M141`/`M191`; device-side regulation and limits remain authoritative. |
 | Follow-printer-bed automatic mode | **Partial** | Policy/API support is present: live Moonraker bed temperature, 3 °C disengage hysteresis, and fail-off on disconnect. The shipped dashboard control is not yet accepted as end-to-end validated. |
-| Timed filament drying | **Partial** | Policy/API support is present: a target plus bounded 1–12 hour duration and automatic shutoff. The shipped dashboard control is not yet accepted as end-to-end validated; named material presets remain planned. |
+| Timed filament drying | **Implemented** | A target plus a bounded 1–12 hour duration with automatic shutoff, driven from the dashboard Dry screen and API v2 (`drying_start` / `drying_stop`). Material presets are implemented (PLA 45 °C/6 h, PETG 65 °C/4 h, ABS 70 °C/4 h, Nylon 55 °C/8 h — one tap pre-fills target + duration). Validated on hardware. |
 | Chamber and PTC temperature display | **Implemented** | Both sensors and their health are exposed in the dashboard and API v2 state. |
 | Sensor-fault and over-temperature shutdown | **Implemented** | Heater fails closed; fixed 85 °C chamber and 105 °C PTC cutoffs are not user-configurable. |
 | Fan follows heater | **Implemented** | TRIAC is held on/off and never phase-angle PWM'd. |
@@ -25,7 +25,7 @@ Current as of **v0.6.0**.
 | Stock WebSocket API and Web UI | **Intentionally omitted** | API v2 and the DragonBreath dashboard are the supported interfaces. |
 | Boot/resume active heating | **Intentionally changed** | DragonBreath always boots OFF and never restores active heat, timers, or leases after reboot. |
 | Persistent fault latch | **Implemented** | Hazard-driven trips (over-temp, sensor fault, comms-loss) are persisted to NVS on the latching transition and restored at boot, so a device that tripped before losing power comes back up heater-OFF with commands inhibited. Boot restore is fail-safe (unreadable store → latched); a failed persist is retried until it commits; clearing is persist-first (HTTP 500 rather than a false "cleared"). User panic-off and the permanent inhibit are deliberately not persisted (clear on reboot). |
-| Fan-only filtration mode | **Unverified / optional** | Not required for parity until stock behavior is confirmed; may be added as a DragonBreath enhancement. |
+| Fan-only filtration mode | **Implemented** | Stock runs the blower alone as the low band of AUTO (bed ≥ `filter_temp`, before the heater engages). DragonBreath reproduces this as a configurable AUTO fan-only band (default on, `filter_temp` default 30 °C) and additionally exposes a mode-independent manual filtration fan (dashboard toggle + `filter` API command). Fan-only in both cases — the heater is never engaged by filtration. |
 
 Safety takes precedence over exact OEM behavior. See [SAFETY.md](SAFETY.md) for
 the enforced invariants and

--- a/tests/pb_policy_host_test.c
+++ b/tests/pb_policy_host_test.c
@@ -361,6 +361,51 @@ static void test_auto_requires_live_moonraker_and_uses_hysteresis(void)
     CHECK(!snapshot().auto_engaged);
 }
 
+static void test_auto_filtration_band_fan_only_not_cooldown(void)
+{
+    reset_fixture();
+    // AUTO, heat threshold 100 C; filter_temp defaults to 30 C, band enabled.
+    CHECK(pb_policy_set_auto(
+        60.0f, 100.0f, PB_SOURCE_WEB, 1) == PB_POLICY_OK);
+
+    // Bed below filter_temp: no filtration, fan off.
+    pb_policy_set_env(25.0f, true);
+    pb_policy_tick();
+    pb_policy_snapshot_t snap = snapshot();
+    CHECK(!snap.auto_filtering);
+    CHECK(snap.effective_fan_percent == 0);
+
+    // Bed >= filter_temp but below the heat threshold: fan-only filtration band.
+    pb_policy_set_env(40.0f, true);
+    pb_policy_tick();
+    snap = snapshot();
+    CHECK(snap.auto_filtering);                 // filtering
+    CHECK(!snap.auto_engaged);                  // heater NOT engaged
+    CHECK(snap.effective_target_c == 0.0f);     // no heat demanded
+    CHECK(snap.effective_fan_percent == 100);   // blower running
+    CHECK(!snap.thermal_purge);                 // P1: must NOT read as cooldown purge
+
+    // Hysteresis: stays on within [filter_temp - 3, ...); releases only below it.
+    pb_policy_set_env(28.0f, true);
+    pb_policy_tick();
+    CHECK(snapshot().auto_filtering);
+    pb_policy_set_env(26.0f, true);
+    pb_policy_tick();
+    snap = snapshot();
+    CHECK(!snap.auto_filtering);
+    CHECK(snap.effective_fan_percent == 0);
+
+    // Moonraker disconnect fails to no-airflow even with a hot bed.
+    pb_policy_set_env(40.0f, true);
+    pb_policy_tick();
+    CHECK(snapshot().auto_filtering);
+    pb_policy_set_env(40.0f, false);
+    pb_policy_tick();
+    snap = snapshot();
+    CHECK(!snap.auto_filtering);
+    CHECK(snap.effective_fan_percent == 0);
+}
+
 static void test_drying_is_bounded_and_expires_off(void)
 {
     reset_fixture();
@@ -960,6 +1005,7 @@ int main(void)
     test_new_command_supersedes_old_lease_and_off_is_unconditional();
     test_lease_expiry_latches_watchdog_fault();
     test_auto_requires_live_moonraker_and_uses_hysteresis();
+    test_auto_filtration_band_fan_only_not_cooldown();
     test_drying_is_bounded_and_expires_off();
     test_runtime_limits_drive_auto_and_remote_lease();
     test_local_power_limit_expires_off_without_fault();


### PR DESCRIPTION
Fan-only chamber filtration — targets **v0.6.5**. Two ways to run the blower fan-only (heater untouched), both driving the previously-unused `requested_fan_percent` path:

## Automatic AUTO-mode band (stock-like, firmware-side)
In **AUTO**, the blower runs alone once the printer bed reaches a configurable **filter temperature** (default **30 °C**, range 20–60 °C), before the heater engages at the higher auto bed threshold — mirroring the stock Panda's filtration band. Enabled by default; hysteresis mirrors the engage band; fails to no-airflow if disabled or Moonraker drops. Persisted; set in **Settings → Filtration (auto mode)** or `GET/POST /settings?filter_temp=&filter_auto=`.

## Manual, out-of-band fan
A new `filter` API v2 command runs the blower fan-only **independent of mode** — not cleared by OFF, additive over any heat airflow, and safe (no heat path, so revision-independent and even aids cooling while faulted). Surfaced as a **Filtration** toggle on the dashboard.

## Surface
- State: `environment.auto_filtering`, `params.filter_temp_c`, `params.filter_auto_enable`.
- `/settings`: `filter_temp` (+ `_min`/`_max`) and `filter_auto`.
- Web UI: dashboard Filtration toggle + a "Filtration (auto mode)" settings card.
- Docs: `OEM_PARITY` fan-only filtration → **Implemented** (and drying → Implemented, folding in #33).

The heater and every over-temp cutoff are unaffected — filtration only ever runs the fan.

## Tests (all green)
Host tests 4/4 · API-v2 contract · dashboard-JS (syntax + dup-id) · `-Wall -Wextra -Werror` build clean (0 warnings). cppcheck: filtration files clean (the two `main` findings are pre-existing and fixed by #28).

## Follow-ups (not in this PR)
- Fluidd `[fan_generic dragonbreath_filter]` in the `dragonbreath-klipper` helper (separate helper release).
- v0.7.0 (Phase E / #28) rebases on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
