### PR TITLE
feat: selectable control source — Klipper / Bambu / Home Assistant (v0.8.0-rc1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+## [0.8.0-rc1] - 2026-07-28
+
+### Added
+- **Selectable control source (Klipper / Bambu / Home Assistant).** The device now
+  binds to exactly one printer/controller, chosen in `/setup` under a new "Control
+  source" card. Klipper (Moonraker) remains the default and is unchanged. A new
+  `pb_source` selector persists the choice; `app_main` starts only the selected
+  client and feeds the existing AUTO seam (`pb_policy_set_env`) — the heater safety
+  model is unchanged and fully source-independent.
+- **Home Assistant integration (tested).** New `pb_ha` MQTT client connects to your
+  broker, publishes MQTT Discovery (a climate entity + chamber/element temperature
+  sensors auto-appear in HA), publishes retained state, and maps HA commands to
+  heater target/mode — holding a device lease and heartbeating it like any remote
+  controller. The climate entity declares Celsius (`temp_unit:C`) so HA converts
+  °C↔°F correctly in both display and setpoints. Validated end-to-end on real
+  hardware (device + Home Assistant + Mosquitto).
+- **Bambu LAN integration (experimental — untested against a printer).** New
+  `pb_bambu` MQTT-over-TLS client reads a Bambu printer's bed temperature over its
+  on-device LAN broker (`mqtts://<ip>:8883`, `bblp` + LAN access code, subscribe
+  `device/<serial>/report`, `pushall` on connect) so AUTO can follow a Bambu print.
+  Read-only — no control commands are ever sent to the printer. Built from the
+  OpenBambuAPI / ha-bambulab spec; **not yet validated on real hardware** — select
+  "Bambu" in `/setup` to test. See `plans/control-source-bambu-ha.md`.
+
+### Changed
+- **`/setup` no longer forces Wi-Fi re-entry to change configuration.** In STA mode,
+  saving with the Wi-Fi fields left blank keeps the existing credentials and just
+  applies the control-source/config change. Wi-Fi is still required during initial
+  AP provisioning.
+
 ## [0.7.2] - 2026-07-28
 
 ### Changed

--- a/components/pb_bambu/CMakeLists.txt
+++ b/components/pb_bambu/CMakeLists.txt
@@ -1,0 +1,7 @@
+idf_component_register(
+    SRCS "pb_bambu.c"
+    INCLUDE_DIRS "include"
+    # esp-mqtt over TLS (esp-tls/mbedTLS) to the printer's on-device broker.
+    # Reports are scanned with strstr/strtof (no cJSON). Built into ESP-IDF.
+    REQUIRES nvs_flash mqtt esp-tls
+)

--- a/components/pb_bambu/include/pb_bambu.h
+++ b/components/pb_bambu/include/pb_bambu.h
@@ -1,0 +1,45 @@
+#pragma once
+// Bambu Lab LAN MQTT client. Connects to the printer's on-device broker in LAN
+// mode (mqtts://<host>:8883, username "bblp", password = LAN access code; the
+// self-signed cert has CN=serial while we connect by IP, so cert verification is
+// relaxed — LAN read-only), subscribes device/<serial>/report, publishes one
+// "pushall" on connect (required on P1/A1 which send deltas), and scans each
+// report for bed_temper / chamber_temper. The cached bed temperature feeds the
+// AUTO seam exactly as Moonraker does. Read-only: we never send control commands
+// to the printer. UNTESTED against real hardware — for community validation (see
+// plans/control-source-bambu-ha.md).
+#include <stdbool.h>
+#include "esp_err.h"
+
+typedef enum {
+    PB_BAMBU_DISABLED,      // no config saved / source not selected
+    PB_BAMBU_DISCONNECTED,  // config present, not currently connected
+    PB_BAMBU_CONNECTING,
+    PB_BAMBU_CONNECTED,     // MQTT+TLS session up, subscribe in flight
+    PB_BAMBU_SUBSCRIBED,    // receiving report updates
+} pb_bambu_state_t;
+
+typedef struct {
+    char host[64];    // printer IP/hostname; empty string = unconfigured
+    char serial[32];  // printer serial (embedded in the MQTT topic path)
+    char code[32];    // LAN access code (MQTT password)
+} pb_bambu_config_t;
+
+typedef struct {
+    pb_bambu_state_t state;
+    bool  connected;      // convenience: state == PB_BAMBU_SUBSCRIBED
+    float bed_temp;       // bed_temper (°C); NaN until first report
+    float chamber_temp;   // chamber_temper (°C); NaN if the model has no sensor
+} pb_bambu_status_t;
+
+esp_err_t pb_bambu_start(void);
+
+// Overwrite saved config (NVS). The running client (once implemented) will
+// reconnect with the new settings.
+esp_err_t pb_bambu_set_config(const pb_bambu_config_t *cfg);
+
+esp_err_t pb_bambu_get_config(pb_bambu_config_t *out);
+esp_err_t pb_bambu_get_status(pb_bambu_status_t *out);
+
+// Wipe saved Bambu config (factory reset).
+esp_err_t pb_bambu_clear_config(void);

--- a/components/pb_bambu/pb_bambu.c
+++ b/components/pb_bambu/pb_bambu.c
@@ -1,0 +1,282 @@
+// Bambu Lab LAN MQTT client. Reads the printer's live bed temperature over its
+// on-device MQTT-over-TLS broker so AUTO can follow a Bambu print, mirroring the
+// Moonraker path. Read-only — no control commands are ever sent to the printer.
+//
+// UNTESTED against real hardware (the maintainer has no Bambu printer); built from
+// the OpenBambuAPI / ha-bambulab protocol spec for community validation. Protocol:
+//   mqtts://<host>:8883, user "bblp", pass = LAN access code, self-signed cert
+//   (CN=serial, connect by IP -> cert verification relaxed). Subscribe
+//   device/<serial>/report; publish one "pushall" on connect (P1/A1 send deltas).
+// See plans/control-source-bambu-ha.md.
+#include "pb_bambu.h"
+
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "mqtt_client.h"
+#include "nvs.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *TAG = "pb_bambu";
+
+#define NVS_NS   "app_nvs"
+#define KEY_HOST "bb_host"
+#define KEY_SER  "bb_serial"
+#define KEY_CODE "bb_code"
+
+// A full "pushall" report is ~10-15 KB. esp-mqtt fragments payloads larger than
+// its RX buffer; we reassemble up to RX_CAP (bed_temper is near the front of the
+// print object, so a truncated tail still yields the follow signal).
+#define MQTT_BUF   8192
+#define RX_CAP     16384
+
+// One pushall on connect; required on P1/A1 (delta-only), harmless on X1.
+static const char PUSHALL[] =
+    "{\"pushing\":{\"sequence_id\":\"0\",\"command\":\"pushall\",\"version\":1,\"push_target\":1}}";
+
+static SemaphoreHandle_t        s_lock  = NULL;
+static pb_bambu_config_t        s_cfg   = {0};
+static pb_bambu_status_t        s_status = {
+    .state = PB_BAMBU_DISABLED, .bed_temp = NAN, .chamber_temp = NAN,
+};
+static esp_mqtt_client_handle_t s_client = NULL;
+
+static char   s_report_topic[80]  = {0};   // device/<serial>/report
+static char   s_request_topic[80] = {0};   // device/<serial>/request
+static char  *s_rx = NULL;                 // RX_CAP reassembly buffer
+static size_t s_rx_len = 0;
+static bool   s_in_report = false;         // current inbound msg is on the report topic
+
+// ---------- NVS ----------
+
+static esp_err_t nvs_load(pb_bambu_config_t *out)
+{
+    memset(out, 0, sizeof(*out));
+    nvs_handle_t h;
+    esp_err_t err = nvs_open(NVS_NS, NVS_READONLY, &h);
+    if (err != ESP_OK) return err;
+
+    size_t sz = sizeof(out->host);
+    err = nvs_get_str(h, KEY_HOST, out->host, &sz);
+    if (err != ESP_OK) { nvs_close(h); return err; }   // no host = unconfigured
+
+    sz = sizeof(out->serial);
+    nvs_get_str(h, KEY_SER, out->serial, &sz);
+    sz = sizeof(out->code);
+    nvs_get_str(h, KEY_CODE, out->code, &sz);
+    nvs_close(h);
+    return ESP_OK;
+}
+
+static esp_err_t nvs_save(const pb_bambu_config_t *cfg)
+{
+    nvs_handle_t h;
+    esp_err_t err = nvs_open(NVS_NS, NVS_READWRITE, &h);
+    if (err != ESP_OK) return err;
+    err = nvs_set_str(h, KEY_HOST, cfg->host);
+    if (err == ESP_OK) err = nvs_set_str(h, KEY_SER, cfg->serial);
+    if (err == ESP_OK) err = nvs_set_str(h, KEY_CODE, cfg->code);
+    if (err == ESP_OK) err = nvs_commit(h);
+    nvs_close(h);
+    return err;
+}
+
+// ---------- report parsing ----------
+
+// Pull the float value of a JSON key via a targeted scan (no full JSON parse — the
+// C3 can't afford a parse tree over a 15 KB payload). `key` includes the quotes,
+// e.g. "\"bed_temper\"".
+static bool find_float(const char *s, const char *key, float *out)
+{
+    const char *q = strstr(s, key);
+    if (!q) return false;
+    q = strchr(q, ':');
+    if (!q) return false;
+    char *end;
+    float v = strtof(q + 1, &end);
+    if (end == q + 1) return false;   // no number parsed
+    *out = v;
+    return true;
+}
+
+static void parse_report(const char *json)
+{
+    float bed, cham;
+    bool got_bed  = find_float(json, "\"bed_temper\"", &bed);
+    bool got_cham = find_float(json, "\"chamber_temper\"", &cham);
+    // NOTE(phase 2b): H2/newer moved chamber temp to a packed device.ctc.info.temp
+    // field; only the legacy flat chamber_temper is read here. Bed follow (the
+    // goal) works on all models via bed_temper.
+
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    if (got_bed) {
+        s_status.bed_temp  = bed;
+        s_status.state     = PB_BAMBU_SUBSCRIBED;   // we have live data now
+        s_status.connected = true;
+    }
+    if (got_cham) s_status.chamber_temp = cham;
+    xSemaphoreGive(s_lock);
+
+    if (got_bed) ESP_LOGD(TAG, "bed=%.1f chamber=%.1f", bed, got_cham ? cham : NAN);
+}
+
+static bool topic_is_report(const char *topic, int len)
+{
+    return len > 0 && (size_t)len == strlen(s_report_topic)
+        && strncmp(topic, s_report_topic, (size_t)len) == 0;
+}
+
+// ---------- mqtt events ----------
+
+static void mqtt_event_handler(void *args, esp_event_base_t base, int32_t id, void *data)
+{
+    (void)args; (void)base;
+    esp_mqtt_event_handle_t e = (esp_mqtt_event_handle_t)data;
+    switch ((esp_mqtt_event_id_t)id) {
+    case MQTT_EVENT_CONNECTED:
+        ESP_LOGI(TAG, "connected; subscribing %s", s_report_topic);
+        xSemaphoreTake(s_lock, portMAX_DELAY);
+        s_status.state = PB_BAMBU_CONNECTED;   // not SUBSCRIBED until first report
+        xSemaphoreGive(s_lock);
+        esp_mqtt_client_subscribe(s_client, s_report_topic, 0);
+        esp_mqtt_client_publish(s_client, s_request_topic, PUSHALL, 0, 0, 0);
+        break;
+
+    case MQTT_EVENT_DISCONNECTED:
+        xSemaphoreTake(s_lock, portMAX_DELAY);
+        s_status.state     = PB_BAMBU_DISCONNECTED;
+        s_status.connected = false;
+        xSemaphoreGive(s_lock);
+        break;
+
+    case MQTT_EVENT_DATA: {
+        // Reassemble a possibly-fragmented payload. The topic is present only on
+        // the first fragment (offset 0); track whether this message is the report.
+        if (e->current_data_offset == 0) {
+            s_in_report = topic_is_report(e->topic, e->topic_len);
+            s_rx_len = 0;
+        }
+        if (!s_in_report || s_rx == NULL) break;
+        size_t off = (size_t)e->current_data_offset;
+        if (off < RX_CAP - 1) {
+            size_t copy = (size_t)e->data_len;
+            if (off + copy > RX_CAP - 1) copy = (RX_CAP - 1) - off;
+            memcpy(s_rx + off, e->data, copy);
+            s_rx_len = off + copy;
+        }
+        if (e->current_data_offset + e->data_len >= e->total_data_len) {
+            s_rx[s_rx_len] = '\0';
+            parse_report(s_rx);
+        }
+        break;
+    }
+
+    default:
+        break;
+    }
+}
+
+// ---------- lifecycle ----------
+
+esp_err_t pb_bambu_start(void)
+{
+    if (s_lock != NULL) return ESP_ERR_INVALID_STATE;
+    s_lock = xSemaphoreCreateMutex();
+    if (s_lock == NULL) return ESP_ERR_NO_MEM;
+
+    if (nvs_load(&s_cfg) != ESP_OK || s_cfg.host[0] == '\0') {
+        ESP_LOGI(TAG, "no Bambu config saved; idle");
+        s_status.state = PB_BAMBU_DISABLED;
+        return ESP_OK;
+    }
+    if (s_cfg.serial[0] == '\0' || s_cfg.code[0] == '\0') {
+        ESP_LOGW(TAG, "Bambu needs host + serial + access code; idle");
+        s_status.state = PB_BAMBU_DISABLED;
+        return ESP_OK;
+    }
+
+    s_rx = malloc(RX_CAP);
+    if (s_rx == NULL) return ESP_ERR_NO_MEM;
+    snprintf(s_report_topic,  sizeof s_report_topic,  "device/%s/report",  s_cfg.serial);
+    snprintf(s_request_topic, sizeof s_request_topic, "device/%s/request", s_cfg.serial);
+
+    char uri[96];
+    snprintf(uri, sizeof uri, "mqtts://%s:8883", s_cfg.host);
+    esp_mqtt_client_config_t mc = {
+        .broker.address.uri = uri,
+        // Self-signed per-device cert (CN=serial) reached by IP: relax verification
+        // for a read-only LAN client. No CA provided -> esp-tls optional verify;
+        // skip the CN check since IP != serial.
+        .broker.verification.skip_cert_common_name_check = true,
+        .broker.verification.use_global_ca_store = false,
+        .credentials.username = "bblp",
+        .credentials.authentication.password = s_cfg.code,
+        .buffer.size = MQTT_BUF,
+    };
+
+    s_client = esp_mqtt_client_init(&mc);
+    if (s_client == NULL) {
+        ESP_LOGE(TAG, "esp_mqtt_client_init failed");
+        free(s_rx); s_rx = NULL;
+        s_status.state = PB_BAMBU_DISCONNECTED;
+        return ESP_FAIL;
+    }
+    esp_mqtt_client_register_event(s_client, ESP_EVENT_ANY_ID, mqtt_event_handler, NULL);
+    esp_err_t err = esp_mqtt_client_start(s_client);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_mqtt_client_start: %s", esp_err_to_name(err));
+        s_status.state = PB_BAMBU_DISCONNECTED;
+        return err;
+    }
+    s_status.state = PB_BAMBU_CONNECTING;
+    ESP_LOGI(TAG, "connecting to %s (serial %s)", uri, s_cfg.serial);
+    return ESP_OK;
+}
+
+esp_err_t pb_bambu_set_config(const pb_bambu_config_t *cfg)
+{
+    if (cfg == NULL) return ESP_ERR_INVALID_ARG;
+    esp_err_t err = nvs_save(cfg);
+    if (err != ESP_OK) return err;
+    if (s_lock) {
+        xSemaphoreTake(s_lock, portMAX_DELAY);
+        s_cfg = *cfg;
+        xSemaphoreGive(s_lock);
+    }
+    return ESP_OK;   // takes effect on next boot (matches pb_moonraker semantics)
+}
+
+esp_err_t pb_bambu_get_config(pb_bambu_config_t *out)
+{
+    if (out == NULL) return ESP_ERR_INVALID_ARG;
+    if (s_lock) xSemaphoreTake(s_lock, portMAX_DELAY);
+    *out = s_cfg;
+    if (s_lock) xSemaphoreGive(s_lock);
+    return ESP_OK;
+}
+
+esp_err_t pb_bambu_get_status(pb_bambu_status_t *out)
+{
+    if (out == NULL) return ESP_ERR_INVALID_ARG;
+    if (s_lock) xSemaphoreTake(s_lock, portMAX_DELAY);
+    *out = s_status;
+    if (s_lock) xSemaphoreGive(s_lock);
+    return ESP_OK;
+}
+
+esp_err_t pb_bambu_clear_config(void)
+{
+    nvs_handle_t h;
+    esp_err_t err = nvs_open(NVS_NS, NVS_READWRITE, &h);
+    if (err != ESP_OK) return err;
+    nvs_erase_key(h, KEY_HOST);
+    nvs_erase_key(h, KEY_SER);
+    nvs_erase_key(h, KEY_CODE);
+    nvs_commit(h);
+    nvs_close(h);
+    return ESP_OK;
+}

