### PR TITLE
docs: sync all documentation to v0.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ OEM parity → [`docs/OEM_PARITY.md`](docs/OEM_PARITY.md) · hardware →
 | Status LEDs (`pb_leds`) | ✅ All four driven from policy: Power = device-alive/fault, On/Auto/Dry = active mode (Auto slow-blinks when armed but waiting). |
 | Front-panel buttons (`pb_buttons`) | ✅ All four polled with debounce + short/long-press; short toggles the labeled mode, 2 s long-press = panic-off (Power-long while faulted = fault clear). Real-Panda + devboard-HIL benches passed. |
 | HTTP control API (`pb_httpd`) | ✅ API v2 (JSON command/state + SSE, CSRF-gated) — shipped in v0.3.0 |
-| Klipper-side helper (M141 / Fluidd) | ✅ [dragonbreath-klipper](https://github.com/plastikman/dragonbreath-klipper) migrated to API v2; deploy lockstep with firmware ≥ v0.3.0 |
-| Auto (follow-bed) / filament-dry modes | 🚧 Shipped in the state machine + UI (v0.3.0); end-to-end hardware soak in progress |
+| Klipper-side helper (M141 / Fluidd) | ✅ [dragonbreath-klipper](https://github.com/plastikman/dragonbreath-klipper): `[heater_generic dragonbreath]` (M141/M191) + `[output_pin dragonbreath_filter]` (fan-only filtration toggle); API v2, deploy lockstep with the firmware |
+| Filament-dry mode | ✅ Timed dry with material presets; validated end-to-end on hardware |
+| Auto (follow-bed) mode | 🚧 Shipped in the state machine + UI; end-to-end hardware soak in progress |
+| Fan-only filtration | ✅ AUTO fan-only band (`filter_temp`) + mode-independent manual `filter` control (dashboard + API); idle-only to enable |
 | Flasher (`tools/flash.py`) | ✅ Backs up full stock flash first, then flashes; `--restore` returns to stock |
 | Web OTA update | ✅ Dual-OTA + rollback; upload from the UI, verified on hardware (DragonBreath-only, refused while heating) |
 | HIL (`pb_hil` / `tools/hil.py`) | ✅ CH341 devboard suite and non-heating real-Panda UART build/flash/no-flash workflows qualified on hardware; native-USB runtime pending on the tested devboard |
@@ -75,12 +77,15 @@ hardware limit. 60–65 °C covers ASA/ABS comfortably.
 
 The responsive, touch-first web UI, served by the device itself over plain HTTP on
 your LAN and embeddable in the Fluidd / Mainsail panel: the live **dashboard**
-(chamber / PTC temperature, trend, and quick controls), **automatic** mode (arm a
-chamber target that follows the printer bed), a timed filament-**drying** cycle
-with material presets, and **settings** (safety limits, comms watchdog, and ±5 °C
-sensor calibration). Provisioning (`/setup`) and DragonBreath-only OTA (`/fw`)
-pages share the same theme. Shown in the dark theme; a light theme and an
-auto / light / dark toggle are built in.
+(chamber / PTC temperature, trend, and quick controls incl. a **Filtration**
+fan-only toggle), **automatic** mode (arm a chamber target that follows the printer
+bed, with an optional fan-only filtration band below the heat threshold), a timed
+filament-**drying** cycle with material presets, and **settings** (safety limits,
+comms watchdog, foldback cut, filtration temperature, and ±5 °C sensor
+calibration). Provisioning (`/setup`) and DragonBreath-only OTA (`/fw`) pages share
+the same theme. Both **light and dark** themes are built in (auto / light / dark
+toggle), and the layout stacks vertically on phones while keeping the full layout
+on desktop.
 
 ## Hardware
 ESP32-C3-MINI-1, mains PSU, PTC heater via SSR (GPIO18), ~220 VAC blower switched
@@ -110,12 +115,13 @@ code and supervise the device.
 
 | Method | Path | Purpose |
 |---|---|---|
-| GET | `/api/v2/info` | device identity, boot identity, firmware and capabilities |
+| GET | `/api/v2/info` | device identity, boot identity, firmware, capabilities, and `rref_kohm` (82/33) |
 | GET | `/api/v2/state` | complete authoritative state snapshot — **no** side effects |
 | GET | `/api/v2/events` | SSE stream of state transitions and telemetry snapshots |
 | GET | `/api/v2/health` | uptime, heap, Wi-Fi signal/channel, SSE client count |
-| POST | `/api/v2/command` | revision-aware OFF/POWER_ON/AUTO/DRYING/fault-clear command |
+| POST | `/api/v2/command` | revision-aware OFF / POWER_ON / AUTO / DRYING / **FILTER** / fault-clear command |
 | POST | `/api/v2/heartbeat` | refresh exactly the device-issued active lease |
+| GET/POST | `/settings` | runtime knobs + bounds: max target, comms watchdog, `cool_release`, `fb_cut` (foldback), `filter_temp`/`filter_auto`, LEDs |
 | POST | `/update` | authenticated DragonBreath app-image OTA; refused while heating |
 
 The alpha `/status`, `/target`, `/heartbeat`, and `/reset` routes are removed.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,6 +1,6 @@
 # DragonBreath — feature set
 
-Current as of **v0.3.0**. Open ESP-IDF firmware for the BIGTREETECH Panda Breath
+Current as of **v0.7.2**. Open ESP-IDF firmware for the BIGTREETECH Panda Breath
 (ESP32-C3) chamber heater with Moonraker/Klipper + local web control.
 
 See [`OEM_PARITY.md`](OEM_PARITY.md) for the explicit implemented/planned/
@@ -17,15 +17,17 @@ heat after a reboot.
 | **Off** | Heater off. | Boot default; `off` command (always accepted). |
 | **Manual / Power-On** | Holds the chamber at a set target. Remote sessions take a device-issued lease and must heartbeat to stay alive. | `power_on` command (web "Manual heat", or Klipper `M141`/`SET_HEATER_TEMPERATURE`). |
 | **Automatic (follow bed)** | Watches the printer's bed temperature (via Moonraker) and heats the chamber to the target whenever the bed is at/above a threshold; disengages below threshold − 3 °C. Autonomous (no host heartbeat), requires the Moonraker link. | `auto` command / web "Follow printer bed". |
-| **Filament drying** | Holds the chamber at a target for a bounded duration (1–12 h), then auto-off. | `drying_start` / web "Filament drying". |
+| **Filament drying** | Holds the chamber at a target for a bounded duration (1–12 h), then auto-off. Material presets pre-fill target + duration. | `drying_start` / web "Filament drying". |
+| **Fan-only filtration** | Runs the chamber blower with **no heat** to filter/circulate air. Two paths: (a) automatic in AUTO — the blower runs alone once the bed reaches `filter_temp` (default 30 °C), before the heater engages; (b) a mode-independent manual toggle. Enabling manual filtration is idle-only (rejected while heating/cooling); turning it off always works. | `filter` command / web "Filtration" button; AUTO band via `filter_temp`/`filter_auto`. |
 
 Commands are **revision-aware** (a stale writer can't clobber newer state) and
-**idempotent** (request-ID replay cache); `off`/`drying_stop` are always accepted
-and never cached.
+**idempotent** (request-ID replay cache); `off`/`drying_stop`/`filter` are always
+accepted and never cached.
 
-AUTO and DRYING are implemented in the policy/API. Their dashboard control path
-is still tracked as partial until its user-facing feedback and end-to-end
-operation are validated; see [`OEM_PARITY.md`](OEM_PARITY.md).
+AUTO and filament drying are implemented in the policy/API; drying is validated
+end-to-end on hardware. The AUTO dashboard control is still tracked as partial
+until its user-facing feedback is fully validated; see
+[`OEM_PARITY.md`](OEM_PARITY.md).
 
 ## Safety
 
@@ -37,6 +39,16 @@ Defense-in-depth — see [`SAFETY.md`](SAFETY.md) for the full model.
 - **Firmware soft cutoffs:** 105 °C PTC over-temp and 85 °C chamber over-temp
   (both **fixed, non-configurable**); sensor-fault fail-closed (a bad thermistor
   latches the heater off).
+- **Element foldback limiter:** below the 105 °C cutoff, the SSR is cut with
+  hysteresis (per-Rref: 82 kΩ → 102 °C / 33 kΩ → 99 °C, or a user `fb_cut`
+  override 90–104 °C) so a hot element holds under the hard cutoff instead of
+  tripping it. Can only remove power; never exceeds 104 °C; the 105 °C cutoff is
+  unaffected.
+- **Per-Rref board detection:** the thermistor reference resistor (82 kΩ V1.0.1 /
+  33 kΩ V1.0) is read from a strap at boot with a dual-pull check that fails safe
+  to the conservative 33 kΩ if the pin floats; exposed as `rref_kohm` at `/info`.
+- **Fan-only filtration never heats:** the filtration blower drives only the fan,
+  never the SSR, and manual enable is idle-only (rejected while heating/cooling).
 - **Comms-loss watchdog:** if the controlling client goes silent while heating,
   the heater latches off. Runtime-configurable within **10 s – 5 min** (never
   disabled or extended past 5 min).
@@ -49,9 +61,15 @@ Defense-in-depth — see [`SAFETY.md`](SAFETY.md) for the full model.
 - **Max-target ceiling** — default 70 °C, hard-capped at 70 °C. No API/UI path
   can command heat above it.
 - **Comms-watchdog timeout** — default 5 min, clamped to 10 s – 5 min.
+- **Cooldown-fan release temp** (`cool_release`) — default 40 °C, range 30–65 °C;
+  the residual-heat purge releases here (engages one 3 °C band above it).
+- **Element-foldback cut** (`fb_cut`) — default auto (per-Rref); override 90–104 °C.
+  Advanced/experts-only — see `tools/diag.py`. Never exceeds 104 °C.
+- **AUTO filtration band** — `filter_temp` (default 30 °C, 20–60 °C) + `filter_auto`
+  (on/off) control the fan-only filtration band in AUTO mode.
 
-Exposed via `GET`/`POST /settings` and the web UI's Advanced/Safety card. The
-fixed over-temp cutoffs are not settable.
+Exposed via `GET`/`POST /settings` and the web UI's Settings cards. The fixed
+over-temp cutoffs are not settable.
 
 ## Status LEDs
 
@@ -97,10 +115,11 @@ button scenario both passed on physical hardware (2026-07-24).
 AC blower switched by a TRIAC held **on/off** (never phase-angle PWM'd), synced
 to the mains zero-cross detector. Airflow follows the heater; **post-print
 cooldown** keeps the blower running after a heating session until the chamber
-falls below 40 °C (gated on a heat-this-session flag, so it never auto-starts on
-temperature alone). A future persisted setting may opt into temperature-latched
-purging across sessions/reboots; session-gated behavior remains the default.
-Fault airflow is always forced on regardless of this preference.
+falls below the configurable release temp (`cool_release`, default 40 °C), gated
+on a heat-this-session flag so it never auto-starts on temperature alone. The
+blower also serves **fan-only filtration** (heater untouched) — automatic in AUTO
+once the bed reaches `filter_temp`, and via the manual `filter` command / dashboard
+toggle. Fault airflow is always forced on regardless.
 
 ## Control API (port 80)
 
@@ -123,20 +142,26 @@ watchdog.
 
 ## Web UI (served by the device)
 
-- **Live dashboard** — SSE-driven status (chamber/element temps, mode, target,
-  heating, fan, controller/link), Manual/Automatic/Filament-drying/Advanced
-  cards.
-- **Captive provisioning** — Wi-Fi + Moonraker setup portal (AP mode).
-- **OTA page** — upload + flash a DragonBreath image; on official builds it also
-  checks GitHub for a newer release and shows a verified download link.
+- **Live dashboard** — SSE-driven status (chamber/element temps + trend chart,
+  mode, target, fan + reason, controller/link) with Manual / Automatic / Dry /
+  Filtration controls and a Settings screen. Responsive and **light/dark themed**:
+  full layout on desktop at any width; stacks vertically on touch devices.
+- **Captive provisioning** (`/setup`, Wi-Fi + Moonraker in AP mode) and **OTA**
+  (`/fw`) pages match the dashboard theme (light/dark). The OTA page streams the
+  image with a live %, then returns to the dashboard once the device reboots.
 - mDNS: reachable at **`dragonbreath.local`**.
 
 ## Klipper / Moonraker integration
 
 [`dragonbreath-klipper`](https://github.com/plastikman/dragonbreath-klipper) is
-the host-side helper (Klipper `extras`): exposes the chamber as a heater for
-`M141` / `M191` and Fluidd, speaks API v2 (SSE + exact-lease heartbeats,
-reactor-safe). Deploy lockstep with firmware ≥ v0.3.0.
+the host-side helper (Klipper `extras`): a `[heater_generic dragonbreath]` exposes
+the chamber as a heater for `M141` / `M191` and Fluidd, and a
+`[output_pin dragonbreath_filter]` exposes the fan-only filtration blower as an
+on/off toggle (binary — the blower can't modulate). Speaks API v2 (SSE +
+exact-lease heartbeats, reactor-safe). Deploy lockstep with the firmware.
+
+The dashboard can also be embedded in the Fluidd/Mainsail printer view via a
+Moonraker `[webcam]` `iframe` — see the DragonBreath README.
 
 DragonBreath also reads printer/bed state directly from Moonraker for AUTO mode.
 The stock firmware can likewise obtain bed temperature from Moonraker in
@@ -153,5 +178,10 @@ paths require a vendor cloud.
 - **Reproducible CI releases** — tag `v*` → factory image, OTA image, install
   bundle, `manifest.json` (source SHA, ESP-IDF version, per-artifact SHA-256),
   and `SHA256SUMS.txt`.
-- Hardware reverse-engineered + validated on a **V1.0.1** board (verify the
-  pinout on other revisions before flashing).
+- **CI static analysis + tests** — cppcheck over `components/`+`main/` and
+  `-Wall -Wextra -Werror` on every first-party component, plus host/simulation
+  tests (heater safety-trip ladder, NTC classify, policy state machine incl. the
+  AUTO filtration band, persistent fault-latch) and the dev-board HIL build.
+- Hardware reverse-engineered + validated on a **V1.0.1** board; the **V1.0**
+  board (33 kΩ Rref) is confirmed in the field. Verify the pinout on other
+  revisions before flashing.

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -1,8 +1,11 @@
-# Panda Breath V1.0.1 — hardware map
+# Panda Breath V1.0 / V1.0.1 — hardware map
 
-BIGTREETECH Panda Breath V1.0.1 control board. Mains-powered PTC chamber heater
+BIGTREETECH Panda Breath control board. Mains-powered PTC chamber heater
 + AC blower fan, controlled over WiFi. Reverse-engineered from the board, the
-schematic, and the stock firmware.
+schematic, and the stock firmware. Reverse-engineered and validated on a **V1.0.1**
+board; the **V1.0** board is identical except for the thermistor reference resistor
+(33 kΩ vs V1.0.1's 82 kΩ), auto-detected at boot from the Rref strap (GPIO19) and
+reported as `rref_kohm` — the V1.0 board is confirmed in the field.
 
 ## Core components
 | Block | Part | Notes |
@@ -13,7 +16,7 @@ schematic, and the stock firmware.
 | Heater switch | **MGR GJ-5-L SSR** | 5 A 24–380 VAC, DC-controlled, on/off only |
 | Fuse | **jdtfuse T6.3A 250V** | over-current only (NOT over-temp) |
 | Fan | **STKJ ST7530B220H** | ~220 VAC EC blower, 0.054 A (~12 W), 2-wire |
-| Fan drive | **MOC3021 + BT136-800E** | random-phase opto-triac + TRIAC, phase-angle |
+| Fan drive | **MOC3021 + BT136-800E** | random-phase opto-triac + TRIAC; hardware supports phase-angle, but DragonBreath drives it **on/off only** (switched at the zero-cross, never phase-chopped) |
 | Zero-cross | **MB6S + TLP785 (P785)** | bridge + opto → ZCD pulse to the MCU |
 
 ## GPIO map (see `components/pb_board/include/pb_board.h`)

--- a/docs/OEM_PARITY.md
+++ b/docs/OEM_PARITY.md
@@ -4,7 +4,7 @@ DragonBreath is not intended to reproduce the stock firmware byte-for-byte. This
 matrix records which user-visible Panda Breath behaviors are implemented, still
 planned, deliberately changed for safety, or intentionally omitted.
 
-Current as of **v0.6.5** (drying validated on hardware 2026-07-27; fan-only filtration added 2026-07-28).
+Current as of **v0.7.2** (drying validated on hardware 2026-07-27; fan-only filtration added 2026-07-28; web UI reworked — no brand header, per-card intros, light/dark, desktop keeps full layout / phones stack).
 
 | Stock/OEM behavior | DragonBreath status | Notes |
 |---|---|---|
@@ -14,7 +14,7 @@ Current as of **v0.6.5** (drying validated on hardware 2026-07-27; fan-only filt
 | Chamber and PTC temperature display | **Implemented** | Both sensors and their health are exposed in the dashboard and API v2 state. |
 | Sensor-fault and over-temperature shutdown | **Implemented** | Heater fails closed; fixed 85 °C chamber and 105 °C PTC cutoffs are not user-configurable. |
 | Fan follows heater | **Implemented** | TRIAC is held on/off and never phase-angle PWM'd. |
-| Residual-heat fan purge | **Implemented** | Session-gated cooldown with hysteresis (engage ≥ 40 °C, release only once **both** chamber and PTC are < 37 °C; an unknown sensor keeps the fan on). Strictly session-gated: the fan never starts on temperature alone, and a power-cycle-while-hot does not spin it. The opt-in temperature-latched policy was **intentionally not added** for that reason. Fault airflow remains unconditional. |
+| Residual-heat fan purge | **Implemented** | Session-gated cooldown with hysteresis around the configurable `cool_release` temp (30–65 °C, default 40 °C): engages one 3 °C band above it, releases only once **both** chamber and PTC are below it; an unknown sensor keeps the fan on. Strictly session-gated: the fan never starts on temperature alone, and a power-cycle-while-hot does not spin it. The opt-in temperature-latched policy was **intentionally not added** for that reason. Fault airflow remains unconditional. |
 | Front-panel mode LEDs | **Implemented** | All four outputs are driven from the authoritative policy snapshot: Power is solid whenever the device is up and blinks on fault; On, Auto, and Dry each light for their own mode. Auto slow-blinks when armed but not engaged (no Moonraker link, or bed below the threshold). Power is release-only — GPIO21 is also the serial console TX. |
 | Front-panel buttons | **Implemented** | All four (Power GPIO9, Auto GPIO8, On GPIO10, Dry GPIO2) are polled with debounce and short/long-press detection. A short press toggles the button's labeled mode (arming from the remembered parameters); a 2 s long-press latches a panic-off, except a long-press on Power while faulted attempts a fault clear. Every button action is attributed to the panel and invalidates any remote lease. A button held at power-on is ignored until released (GPIO9/8/2 are strapping pins). |
 | Local status/configuration UI | **Implemented** | Responsive, touch-first single-page dashboard with manual/automatic/drying control screens, a settings screen (safety limits, sensor calibration, LEDs), an at-a-glance status panel (fan + reason, controller, auto/drying, printer, fault), and setup/OTA pages. Light/dark themes. |

--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -22,7 +22,14 @@ guarantee** — no firmware can promise the absence of every fault.
 
 ## Layer 3 (this firmware) — soft cutoffs
 `pb_heater` enforces, every control tick, before any heat request:
-- **PTC element over-temp** → force off at 105 °C (stock parity).
+- **PTC element over-temp** → force off at 105 °C (stock parity). Always the first,
+  unconditional, latching check.
+- **Element foldback limiter** → below the 105 °C cutoff, the SSR is cut with
+  hysteresis at a per-Rref point and held off until the element cools to a resume
+  point, so a hot/slow element holds *under* the hard cutoff instead of ratcheting
+  into it. Cut point is per-board (82 kΩ → 102 °C / 33 kΩ → 99 °C) or a user
+  override `fb_cut` (90–104 °C). It can **only remove power**, can never exceed
+  104 °C, and does not touch the fixed 105 °C hardware cutoff.
 - **Chamber over-temp** → force off at 85 °C.
 - **Sensor fault while heating** (open/short) → fail-closed.
 - **Comms-loss watchdog** → if no controller link for 5 min while heating, latch
@@ -106,11 +113,21 @@ transient init failure must not brick the device across reboots).
 
 ## Residual-heat purge (session-gated, hysteresis)
 After heat has run **this session**, the cooldown fan keeps running while the
-chamber **or** PTC sensor is hot, engaging at ≥ 40 °C and releasing only once
-**both** are below 37 °C (an unknown/faulted sensor keeps the fan on). It is
-strictly session-gated: the fan **never** starts on temperature alone, and
-because that gate is RAM-only, a **power-cycle-while-hot does not spin the fan**.
-A fault forces airflow ON unconditionally, independent of this purge.
+chamber **or** PTC sensor is hot. The release temperature is the user-configurable
+`cool_release` (30–65 °C, default 40 °C); the fan engages one 3 °C hysteresis band
+above it and releases only once **both** sensors are below `cool_release` (an
+unknown/faulted sensor keeps the fan on). It is strictly session-gated: the fan
+**never** starts on temperature alone, and because that gate is RAM-only, a
+**power-cycle-while-hot does not spin the fan**. A fault forces airflow ON
+unconditionally, independent of this purge.
+
+## Fan-only filtration is heater-independent and idle-only to enable
+The manual filtration blower (`filter` command) and the AUTO fan-only filtration
+band drive **only the blower** — they never engage the heater/SSR. Enabling manual
+filtration is **idle-only**: turning it on while the heater is heating or the
+cooldown purge is running is rejected (`heater_busy`, HTTP 409) so a status-page
+toggle can't disturb an active heat cycle; turning it *off* is always allowed. The
+AUTO band fails to no-airflow if disabled or if Moonraker disconnects.
 
 ## What is NOT protected
 - **Over-current** is only the 6.3 A mains fuse. There is no PCB over-temp cutoff.

--- a/docs/api-v2.md
+++ b/docs/api-v2.md
@@ -9,8 +9,9 @@ routes require `X-DragonBreath-Auth`; the device does not enable CORS.
 
 ## Read-only routes
 
-- `GET /api/v2/info` — API version, stable device ID, per-boot ID, firmware and
-  capabilities.
+- `GET /api/v2/info` — API version, stable device ID, per-boot ID, firmware,
+  capabilities, and `rref_kohm` (the resolved thermistor reference resistor — 82 on
+  V1.0.1, 33 on V1.0 — read once at boot from the strap).
 - `GET /api/v2/state` — full authoritative snapshot. Reading never refreshes a
   lease or otherwise changes device state.
 - `GET /api/v2/events` — Server-Sent Events. A `state` event is sent on connect
@@ -56,6 +57,7 @@ The complete snapshot, not locally remembered intent, is the source of truth:
     "moonraker_connected": true,
     "bed_temperature_c": 100.0,
     "auto_engaged": false,
+    "auto_filtering": false,
     "auto_bed_threshold_c": 0.0
   },
   "drying": {"active": false, "remaining_seconds": 0},
@@ -64,7 +66,9 @@ The complete snapshot, not locally remembered intent, is the source of truth:
     "auto_target_c": 60.0,
     "auto_bed_threshold_c": 100.0,
     "dry_target_c": 60.0,
-    "dry_hours": 12
+    "dry_hours": 12,
+    "filter_temp_c": 30.0,
+    "filter_auto_enable": true
   },
   "control": {
     "lease": {
@@ -87,6 +91,12 @@ authenticated response that creates a POWER_ON lease returns it.
 `state_revision` changes only for control, mode, lease, fault, and safety
 transitions; ordinary temperature samples and successful heartbeats do not
 increment it.
+
+`fan.reason` is one of: `off`, `heater` (airflow while heating), `thermal_purge`
+(residual-heat cooldown purge), `auto_filter` (the AUTO fan-only filtration band),
+`requested` (the manual filtration fan), or `fault` (safety airflow).
+`environment.auto_filtering` is `true` while the AUTO fan-only band is driving the
+blower (bed at/above `filter_temp_c`, below the heat-engage threshold).
 
 `params` reports the *remembered* mode parameters — the values most recently
 accepted for each mode, used to pre-fill the UI and to re-arm a mode when the
@@ -121,6 +131,11 @@ Supported commands:
   the observed Moonraker bed state.
 - `{"name":"drying_start","target_c":50,"hours":4}` — bounded to 1–12 hours.
 - `{"name":"drying_stop"}` — unconditional safer stop.
+- `{"name":"filter","percent":100}` — manual fan-only filtration blower (0 = off,
+  1–100 = on; the blower is on/off, so any non-zero runs it). Heater untouched;
+  independent of mode and revision-independent. **Enable is idle-only**: turning it
+  *on* while the heater is heating or the cooldown purge is running is rejected with
+  `heater_busy` (HTTP 409); turning it *off* is always allowed.
 - `{"name":"clear_fault"}` — clears a recoverable fault only at the expected
   revision. Permanent inhibits require correcting the condition and rebooting.
 
@@ -175,11 +190,17 @@ Defined error codes include `invalid_command`, `unsupported_api_version`,
 
 These predate/sit beside the versioned control surface and are stable:
 
-- `GET /settings` — the runtime-configurable safety settings plus their bounds:
-  `{"max","max_min","max_abs","comms_ms","comms_ms_min","comms_ms_max","leds_enabled"}`.
-  Open (read-only, no side effects). `leds_enabled` is the status-LED master
-  enable (bool, default `true`).
-- `POST /settings?max=<°C>&comms_ms=<ms>&leds_enabled=<0|1>` — update any subset.
+- `GET /settings` — the runtime-configurable settings plus their bounds:
+  `{"max","max_min","max_abs","comms_ms","comms_ms_min","comms_ms_max",`
+  `"cool_release","cool_release_min","cool_release_max",`
+  `"fb_cut","fb_cut_default","fb_cut_min","fb_cut_max",`
+  `"filter_temp","filter_temp_min","filter_temp_max","filter_auto","leds_enabled"}`.
+  Open (read-only, no side effects). `cool_release` is the cooldown-fan "cool down
+  to" temperature (30–65 °C, default 40). `fb_cut` is the element-foldback cut
+  (90–104 °C; `0` = auto → the per-Rref `fb_cut_default`). `filter_temp` (20–60 °C,
+  default 30) + `filter_auto` (bool) drive the AUTO fan-only filtration band.
+  `leds_enabled` is the status-LED master enable (bool, default `true`).
+- `POST /settings?max=<°C>&comms_ms=<ms>&cool_release=<°C>&fb_cut=<°C>&filter_temp=<°C>&filter_auto=<0|1>&leds_enabled=<0|1>` — update any subset.
   Auth-gated (`X-DragonBreath-Auth`). Safety values are clamped to the safe
   envelope server-side (the max-target ceiling can never exceed the absolute cap,
   the comms watchdog stays within its min/max) and the clamped effective values


### PR DESCRIPTION
Documentation-only sync bringing every doc in line with the firmware shipped across v0.6.5 → v0.7.2. No firmware or behavior change.

## What changed

**`docs/api-v2.md`**
- `/info` now documents `rref_kohm` (82/33).
- State snapshot: `auto_filtering`, `filter_temp_c`, `filter_auto_enable`.
- `fan.reason` value enumeration (off/heater/thermal_purge/auto_filter/requested/fault).
- New `filter` command (percent; idle-only enable → `heater_busy` / HTTP 409).
- Expanded `/settings` schema + bounds: `cool_release`, `fb_cut`, `filter_temp`, `filter_auto`.

**`docs/SAFETY.md`**
- Element foldback limiter (per-Rref cut with hysteresis; `fb_cut` override; ≤104 °C).
- Residual-heat purge release temp is now the configurable `cool_release` (was documented as fixed).
- New section: fan-only filtration is heater-independent and idle-only to enable.

**`docs/FEATURES.md`**
- Version → v0.7.2; fan-only filtration mode; drying validated end-to-end.
- Foldback / per-Rref / fan-only safety bullets; new configurable settings.
- Responsive + light/dark themed web UI; themed `/setup` & `/fw`.
- Klipper `heater_generic` + `output_pin dragonbreath_filter` + Fluidd iframe note.
- CI static-analysis + host/HIL tests; V1.0 field-confirmed.

**`README.md`**
- Status rows split: drying validated, AUTO still 🚧; new filtration row.
- Control-API table: `FILTER` command, `/settings` row, `rref_kohm` on `/info`.
- Helper row mentions `[heater_generic]` + `[output_pin dragonbreath_filter]`.
- Filtration + theming/responsive layout in the Web-UI blurb.

**`docs/OEM_PARITY.md`**
- "Current as of" v0.6.5 → v0.7.2; purge row reflects configurable `cool_release`.

**`docs/HARDWARE.md`**
- Title V1.0 / V1.0.1 + per-Rref auto-detect note.
- Fan drive wording clarified: on/off at the zero-cross, never phase-angle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)