--- a/components/pb_ha/CMakeLists.txt
+++ b/components/pb_ha/CMakeLists.txt
@@ -1,0 +1,8 @@
+idf_component_register(
+    SRCS "pb_ha.c"
+    INCLUDE_DIRS "include"
+    # esp-mqtt to the user's broker; esp_timer for pacing; pb_policy for the
+    # command/snapshot API. All built into ESP-IDF / first-party — no third-party
+    # dependency. State/discovery JSON is built with snprintf (no cJSON needed).
+    REQUIRES nvs_flash mqtt esp_timer pb_policy
+)

--- a/components/pb_ha/include/pb_ha.h
+++ b/components/pb_ha/include/pb_ha.h
@@ -1,0 +1,46 @@
+#pragma once
+// Home Assistant MQTT client. Unlike Klipper/Bambu, HA is a CONTROLLER, not a
+// bed-temp source: it connects to the user's MQTT broker, publishes MQTT-Discovery
+// configs (a climate entity + temperature sensors auto-appear in HA), publishes a
+// retained state topic, and subscribes command topics that map to ordinary
+// pb_policy commands (the same ones any web/klipper client issues). Heat control
+// holds a device-issued lease and heartbeats it, like any remote controller. It
+// does NOT feed the AUTO bed-follow seam — there is no printer bed in HA mode.
+// See plans/control-source-bambu-ha.md.
+#include <stdbool.h>
+#include <stdint.h>
+#include "esp_err.h"
+
+typedef enum {
+    PB_HA_DISABLED,      // no config saved / source not selected
+    PB_HA_DISCONNECTED,  // config present, not currently connected
+    PB_HA_CONNECTING,
+    PB_HA_CONNECTED,     // broker session up (publishing/subscribing)
+} pb_ha_state_t;
+
+typedef struct {
+    char     host[64];   // broker IP/hostname; empty string = unconfigured
+    uint16_t port;       // defaults to 1883 if 0
+    char     user[32];   // broker username (optional)
+    char     pass[64];   // broker password (optional)
+    char     topic[48];  // topic prefix (defaults to "dragonbreath")
+} pb_ha_config_t;
+
+typedef struct {
+    pb_ha_state_t state;
+    bool          connected;   // convenience: state == PB_HA_CONNECTED
+} pb_ha_status_t;
+
+esp_err_t pb_ha_start(void);
+
+// Periodic pump: publishes retained state (~2 s) and heartbeats the heat lease
+// (~5 s, well under the comms-watchdog minimum). Call from the control loop when
+// HA is the active source. No-op if the client isn't running.
+void pb_ha_tick(void);
+
+esp_err_t pb_ha_set_config(const pb_ha_config_t *cfg);
+esp_err_t pb_ha_get_config(pb_ha_config_t *out);
+esp_err_t pb_ha_get_status(pb_ha_status_t *out);
+
+// Wipe saved HA config (factory reset).
+esp_err_t pb_ha_clear_config(void);

--- a/components/pb_ha/pb_ha.c
+++ b/components/pb_ha/pb_ha.c
@@ -1,0 +1,410 @@
+// Home Assistant MQTT client. Connects to the user's broker, publishes
+// MQTT-Discovery so a climate entity + temperature sensors auto-appear in HA,
+// publishes a retained state topic, and maps command topics to pb_policy calls.
+// Heat control holds a device-issued POWER_ON lease and heartbeats it like any
+// remote controller. See plans/control-source-bambu-ha.md.
+//
+// Threading: the esp-mqtt event handler runs on the mqtt task (connect/discovery/
+// subscribe + inbound commands); pb_ha_tick() runs on the control task (state
+// publish + lease heartbeat). esp_mqtt_client_publish() is thread-safe; the shared
+// lease/target state is guarded by s_lock.
+#include "pb_ha.h"
+#include "pb_policy.h"
+
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "mqtt_client.h"
+#include "nvs.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *TAG = "pb_ha";
+
+#define NVS_NS    "app_nvs"
+#define KEY_HOST  "ha_host"
+#define KEY_PORT  "ha_port"
+#define KEY_USER  "ha_user"
+#define KEY_PASS  "ha_pass"
+#define KEY_TOPIC "ha_topic"
+
+#define DEFAULT_PORT     1883
+#define DEFAULT_PREFIX   "dragonbreath"
+#define STATE_PERIOD_US  (2 * 1000 * 1000)   // publish state every ~2 s
+#define HB_PERIOD_US     (5 * 1000 * 1000)   // heartbeat lease every ~5 s (<< watchdog min)
+#define TARGET_MIN_C     20.0f
+#define TARGET_MAX_C     70.0f
+
+static SemaphoreHandle_t        s_lock   = NULL;
+static pb_ha_config_t           s_cfg    = {0};
+static pb_ha_status_t           s_status = { .state = PB_HA_DISABLED };
+static esp_mqtt_client_handle_t s_client = NULL;
+
+// Shared control state (guarded by s_lock).
+static bool               s_have_lease = false;
+static pb_policy_lease_t  s_lease      = {0};
+static float              s_desired_target = 45.0f;
+
+// Pacing (control task only).
+static int64_t s_last_state_us = 0;
+static int64_t s_last_hb_us    = 0;
+
+// Availability (LWT) topic — must outlive esp_mqtt_client_init(), so it's static.
+static char s_avail_topic[80] = {0};
+
+static const char *prefix(void) { return s_cfg.topic[0] ? s_cfg.topic : DEFAULT_PREFIX; }
+
+// ---------- NVS ----------
+
+static esp_err_t nvs_load(pb_ha_config_t *out)
+{
+    memset(out, 0, sizeof(*out));
+    nvs_handle_t h;
+    esp_err_t err = nvs_open(NVS_NS, NVS_READONLY, &h);
+    if (err != ESP_OK) return err;
+
+    size_t sz = sizeof(out->host);
+    err = nvs_get_str(h, KEY_HOST, out->host, &sz);
+    if (err != ESP_OK) { nvs_close(h); return err; }   // no host = unconfigured
+
+    uint16_t p = 0;
+    if (nvs_get_u16(h, KEY_PORT, &p) == ESP_OK && p > 0) out->port = p;
+    else out->port = DEFAULT_PORT;
+
+    sz = sizeof(out->user);  nvs_get_str(h, KEY_USER, out->user, &sz);
+    sz = sizeof(out->pass);  nvs_get_str(h, KEY_PASS, out->pass, &sz);
+    sz = sizeof(out->topic); nvs_get_str(h, KEY_TOPIC, out->topic, &sz);
+    nvs_close(h);
+    return ESP_OK;
+}
+
+static esp_err_t nvs_save(const pb_ha_config_t *cfg)
+{
+    nvs_handle_t h;
+    esp_err_t err = nvs_open(NVS_NS, NVS_READWRITE, &h);
+    if (err != ESP_OK) return err;
+    err = nvs_set_str(h, KEY_HOST, cfg->host);
+    if (err == ESP_OK) err = nvs_set_u16(h, KEY_PORT, cfg->port ? cfg->port : DEFAULT_PORT);
+    if (err == ESP_OK) err = nvs_set_str(h, KEY_USER, cfg->user);
+    if (err == ESP_OK) err = nvs_set_str(h, KEY_PASS, cfg->pass);
+    if (err == ESP_OK) err = nvs_set_str(h, KEY_TOPIC, cfg->topic);
+    if (err == ESP_OK) err = nvs_commit(h);
+    nvs_close(h);
+    return err;
+}
+
+// ---------- control mapping ----------
+
+// Turn heat ON at a target (idempotent target update). Takes a fresh lease and
+// remembers it so pb_ha_tick() can heartbeat. Reuses PB_SOURCE_WEB (no new policy
+// source) with owner "ha" for attribution.
+static void start_heat(float target_c)
+{
+    if (target_c < TARGET_MIN_C) target_c = TARGET_MIN_C;
+    if (target_c > TARGET_MAX_C) target_c = TARGET_MAX_C;
+    pb_policy_lease_t lease = {0};
+    pb_policy_result_t r = pb_policy_set_power_on(
+        target_c, PB_SOURCE_WEB, "ha", PB_POLICY_REVISION_ANY, &lease);
+    if (r == PB_POLICY_OK) {
+        xSemaphoreTake(s_lock, portMAX_DELAY);
+        s_lease = lease;
+        s_have_lease = true;
+        s_desired_target = target_c;
+        s_last_hb_us = esp_timer_get_time();
+        xSemaphoreGive(s_lock);
+        ESP_LOGI(TAG, "HA -> heat %.0f C", target_c);
+    } else {
+        ESP_LOGW(TAG, "HA heat rejected (policy result %d)", (int)r);
+    }
+}
+
+static void stop_heat(void)
+{
+    pb_policy_set_mode_off(PB_SOURCE_WEB);
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    s_have_lease = false;
+    xSemaphoreGive(s_lock);
+    ESP_LOGI(TAG, "HA -> off");
+}
+
+static void handle_cmd(const char *topic, int tlen, const char *data, int dlen)
+{
+    char t[96];
+    int n = tlen < (int)sizeof(t) - 1 ? tlen : (int)sizeof(t) - 1;
+    memcpy(t, topic, n); t[n] = '\0';
+    char d[32];
+    n = dlen < (int)sizeof(d) - 1 ? dlen : (int)sizeof(d) - 1;
+    memcpy(d, data, n); d[n] = '\0';
+
+    char mode_set[80], temp_set[80];
+    snprintf(mode_set, sizeof mode_set, "%s/mode/set", prefix());
+    snprintf(temp_set, sizeof temp_set, "%s/temp/set", prefix());
+
+    if (strcmp(t, mode_set) == 0) {
+        if (strcmp(d, "heat") == 0) {
+            float tgt;
+            xSemaphoreTake(s_lock, portMAX_DELAY);
+            tgt = s_desired_target;
+            xSemaphoreGive(s_lock);
+            start_heat(tgt);
+        } else {   // "off" (or anything else -> safer off)
+            stop_heat();
+        }
+    } else if (strcmp(t, temp_set) == 0) {
+        float tgt = strtof(d, NULL);
+        if (tgt > 0) start_heat(tgt);   // setting a target implies heat-on
+    }
+}
+
+// ---------- publish ----------
+
+static void publish_discovery(void)
+{
+    const char *p = prefix();
+    char buf[1024];
+
+    // Climate entity (HA MQTT discovery, abbreviated keys). State fields are read
+    // from the single retained <p>/state JSON via templates.
+    int cfg = snprintf(buf, sizeof buf,
+        "{\"name\":\"DragonBreath\",\"uniq_id\":\"%s_climate\","
+        "\"avty_t\":\"%s/availability\","
+        "\"curr_temp_t\":\"%s/state\",\"curr_temp_tpl\":\"{{value_json.chamber}}\","
+        "\"temp_stat_t\":\"%s/state\",\"temp_stat_tpl\":\"{{value_json.target}}\","
+        "\"temp_cmd_t\":\"%s/temp/set\","
+        "\"mode_stat_t\":\"%s/state\",\"mode_stat_tpl\":\"{{value_json.mode}}\","
+        "\"mode_cmd_t\":\"%s/mode/set\","
+        // temp_unit "C": our target/current values on the state + command topics are
+        // Celsius. HA converts for display and converts a user's setpoint (e.g. °F on
+        // an imperial system) back to °C before publishing to temp_cmd_t.
+        "\"temp_unit\":\"C\","
+        "\"modes\":[\"off\",\"heat\"],\"min_temp\":20,\"max_temp\":70,\"temp_step\":1,"
+        "\"dev\":{\"ids\":[\"%s\"],\"name\":\"DragonBreath\",\"mdl\":\"Panda Breath\",\"mf\":\"DragonBreath\"}}",
+        p, p, p, p, p, p, p, p);
+    if (cfg > 0 && cfg < (int)sizeof buf) {
+        char topic[96];
+        snprintf(topic, sizeof topic, "homeassistant/climate/%s/config", p);
+        esp_mqtt_client_publish(s_client, topic, buf, 0, 1, 1);   // qos1, retain
+    }
+
+    // Chamber temperature sensor.
+    snprintf(buf, sizeof buf,
+        "{\"name\":\"DragonBreath Chamber\",\"uniq_id\":\"%s_chamber\","
+        "\"avty_t\":\"%s/availability\",\"stat_t\":\"%s/state\","
+        "\"val_tpl\":\"{{value_json.chamber}}\",\"unit_of_meas\":\"\xC2\xB0""C\","
+        "\"dev_cla\":\"temperature\",\"dev\":{\"ids\":[\"%s\"]}}",
+        p, p, p, p);
+    {
+        char topic[96];
+        snprintf(topic, sizeof topic, "homeassistant/sensor/%s_chamber/config", p);
+        esp_mqtt_client_publish(s_client, topic, buf, 0, 1, 1);
+    }
+
+    // Element (PTC) temperature sensor.
+    snprintf(buf, sizeof buf,
+        "{\"name\":\"DragonBreath Element\",\"uniq_id\":\"%s_ptc\","
+        "\"avty_t\":\"%s/availability\",\"stat_t\":\"%s/state\","
+        "\"val_tpl\":\"{{value_json.ptc}}\",\"unit_of_meas\":\"\xC2\xB0""C\","
+        "\"dev_cla\":\"temperature\",\"dev\":{\"ids\":[\"%s\"]}}",
+        p, p, p, p);
+    {
+        char topic[96];
+        snprintf(topic, sizeof topic, "homeassistant/sensor/%s_ptc/config", p);
+        esp_mqtt_client_publish(s_client, topic, buf, 0, 1, 1);
+    }
+}
+
+static void publish_state(void)
+{
+    pb_policy_snapshot_t snap;
+    pb_policy_get_snapshot(&snap);
+
+    char cb[16], pb[16];
+    if (isfinite(snap.chamber_c)) snprintf(cb, sizeof cb, "%.1f", snap.chamber_c); else strcpy(cb, "null");
+    if (isfinite(snap.ptc_c))     snprintf(pb, sizeof pb, "%.1f", snap.ptc_c);     else strcpy(pb, "null");
+    const char *mode = (snap.mode == PB_MODE_OFF) ? "off" : "heat";
+
+    char buf[160];
+    snprintf(buf, sizeof buf,
+        "{\"chamber\":%s,\"ptc\":%s,\"target\":%.0f,\"mode\":\"%s\",\"fan\":%u}",
+        cb, pb, (double)snap.effective_target_c, mode, (unsigned)snap.effective_fan_percent);
+
+    char topic[80];
+    snprintf(topic, sizeof topic, "%s/state", prefix());
+    esp_mqtt_client_publish(s_client, topic, buf, 0, 0, 1);   // qos0, retain
+}
+
+// ---------- mqtt events ----------
+
+static void mqtt_event_handler(void *args, esp_event_base_t base, int32_t id, void *data)
+{
+    (void)args; (void)base;
+    esp_mqtt_event_handle_t e = (esp_mqtt_event_handle_t)data;
+    switch ((esp_mqtt_event_id_t)id) {
+    case MQTT_EVENT_CONNECTED: {
+        ESP_LOGI(TAG, "connected to broker");
+        xSemaphoreTake(s_lock, portMAX_DELAY);
+        s_status.state = PB_HA_CONNECTED;
+        s_status.connected = true;
+        xSemaphoreGive(s_lock);
+        // Availability online (retained), discovery, then subscribe commands.
+        esp_mqtt_client_publish(s_client, s_avail_topic, "online", 0, 1, 1);
+        publish_discovery();
+        char sub[80];
+        snprintf(sub, sizeof sub, "%s/mode/set", prefix());
+        esp_mqtt_client_subscribe(s_client, sub, 1);
+        snprintf(sub, sizeof sub, "%s/temp/set", prefix());
+        esp_mqtt_client_subscribe(s_client, sub, 1);
+        s_last_state_us = 0;   // force an immediate state publish on next tick
+        break;
+    }
+    case MQTT_EVENT_DISCONNECTED:
+        xSemaphoreTake(s_lock, portMAX_DELAY);
+        s_status.state = PB_HA_DISCONNECTED;
+        s_status.connected = false;
+        xSemaphoreGive(s_lock);
+        break;
+    case MQTT_EVENT_DATA:
+        if (e->topic_len > 0 && e->data_len >= 0)
+            handle_cmd(e->topic, e->topic_len, e->data, e->data_len);
+        break;
+    default:
+        break;
+    }
+}
+
+// ---------- lifecycle ----------
+
+esp_err_t pb_ha_start(void)
+{
+    if (s_lock != NULL) return ESP_ERR_INVALID_STATE;
+    s_lock = xSemaphoreCreateMutex();
+    if (s_lock == NULL) return ESP_ERR_NO_MEM;
+
+    if (nvs_load(&s_cfg) != ESP_OK || s_cfg.host[0] == '\0') {
+        ESP_LOGI(TAG, "no Home Assistant config saved; idle");
+        s_status.state = PB_HA_DISABLED;
+        return ESP_OK;
+    }
+
+    // Seed the desired target from the remembered manual target.
+    pb_policy_params_t params;
+    pb_policy_get_params(&params);
+    if (params.manual_target_c > 0) s_desired_target = params.manual_target_c;
+
+    snprintf(s_avail_topic, sizeof s_avail_topic, "%s/availability", prefix());
+
+    char uri[96];
+    snprintf(uri, sizeof uri, "mqtt://%s:%u", s_cfg.host, (unsigned)s_cfg.port);
+    esp_mqtt_client_config_t mc = {
+        .broker.address.uri = uri,
+        .session.last_will = {
+            .topic  = s_avail_topic,
+            .msg    = "offline",
+            .msg_len = 7,
+            .qos    = 1,
+            .retain = 1,
+        },
+    };
+    if (s_cfg.user[0]) mc.credentials.username = s_cfg.user;
+    if (s_cfg.pass[0]) mc.credentials.authentication.password = s_cfg.pass;
+
+    s_client = esp_mqtt_client_init(&mc);
+    if (s_client == NULL) {
+        ESP_LOGE(TAG, "esp_mqtt_client_init failed");
+        s_status.state = PB_HA_DISCONNECTED;
+        return ESP_FAIL;
+    }
+    esp_mqtt_client_register_event(s_client, ESP_EVENT_ANY_ID, mqtt_event_handler, NULL);
+    esp_err_t err = esp_mqtt_client_start(s_client);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_mqtt_client_start: %s", esp_err_to_name(err));
+        s_status.state = PB_HA_DISCONNECTED;
+        return err;
+    }
+    s_status.state = PB_HA_CONNECTING;
+    ESP_LOGI(TAG, "connecting to broker %s (prefix '%s')", uri, prefix());
+    return ESP_OK;
+}
+
+void pb_ha_tick(void)
+{
+    if (s_client == NULL) return;
+    bool connected;
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    connected = s_status.connected;
+    xSemaphoreGive(s_lock);
+    if (!connected) return;
+
+    int64_t now = esp_timer_get_time();
+    if (now - s_last_state_us >= STATE_PERIOD_US) {
+        s_last_state_us = now;
+        publish_state();
+    }
+
+    // Heartbeat the heat lease so the comms watchdog keeps heat alive. If the
+    // heartbeat is rejected (lease expired/superseded), drop our copy.
+    bool do_hb = false;
+    pb_policy_lease_t lease = {0};
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    if (s_have_lease && now - s_last_hb_us >= HB_PERIOD_US) {
+        lease = s_lease;
+        s_last_hb_us = now;
+        do_hb = true;
+    }
+    xSemaphoreGive(s_lock);
+    if (do_hb && pb_policy_heartbeat(&lease) != PB_POLICY_OK) {
+        xSemaphoreTake(s_lock, portMAX_DELAY);
+        s_have_lease = false;
+        xSemaphoreGive(s_lock);
+    }
+}
+
+esp_err_t pb_ha_set_config(const pb_ha_config_t *cfg)
+{
+    if (cfg == NULL) return ESP_ERR_INVALID_ARG;
+    esp_err_t err = nvs_save(cfg);
+    if (err != ESP_OK) return err;
+    if (s_lock) {
+        xSemaphoreTake(s_lock, portMAX_DELAY);
+        s_cfg = *cfg;
+        xSemaphoreGive(s_lock);
+    }
+    return ESP_OK;   // takes effect on next boot (matches pb_moonraker semantics)
+}
+
+esp_err_t pb_ha_get_config(pb_ha_config_t *out)
+{
+    if (out == NULL) return ESP_ERR_INVALID_ARG;
+    if (s_lock) xSemaphoreTake(s_lock, portMAX_DELAY);
+    *out = s_cfg;
+    if (s_lock) xSemaphoreGive(s_lock);
+    return ESP_OK;
+}
+
+esp_err_t pb_ha_get_status(pb_ha_status_t *out)
+{
+    if (out == NULL) return ESP_ERR_INVALID_ARG;
+    if (s_lock) xSemaphoreTake(s_lock, portMAX_DELAY);
+    *out = s_status;
+    if (s_lock) xSemaphoreGive(s_lock);
+    return ESP_OK;
+}
+
+esp_err_t pb_ha_clear_config(void)
+{
+    nvs_handle_t h;
+    esp_err_t err = nvs_open(NVS_NS, NVS_READWRITE, &h);
+    if (err != ESP_OK) return err;
+    nvs_erase_key(h, KEY_HOST);
+    nvs_erase_key(h, KEY_PORT);
+    nvs_erase_key(h, KEY_USER);
+    nvs_erase_key(h, KEY_PASS);
+    nvs_erase_key(h, KEY_TOPIC);
+    nvs_commit(h);
+    nvs_close(h);
+    return ESP_OK;
+}

--- a/components/pb_portal/CMakeLists.txt
+++ b/components/pb_portal/CMakeLists.txt
@@ -1,7 +1,7 @@
 idf_component_register(
     SRCS "pb_portal.c" "pb_dns.c"
     INCLUDE_DIRS "include"
-    REQUIRES esp_http_server pb_wifi pb_httpd nvs_flash esp_wifi lwip json
+    REQUIRES esp_http_server pb_wifi pb_httpd pb_source nvs_flash esp_wifi lwip json
 )
 
 # The STA-mode dashboard is a real source file (www/app.html) that we gzip at

--- a/components/pb_portal/pb_portal.c
+++ b/components/pb_portal/pb_portal.c
@@ -3,10 +3,12 @@
 #include "pb_dns.h"
 #include "pb_httpd.h"
 #include "pb_wifi.h"
+#include "pb_source.h"
 
 #include "esp_http_server.h"
 #include "esp_log.h"
 #include "esp_wifi.h"
+#include "esp_system.h"
 #include "esp_app_desc.h"
 #include "nvs.h"
 #include "lwip/inet.h"
@@ -358,18 +360,31 @@ static esp_err_t fw_page(httpd_req_t *req)
     return httpd_resp_send_chunk(req, NULL, 0);
 }
 
-// Wi-Fi + Moonraker config page (AP captive root, and /setup in STA mode).
+// Wi-Fi + control-source config page (AP captive root, and /setup in STA mode).
+// The device binds to exactly ONE control source; the card carries all three
+// field groups and reveals only the selected one (JS). Non-secret values are
+// pre-filled (escaped); secrets (Bambu access code, HA password) are never echoed
+// — an empty field means "leave unchanged" (see save_post).
 static esp_err_t config_page(httpd_req_t *req)
 {
-    char mk_host[64] = {0};
-    uint16_t mk_port = 7125;
+    char mk_host[64] = {0};   uint16_t mk_port = 7125;
+    char bb_host[64] = {0},   bb_serial[32] = {0};
+    char ha_host[64] = {0};   uint16_t ha_port = 1883;
+    char ha_user[32] = {0},   ha_topic[48] = {0};
     nvs_handle_t h;
     if (nvs_open(NVS_NS, NVS_READONLY, &h) == ESP_OK) {
-        size_t sz = sizeof mk_host;
-        nvs_get_str(h, "mk_host", mk_host, &sz);
+        size_t sz;
+        sz = sizeof mk_host;   nvs_get_str(h, "mk_host", mk_host, &sz);
         nvs_get_u16(h, "mk_port", &mk_port);
+        sz = sizeof bb_host;   nvs_get_str(h, "bb_host", bb_host, &sz);
+        sz = sizeof bb_serial; nvs_get_str(h, "bb_serial", bb_serial, &sz);
+        sz = sizeof ha_host;   nvs_get_str(h, "ha_host", ha_host, &sz);
+        nvs_get_u16(h, "ha_port", &ha_port);
+        sz = sizeof ha_user;   nvs_get_str(h, "ha_user", ha_user, &sz);
+        sz = sizeof ha_topic;  nvs_get_str(h, "ha_topic", ha_topic, &sz);
         nvs_close(h);
     }
+    pb_ctl_source_t src = pb_source_get();
 
     httpd_resp_set_type(req, "text/html; charset=utf-8");
     SEND(req, PAGE_HEAD);
@@ -378,18 +393,74 @@ static esp_err_t config_page(httpd_req_t *req)
     send_auth_inject(req);
     SEND(req, CONFIG_WIFI);
 
-    // Moonraker card — values embedded so we never emit an empty chunk. mk_host
-    // is user-controlled (stored in NVS via /save), so escape it before it lands
-    // in the value="..." attribute (stored-XSS prevention). mk_port is a uint16.
-    char mk_host_esc[192];
-    html_attr_escape(mk_host, mk_host_esc, sizeof mk_host_esc);
-    char card[420];
-    snprintf(card, sizeof card,
-        "<div class=card><h2>Printer (Moonraker)</h2>"
+    // Reused buffers: emit each piece before reusing, to keep httpd-task stack
+    // small. esc holds a single HTML-attribute-escaped user value at a time; buf
+    // is sized for the largest piece (the HA group + the reveal <script>).
+    char buf[640], esc[256];
+
+    // Source selector.
+    snprintf(buf, sizeof buf,
+        "<div class=card><h2>Control source</h2>"
+        "<label>Bind this heater to</label>"
+        "<select id=ctlsrc name=ctl_src onchange='srcshow()'>"
+        "<option value=0%s>Klipper (Moonraker)</option>"
+        "<option value=1%s>Bambu (LAN)</option>"
+        "<option value=2%s>Home Assistant</option></select>",
+        src == PB_SRC_KLIPPER ? " selected" : "",
+        src == PB_SRC_BAMBU   ? " selected" : "",
+        src == PB_SRC_HA      ? " selected" : "");
+    SEND(req, buf);
+
+    // Klipper group.
+    html_attr_escape(mk_host, esc, sizeof esc);
+    snprintf(buf, sizeof buf,
+        "<div class=grp data-src=0 style='display:%s'>"
         "<label>Host / IP</label><input name=mk_host value=\"%s\" placeholder='e.g. 10.168.2.34'>"
         "<label>Port</label><input name=mk_port value=\"%u\"></div>",
-        mk_host_esc, (unsigned)mk_port);
-    SEND(req, card);
+        src == PB_SRC_KLIPPER ? "block" : "none", esc, (unsigned)mk_port);
+    SEND(req, buf);
+
+    // Bambu group.
+    html_attr_escape(bb_host, esc, sizeof esc);
+    snprintf(buf, sizeof buf,
+        "<div class=grp data-src=1 style='display:%s'>"
+        "<label>Printer IP</label><input name=bb_host value=\"%s\" placeholder='e.g. 10.168.2.50'>",
+        src == PB_SRC_BAMBU ? "block" : "none", esc);
+    SEND(req, buf);
+    html_attr_escape(bb_serial, esc, sizeof esc);
+    snprintf(buf, sizeof buf,
+        "<label>Serial</label><input name=bb_serial value=\"%s\" placeholder='e.g. 01P00A000000000'>"
+        "<label>LAN access code</label><input name=bb_code type=password placeholder='(unchanged)' autocomplete=off>"
+        "<small style='color:var(--muted)'>Enable <b>LAN Only Mode</b> on the printer; use its Access Code.</small></div>",
+        esc);
+    SEND(req, buf);
+
+    // Home Assistant group.
+    html_attr_escape(ha_host, esc, sizeof esc);
+    snprintf(buf, sizeof buf,
+        "<div class=grp data-src=2 style='display:%s'>"
+        "<label>MQTT broker</label><input name=ha_host value=\"%s\" placeholder='e.g. 10.168.2.10'>"
+        "<label>Port</label><input name=ha_port value=\"%u\">",
+        src == PB_SRC_HA ? "block" : "none", esc, (unsigned)ha_port);
+    SEND(req, buf);
+    html_attr_escape(ha_user, esc, sizeof esc);
+    snprintf(buf, sizeof buf,
+        "<label>Username</label><input name=ha_user value=\"%s\" autocomplete=off>"
+        "<label>Password</label><input name=ha_pass type=password placeholder='(unchanged)' autocomplete=off>",
+        esc);
+    SEND(req, buf);
+    html_attr_escape(ha_topic, esc, sizeof esc);
+    snprintf(buf, sizeof buf,
+        "<label>Topic prefix</label><input name=ha_topic value=\"%s\" placeholder='dragonbreath'></div></div>",
+        esc);
+    SEND(req, buf);
+    // Reveal-only-the-selected-group script (static — kept out of the snprintf
+    // above so it isn't subject to format-truncation on a long topic value).
+    SEND(req,
+        "<script>function srcshow(){var v=document.getElementById('ctlsrc').value,"
+        "g=document.querySelectorAll('.grp');"
+        "for(var i=0;i<g.length;i++)g[i].style.display=(g[i].getAttribute('data-src')==v)?'block':'none';}"
+        "srcshow();</script>");
 
     SEND(req, PAGE_TAIL);
     return httpd_resp_send_chunk(req, NULL, 0);
@@ -460,7 +531,9 @@ static esp_err_t save_post(httpd_req_t *req)
         return httpd_resp_sendstr(req, "{\"error\":\"missing/invalid X-DragonBreath-Auth header\"}");
     }
 
-    char body[640];
+    // Larger than the Wi-Fi-only form: now also carries the control-source
+    // selector + Klipper/Bambu/HA field groups (all groups submit, even hidden).
+    char body[1024];
     int total = 0, r;
     while ((r = httpd_req_recv(req, body + total, sizeof body - 1 - total)) > 0) {
         total += r;
@@ -470,23 +543,57 @@ static esp_err_t save_post(httpd_req_t *req)
 
     char ssid[33] = {0}, ssid_manual[33] = {0}, pass[65] = {0};
     char mk_host[64] = {0}, mk_port_s[8] = {0};
+    char src_s[4] = {0};
+    char bb_host[64] = {0}, bb_serial[32] = {0}, bb_code[32] = {0};
+    char ha_host[64] = {0}, ha_port_s[8] = {0}, ha_user[32] = {0}, ha_pass[64] = {0}, ha_topic[48] = {0};
     form_get(body, "ssid", ssid, sizeof ssid);
     form_get(body, "ssid_manual", ssid_manual, sizeof ssid_manual);
     form_get(body, "password", pass, sizeof pass);
+    form_get(body, "ctl_src", src_s, sizeof src_s);
     form_get(body, "mk_host", mk_host, sizeof mk_host);
     form_get(body, "mk_port", mk_port_s, sizeof mk_port_s);
+    form_get(body, "bb_host", bb_host, sizeof bb_host);
+    form_get(body, "bb_serial", bb_serial, sizeof bb_serial);
+    form_get(body, "bb_code", bb_code, sizeof bb_code);
+    form_get(body, "ha_host", ha_host, sizeof ha_host);
+    form_get(body, "ha_port", ha_port_s, sizeof ha_port_s);
+    form_get(body, "ha_user", ha_user, sizeof ha_user);
+    form_get(body, "ha_pass", ha_pass, sizeof ha_pass);
+    form_get(body, "ha_topic", ha_topic, sizeof ha_topic);
 
     const char *chosen = ssid_manual[0] ? ssid_manual : ssid;
-    if (chosen[0] == '\0') {
+    // In AP/provisioning mode there are no saved creds yet, so a Wi-Fi network is
+    // mandatory. Once joined (STA), Wi-Fi is OPTIONAL: leaving it blank keeps the
+    // existing creds and just applies the control-source/config change — so
+    // switching source (or editing Bambu/HA fields) never forces a Wi-Fi re-entry.
+    bool have_wifi = chosen[0] != '\0';
+    if (!have_wifi && pb_wifi_state() == PB_WIFI_STATE_AP_PORTAL) {
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "no Wi-Fi network chosen");
         return ESP_FAIL;
     }
 
     nvs_handle_t h;
     if (nvs_open(NVS_NS, NVS_READWRITE, &h) == ESP_OK) {
+        // Control source (0=klipper/1=bambu/2=ha); ignore out-of-range.
+        if (src_s[0]) {
+            int s = atoi(src_s);
+            if (s >= PB_SRC_KLIPPER && s <= PB_SRC_HA) nvs_set_u8(h, "ctl_src", (uint8_t)s);
+        }
+        // Klipper.
         if (mk_host[0]) nvs_set_str(h, "mk_host", mk_host);
         int port = atoi(mk_port_s);
         if (port > 0 && port < 65536) nvs_set_u16(h, "mk_port", (uint16_t)port);
+        // Bambu (secret bb_code only written when re-entered).
+        if (bb_host[0])   nvs_set_str(h, "bb_host", bb_host);
+        if (bb_serial[0]) nvs_set_str(h, "bb_serial", bb_serial);
+        if (bb_code[0])   nvs_set_str(h, "bb_code", bb_code);
+        // Home Assistant (secret ha_pass only written when re-entered).
+        if (ha_host[0])  nvs_set_str(h, "ha_host", ha_host);
+        int hp = atoi(ha_port_s);
+        if (hp > 0 && hp < 65536) nvs_set_u16(h, "ha_port", (uint16_t)hp);
+        if (ha_user[0])  nvs_set_str(h, "ha_user", ha_user);
+        if (ha_pass[0])  nvs_set_str(h, "ha_pass", ha_pass);
+        if (ha_topic[0]) nvs_set_str(h, "ha_topic", ha_topic);
         nvs_commit(h);
         nvs_close(h);
     }
@@ -496,10 +603,16 @@ static esp_err_t save_post(httpd_req_t *req)
         "<!doctype html><meta charset=utf-8>"
         "<meta name=viewport content='width=device-width,initial-scale=1'>"
         "<body style='font-family:system-ui,sans-serif;text-align:center;margin-top:3em;background:#141414;color:#eee'>"
-        "<h2>Saved &#10003;</h2><p>Rebooting and joining your Wi-Fi&hellip;</p>"
+        "<h2>Saved &#10003;</h2><p>Rebooting&hellip;</p>"
         "<p><small>This page will disconnect \xE2\x80\x94 that's expected.</small></p>");
-    ESP_LOGI(TAG, "provisioned SSID='%s' moonraker='%s' — rebooting", chosen, mk_host);
-    pb_wifi_save_creds_and_reboot(chosen, pass);   // writes ssid/password + reboots
+    if (have_wifi) {
+        ESP_LOGI(TAG, "provisioned SSID='%s' — rebooting", chosen);
+        pb_wifi_save_creds_and_reboot(chosen, pass);   // writes ssid/password + reboots
+    } else {
+        // STA config-only change: keep Wi-Fi creds, apply the new source on reboot.
+        ESP_LOGI(TAG, "config saved (Wi-Fi unchanged) — rebooting");
+        esp_restart();
+    }
     return ESP_OK;                                  // unreachable
 }
 

--- a/components/pb_source/CMakeLists.txt
+++ b/components/pb_source/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "pb_source.c"
+    INCLUDE_DIRS "include"
+    REQUIRES nvs_flash
+)

--- a/components/pb_source/include/pb_source.h
+++ b/components/pb_source/include/pb_source.h
@@ -1,0 +1,24 @@
+#pragma once
+// Control-source selector. The device binds to EXACTLY ONE printer/controller at
+// a time (never several). Klipper (Moonraker) is the default and the shipped
+// path; Bambu and Home Assistant are optional parity sources. The choice is
+// persisted in NVS (app_nvs / "ctl_src") and read once at boot by app_main, which
+// starts only the selected client. See plans/control-source-bambu-ha.md.
+#include "esp_err.h"
+#include <stdint.h>
+
+typedef enum {
+    PB_SRC_KLIPPER = 0,   // Moonraker WebSocket — default, the real target
+    PB_SRC_BAMBU   = 1,   // Bambu LAN MQTT bed-follow (read-only)
+    PB_SRC_HA      = 2,   // Home Assistant MQTT — HA is the controller
+} pb_ctl_source_t;
+
+// Persisted control source. Returns PB_SRC_KLIPPER if unset or out of range
+// (fail-safe to the shipped path).
+pb_ctl_source_t pb_source_get(void);
+
+// Persist the control source. Takes effect on the next boot (app_main starts the
+// selected client at bring-up).
+esp_err_t pb_source_set(pb_ctl_source_t src);
+
+const char *pb_source_str(pb_ctl_source_t src);

--- a/components/pb_source/pb_source.c
+++ b/components/pb_source/pb_source.c
@@ -1,0 +1,38 @@
+#include "pb_source.h"
+#include "nvs.h"
+
+#define NVS_NS  "app_nvs"
+#define KEY_SRC "ctl_src"
+
+pb_ctl_source_t pb_source_get(void)
+{
+    uint8_t v = PB_SRC_KLIPPER;
+    nvs_handle_t h;
+    if (nvs_open(NVS_NS, NVS_READONLY, &h) == ESP_OK) {
+        nvs_get_u8(h, KEY_SRC, &v);   // leaves v at default if key absent
+        nvs_close(h);
+    }
+    if (v > PB_SRC_HA) v = PB_SRC_KLIPPER;   // fail-safe to the shipped path
+    return (pb_ctl_source_t)v;
+}
+
+esp_err_t pb_source_set(pb_ctl_source_t src)
+{
+    if (src > PB_SRC_HA) return ESP_ERR_INVALID_ARG;
+    nvs_handle_t h;
+    esp_err_t err = nvs_open(NVS_NS, NVS_READWRITE, &h);
+    if (err != ESP_OK) return err;
+    err = nvs_set_u8(h, KEY_SRC, (uint8_t)src);
+    if (err == ESP_OK) err = nvs_commit(h);
+    nvs_close(h);
+    return err;
+}
+
+const char *pb_source_str(pb_ctl_source_t src)
+{
+    switch (src) {
+    case PB_SRC_BAMBU: return "bambu";
+    case PB_SRC_HA:    return "ha";
+    default:           return "klipper";
+    }
+}

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -2,5 +2,5 @@ idf_component_register(
     SRCS "app_main.c"
     INCLUDE_DIRS "."
     REQUIRES pb_board pb_ntc pb_heater pb_fan pb_policy pb_leds pb_buttons pb_hil pb_httpd pb_portal
-             pb_wifi pb_moonraker pb_evlog nvs_flash esp_wifi esp_netif mdns app_update
+             pb_wifi pb_moonraker pb_source pb_bambu pb_ha pb_evlog nvs_flash esp_wifi esp_netif mdns app_update
 )

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -35,6 +35,10 @@
 #include "mdns.h"
 #include "pb_wifi.h"
 #include "pb_moonraker.h"
+#include "pb_source.h"
+#include "pb_bambu.h"
+#include "pb_ha.h"
+#include <math.h>
 
 #include "pb_httpd.h"
 #include "pb_portal.h"
@@ -55,9 +59,14 @@ static const char *TAG = "dragonbreath";
 // Set true once the network components have been started, so the control loop
 // doesn't touch pb_* state before it's initialized.
 static volatile bool s_net_up = false;
-// Set true only if pb_moonraker_start() succeeded — never query a client that
-// failed to initialize (its internal state/mutex may be unset).
-static volatile bool s_mk_up = false;
+// Set true only if the selected source client's *_start() succeeded — never
+// query a client that failed to initialize (its internal state/mutex may be
+// unset). Exactly one of these is ever set, per the control-source selector.
+static volatile bool s_mk_up    = false;   // Klipper (Moonraker)
+static volatile bool s_bambu_up = false;   // Bambu LAN MQTT
+static volatile bool s_ha_up    = false;   // Home Assistant MQTT
+// The persisted control source, read once at boot. Default Klipper.
+static pb_ctl_source_t s_src = PB_SRC_KLIPPER;
 
 // Control-task handle, so accepted policy commands can update outputs/LEDs
 // without waiting up to a full periodic tick. Panic-off uses the same prompt
@@ -192,9 +201,39 @@ static void control_task(void *arg)
     for (;;) {
         pb_moonraker_status_t st = {0};
 #ifndef CONFIG_PB_HIL_DEVBOARD
-        if (s_net_up && s_mk_up) pb_moonraker_get_status(&st);
-        bool mk_connected = s_mk_up && st.state == PB_MK_SUBSCRIBED;
-        pb_policy_set_env(st.bed_temp, mk_connected);
+        // Feed the AUTO seam from whichever ONE source is bound. All three paths
+        // converge on pb_policy_set_env(bed_c, connected); the policy is
+        // source-agnostic. Not-connected feeds bed_c=0/connected=false (identical
+        // to the pre-selector behavior when Moonraker was down).
+        float bed_c = 0.0f;
+        bool  src_connected = false;
+        if (s_net_up) {
+            switch (s_src) {
+            case PB_SRC_BAMBU:
+                if (s_bambu_up) {
+                    pb_bambu_status_t bs;
+                    pb_bambu_get_status(&bs);
+                    src_connected = (bs.state == PB_BAMBU_SUBSCRIBED);
+                    if (src_connected && isfinite(bs.bed_temp)) bed_c = bs.bed_temp;
+                }
+                break;
+            case PB_SRC_HA:
+                // HA is a controller, not a bed source — no AUTO follow. Pump the
+                // HA client (retained state publish + heat-lease heartbeat); it
+                // drives target/mode through pb_policy directly.
+                if (s_ha_up) pb_ha_tick();
+                break;
+            case PB_SRC_KLIPPER:
+            default:
+                if (s_mk_up) {
+                    pb_moonraker_get_status(&st);
+                    src_connected = (st.state == PB_MK_SUBSCRIBED);
+                    bed_c = st.bed_temp;
+                }
+                break;
+            }
+        }
+        pb_policy_set_env(bed_c, src_connected);
 #endif
 
         // Safety/control loop: enforces every heater cutoff + fan-follows-heater.
@@ -212,12 +251,12 @@ static void control_task(void *arg)
             pb_fan_zc_diag(&zc, &zciv);
             ESP_LOGI(TAG,
                 "rev=%lu mode=%s source=%s target=%.0fC heater=%s | chamber=%.1fC ptc=%.1fC | "
-                "wifi=%d mk=%d printer=%s bed=%.1f | ZC n=%lu dt=%luus",
+                "wifi=%d src=%s mk=%d printer=%s bed=%.1f | ZC n=%lu dt=%luus",
                 (unsigned long)snap.state_revision,
                 pb_policy_mode_str(snap.mode), pb_policy_source_str(snap.source),
                 snap.effective_target_c, snap.heater_output ? "ON" : "off",
                 snap.chamber_c, snap.ptc_c,
-                net ? (int)pb_wifi_state() : -1, (int)st.state,
+                net ? (int)pb_wifi_state() : -1, pb_source_str(s_src), (int)st.state,
                 pb_printer_state_str(st.printer), st.bed_temp,
                 (unsigned long)zc, (unsigned long)zciv);
         }
@@ -304,10 +343,33 @@ void app_main(void)
     // Mains-powered device: disable WiFi modem-sleep so the control API stays
     // responsive (power-save adds ~0.5s latency spikes to incoming requests).
     esp_wifi_set_ps(WIFI_PS_NONE);
-    if ((e = pb_moonraker_start()) != ESP_OK)
-        ESP_LOGE(TAG, "pb_moonraker_start: %s (continuing; will not query moonraker)", esp_err_to_name(e));
-    else
-        s_mk_up = true;
+    // Control-source selector: start ONLY the bound client. Klipper is the
+    // default and the shipped path; Bambu/HA are opt-in. Each is log-and-continue
+    // like the rest of network bring-up — a source that fails to init just leaves
+    // the device without printer-follow, never aborting the safety loop.
+    s_src = pb_source_get();
+    switch (s_src) {
+    case PB_SRC_BAMBU:
+        if ((e = pb_bambu_start()) != ESP_OK)
+            ESP_LOGE(TAG, "pb_bambu_start: %s (continuing; no printer follow)", esp_err_to_name(e));
+        else
+            s_bambu_up = true;
+        break;
+    case PB_SRC_HA:
+        if ((e = pb_ha_start()) != ESP_OK)
+            ESP_LOGE(TAG, "pb_ha_start: %s (continuing; no HA control)", esp_err_to_name(e));
+        else
+            s_ha_up = true;
+        break;
+    case PB_SRC_KLIPPER:
+    default:
+        if ((e = pb_moonraker_start()) != ESP_OK)
+            ESP_LOGE(TAG, "pb_moonraker_start: %s (continuing; will not query moonraker)", esp_err_to_name(e));
+        else
+            s_mk_up = true;
+        break;
+    }
+    ESP_LOGI(TAG, "control source: %s", pb_source_str(s_src));
     if ((e = pb_httpd_start()) != ESP_OK)
         ESP_LOGE(TAG, "pb_httpd_start: %s (continuing)", esp_err_to_name(e));
     else if ((e = pb_portal_start()) != ESP_OK)   // portal needs the httpd handle


### PR DESCRIPTION
Implements the control-source selector from the RFC (#47). The device binds to **exactly one** of Klipper / Bambu / Home Assistant, chosen in `/setup`. Klipper (Moonraker) stays the default and its path is unchanged.

Purely additive connective tissue — **no changes to `pb_policy`/`pb_heater` or the safety model**. New sources only feed the existing AUTO seam (`pb_policy_set_env`) or submit ordinary policy commands, so an untested source can at worst mean "AUTO doesn't track", never unsafe heating.

## What's included
- **`pb_source`** — `ctl_src` NVS selector (fail-safe to Klipper); `app_main` starts only the selected client.
- **`pb_ha` — Home Assistant, TESTED end-to-end on real hardware.** esp-mqtt to the broker, MQTT Discovery (climate + chamber/element sensors auto-appear), retained state, command topics → `pb_policy` (holds a POWER_ON lease + heartbeats). Declares `temp_unit:C` so HA converts °C↔°F correctly both ways. Verified: discovery, live state, setpoint/mode control, and a HA 113°F setpoint arriving as 45°C on the device.
- **`pb_bambu` — Bambu LAN, EXPERIMENTAL/untested.** esp-mqtt over TLS to the printer's on-device broker (`bblp` + access code, `device/<serial>/report`, `pushall`, scan `bed_temper`). Read-only; feeds the AUTO seam. For community validation.
- **`/setup`** — "Control source" card; secrets never echoed; **no longer forces Wi-Fi re-entry** to change config in STA mode.

## Testing
- HA path validated on real hardware (device + Home Assistant + Mosquitto).
- Klipper default verified unchanged (moonraker still connects post-flash).
- Firmware builds clean (`-Wall -Wextra -Werror`, 0 warnings); flashed to bench.

Cuts **v0.8.0-rc1** on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)