### PR TITLE
fix: AUTO bed-setpoint trigger + /setup Wi-Fi & password fixes (v0.8.0-rc2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+## [0.8.0-rc2] - 2026-07-28
+
+### Changed
+- **AUTO / fan-only filtration now trigger on the bed SETPOINT, not the measured
+  bed temperature (stock parity).** Heat (and the filtration band) engage as soon
+  as the print *commands* a bed at/above the threshold — so the chamber warms
+  alongside the bed instead of waiting for the bed to physically reach the
+  threshold — and disengage when the setpoint drops (e.g. print end). Applies to
+  both the Klipper (Moonraker) and Bambu sources; the bed setpoint is now plumbed
+  through the AUTO seam and exposed as `environment.bed_target_c` in the state API.
+
+### Fixed
+- **Changing configuration in `/setup` no longer wipes Wi-Fi.** Switching the
+  control source (or editing any field) could drop the device to AP mode: the
+  browser's Wi-Fi dropdown auto-selected a scanned network and submitted it with a
+  blank password, overwriting the saved credentials. The dropdown now defaults to
+  "keep current Wi-Fi" in STA mode, so a config-only save leaves Wi-Fi untouched.
+- **Password "show" toggle no longer swaps to a monkey emoji.** The reveal button
+  stays a plain eye and indicates state with a strikethrough (struck = hidden).
+
 ## [0.8.0-rc1] - 2026-07-28
 
 ### Added

--- a/components/pb_bambu/include/pb_bambu.h
+++ b/components/pb_bambu/include/pb_bambu.h
@@ -29,6 +29,7 @@ typedef struct {
     pb_bambu_state_t state;
     bool  connected;      // convenience: state == PB_BAMBU_SUBSCRIBED
     float bed_temp;       // bed_temper (°C); NaN until first report
+    float bed_target;     // bed_target_temper (°C, the setpoint AUTO triggers on)
     float chamber_temp;   // chamber_temper (°C); NaN if the model has no sensor
 } pb_bambu_status_t;
 

--- a/components/pb_bambu/pb_bambu.c
+++ b/components/pb_bambu/pb_bambu.c
@@ -41,7 +41,7 @@ static const char PUSHALL[] =
 static SemaphoreHandle_t        s_lock  = NULL;
 static pb_bambu_config_t        s_cfg   = {0};
 static pb_bambu_status_t        s_status = {
-    .state = PB_BAMBU_DISABLED, .bed_temp = NAN, .chamber_temp = NAN,
+    .state = PB_BAMBU_DISABLED, .bed_temp = NAN, .bed_target = NAN, .chamber_temp = NAN,
 };
 static esp_mqtt_client_handle_t s_client = NULL;
 
@@ -105,12 +105,16 @@ static bool find_float(const char *s, const char *key, float *out)
 
 static void parse_report(const char *json)
 {
-    float bed, cham;
+    float bed, bedtgt, cham;
     bool got_bed  = find_float(json, "\"bed_temper\"", &bed);
+    // bed_target_temper is the commanded setpoint AUTO triggers on. Match the
+    // "_target_temper" so it can't be confused with "bed_temper" (strstr finds the
+    // first hit; searching the more specific key avoids the prefix collision).
+    bool got_tgt  = find_float(json, "bed_target_temper", &bedtgt);
     bool got_cham = find_float(json, "\"chamber_temper\"", &cham);
     // NOTE(phase 2b): H2/newer moved chamber temp to a packed device.ctc.info.temp
     // field; only the legacy flat chamber_temper is read here. Bed follow (the
-    // goal) works on all models via bed_temper.
+    // goal) works on all models via bed_temper/bed_target_temper.
 
     xSemaphoreTake(s_lock, portMAX_DELAY);
     if (got_bed) {
@@ -118,6 +122,7 @@ static void parse_report(const char *json)
         s_status.state     = PB_BAMBU_SUBSCRIBED;   // we have live data now
         s_status.connected = true;
     }
+    if (got_tgt)  s_status.bed_target = bedtgt;
     if (got_cham) s_status.chamber_temp = cham;
     xSemaphoreGive(s_lock);
 

--- a/components/pb_hil/pb_hil.c
+++ b/components/pb_hil/pb_hil.c
@@ -298,7 +298,12 @@ static void handle_request(const cJSON *request)
             emit(response);
             return;
         }
-        pb_policy_set_env((float)bed_c, cJSON_IsTrue(connected));
+        // bed_target_c is the AUTO/filter trigger (bed setpoint); optional, so a
+        // harness that only injects bed_c still works (defaults to bed_c so the old
+        // "measured == trigger" behavior is preserved for existing HIL scenarios).
+        double bed_target_c = bed_c;
+        json_number(request, "bed_target_c", &bed_target_c);
+        pb_policy_set_env((float)bed_c, (float)bed_target_c, cJSON_IsTrue(connected));
         cJSON_AddBoolToObject(response, "ok", true);
     } else if (strcmp(cmd->valuestring, "zero_cross") == 0) {
         double count = 1.0;

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -153,6 +153,7 @@ static cJSON *state_json(const pb_policy_snapshot_t *s)
     cJSON *environment = cJSON_AddObjectToObject(o, "environment");
     cJSON_AddBoolToObject(environment, "moonraker_connected", s->moonraker_connected);
     add_num1(environment, "bed_temperature_c", s->bed_c);
+    add_num1(environment, "bed_target_c", s->bed_target_c);
     cJSON_AddBoolToObject(environment, "auto_engaged", s->auto_engaged);
     cJSON_AddBoolToObject(environment, "auto_filtering", s->auto_filtering);
     add_num1(environment, "auto_bed_threshold_c", s->auto_bed_threshold_c);

--- a/components/pb_policy/include/pb_policy.h
+++ b/components/pb_policy/include/pb_policy.h
@@ -89,7 +89,8 @@ typedef struct {
     pb_ntc_status_t ptc_status;
 
     bool moonraker_connected;
-    float bed_c;
+    float bed_c;          // measured printer bed temperature (display)
+    float bed_target_c;   // commanded printer bed setpoint (AUTO/filter trigger)
     bool auto_engaged;
     bool auto_filtering;          // AUTO fan-only band active (blower on, no heat)
     float auto_bed_threshold_c;
@@ -173,7 +174,12 @@ bool  pb_policy_get_filter_auto_enable(void);
 
 // Update printer environment used by AUTO.  This is observer input, not a
 // control command, and therefore never creates or refreshes a control lease.
-void pb_policy_set_env(float bed_c, bool moonraker_connected);
+// Feed the printer environment for AUTO. bed_c is the measured bed temperature
+// (display); bed_target_c is the commanded bed SETPOINT, which is what AUTO and the
+// fan-only filtration band trigger on — heat/airflow engage as soon as the print
+// COMMANDS a bed >= threshold, not when the bed physically reaches it (stock
+// parity). Pass bed_target_c = 0 when unknown/disconnected.
+void pb_policy_set_env(float bed_c, float bed_target_c, bool moonraker_connected);
 
 // Refresh exactly the active lease.  A stale/superseded lease cannot keep heat
 // alive.

--- a/components/pb_policy/pb_policy.c
+++ b/components/pb_policy/pb_policy.c
@@ -67,7 +67,8 @@ typedef struct {
     uint8_t requested_fan_percent;
 
     bool mk_connected;
-    float bed_c;
+    float bed_c;          // measured bed temperature (display only)
+    float bed_target_c;   // commanded bed setpoint (AUTO/filter trigger)
     float auto_bed_threshold_c;
     bool auto_engaged;
     bool auto_filtering;         // AUTO fan-only band latch (blower on, no heat)
@@ -619,11 +620,12 @@ void pb_policy_stop_drying(pb_source_t source)
     pb_policy_set_mode_off(source);
 }
 
-void pb_policy_set_env(float bed_c, bool moonraker_connected)
+void pb_policy_set_env(float bed_c, float bed_target_c, bool moonraker_connected)
 {
     if (!s_lock) return;
     xSemaphoreTake(s_lock, portMAX_DELAY);
     s.bed_c = isfinite(bed_c) ? bed_c : 0.0f;
+    s.bed_target_c = isfinite(bed_target_c) ? bed_target_c : 0.0f;
     s.mk_connected = moonraker_connected;
     xSemaphoreGive(s_lock);
 }
@@ -870,27 +872,33 @@ void pb_policy_tick(void)
 
         case PB_MODE_AUTO:
         {
+            // Trigger on the bed SETPOINT (commanded), not the measured bed temp
+            // (stock parity): heat engages as soon as the print commands a bed
+            // >= threshold, so the chamber warms alongside the bed instead of
+            // waiting for the bed to physically reach the threshold. Setpoint drops
+            // to 0 when the print ends, which disengages.
             bool was_engaged = s.auto_engaged;
             if (!s.mk_connected) {
                 s.auto_engaged = false;
-            } else if (!s.auto_engaged && s.bed_c >= s.auto_bed_threshold_c) {
+            } else if (!s.auto_engaged && s.bed_target_c >= s.auto_bed_threshold_c) {
                 s.auto_engaged = true;
             } else if (s.auto_engaged
-                       && s.bed_c < s.auto_bed_threshold_c
+                       && s.bed_target_c < s.auto_bed_threshold_c
                                       - PB_AUTO_BED_HYSTERESIS_C) {
                 s.auto_engaged = false;
             }
-            // Fan-only filtration band (stock-like): once the bed reaches
+            // Fan-only filtration band (stock-like): once the bed SETPOINT reaches
             // filter_temp_c the blower runs ALONE — before the heater engages at
-            // the higher auto bed threshold. Same hysteresis shape as engage;
-            // gated off if disabled or Moonraker is down (fail to no-airflow).
+            // the higher auto bed threshold. Same setpoint-trigger + hysteresis
+            // shape as engage; gated off if disabled or Moonraker is down (fail to
+            // no-airflow).
             bool was_filtering = s.auto_filtering;
             if (!s.mk_connected || !s.params.filter_auto_enable) {
                 s.auto_filtering = false;
-            } else if (!s.auto_filtering && s.bed_c >= s.params.filter_temp_c) {
+            } else if (!s.auto_filtering && s.bed_target_c >= s.params.filter_temp_c) {
                 s.auto_filtering = true;
             } else if (s.auto_filtering
-                       && s.bed_c < s.params.filter_temp_c
+                       && s.bed_target_c < s.params.filter_temp_c
                                       - PB_AUTO_BED_HYSTERESIS_C) {
                 s.auto_filtering = false;
             }
@@ -1015,6 +1023,7 @@ void pb_policy_get_snapshot(pb_policy_snapshot_t *out)
     out->requested_fan_percent = s.requested_fan_percent;
     out->moonraker_connected = s.mk_connected;
     out->bed_c = s.bed_c;
+    out->bed_target_c = s.bed_target_c;
     out->auto_engaged = s.auto_engaged;
     out->auto_filtering = (s.mode == PB_MODE_AUTO) && s.auto_filtering;
     out->auto_bed_threshold_c = s.auto_bed_threshold_c;

--- a/components/pb_portal/pb_portal.c
+++ b/components/pb_portal/pb_portal.c
@@ -198,7 +198,9 @@ static const char CONFIG_WIFI[] =
     "<label>Network</label><select id=ssid name=ssid><option value=''>scanning\xE2\x80\xA6</option></select>"
     "<label>\xE2\x80\xA6 or hidden SSID</label><input name=ssid_manual placeholder='(optional)'>"
     "<label>Password</label><div class=pw><input id=pw type=password name=password autocomplete=off>"
-    "<button type=button id=eye onclick='togglePw()' aria-label='show password'>\xF0\x9F\x91\x81</button></div>"
+    // Eye toggles password visibility. Strikethrough (via CSS) = hidden; plain = shown.
+    // Starts struck since the field starts masked. (No emoji swap — a plain eye only.)
+    "<button type=button id=eye onclick='togglePw()' aria-label='show password' style='text-decoration:line-through'>\xF0\x9F\x91\x81</button></div>"
     "<button type=button class=sec onclick='rescan()'>Rescan networks</button></div>";
 
 // Dedicated firmware-update page (GET /fw) — DragonBreath OTA only, its own page so
@@ -298,12 +300,21 @@ static const char PAGE_TAIL[] =
     "var h=hdr();h['Content-Type']='application/x-www-form-urlencoded';"
     "fetch('/save',{method:'POST',headers:h,body:b}).then(done).catch(done);"
     "return false;}"
+    // Toggle visibility; strikethrough the eye when masked (no monkey emoji).
     "function togglePw(){var p=document.getElementById('pw'),e=document.getElementById('eye');"
-    "var s=p.type==='password';p.type=s?'text':'password';e.textContent=s?'\xF0\x9F\x99\x88':'\xF0\x9F\x91\x81';}"
+    "p.type=p.type==='password'?'text':'password';"
+    "e.style.textDecoration=(p.type==='password')?'line-through':'none';}"
+    // Network list. The first option is empty/selected by default: in STA it means
+    // \"keep current Wi-Fi\" so saving without touching it does NOT rewrite creds
+    // (window.DB_KEEPWIFI); in AP provisioning it's a \"choose a network\" prompt.
+    // This prevents a config-only save (e.g. switching control source) from
+    // silently overwriting Wi-Fi with a blank password.
     "function fill(l){var s=document.getElementById('ssid'),c=s.value;s.innerHTML='';"
-    "if(!l.length){s.innerHTML='<option value=\"\">(none found \xE2\x80\x94 tap Rescan)</option>';return;}"
+    "var o0=document.createElement('option');o0.value='';"
+    "o0.textContent=window.DB_KEEPWIFI?'\xE2\x80\x94 Keep current Wi-Fi \xE2\x80\x94':(l.length?'Select a network\xE2\x80\xA6':'(none found \xE2\x80\x94 tap Rescan)');"
+    "s.appendChild(o0);"
     "l.forEach(function(n){var o=document.createElement('option');o.textContent=n;o.value=n;s.appendChild(o);});"
-    "if(c)s.value=c;}"
+    "s.value=c||'';}"
     "function load(){fetch('/scan.json').then(function(r){return r.json();}).then(fill).catch(function(){});}"
     "function rescan(){fetch('/rescan',{method:'POST'}).then(function(){setTimeout(load,1800);});}"
     "load();setInterval(load,4000);"
@@ -391,6 +402,11 @@ static esp_err_t config_page(httpd_req_t *req)
     SEND(req, PAGE_HDR);     // product header kept on /setup + AP captive portal
     SEND(req, WRAP_OPEN);
     send_auth_inject(req);
+    // In STA mode Wi-Fi is already provisioned, so the network dropdown defaults to
+    // "keep current Wi-Fi" (blank) — a config-only save won't rewrite creds. In AP
+    // provisioning there are no creds yet, so a network must be chosen.
+    if (pb_wifi_state() != PB_WIFI_STATE_AP_PORTAL)
+        SEND(req, "<script>window.DB_KEEPWIFI=1;</script>");
     SEND(req, CONFIG_WIFI);
 
     // Reused buffers: emit each piece before reusing, to keep httpd-task stack

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -202,10 +202,11 @@ static void control_task(void *arg)
         pb_moonraker_status_t st = {0};
 #ifndef CONFIG_PB_HIL_DEVBOARD
         // Feed the AUTO seam from whichever ONE source is bound. All three paths
-        // converge on pb_policy_set_env(bed_c, connected); the policy is
-        // source-agnostic. Not-connected feeds bed_c=0/connected=false (identical
-        // to the pre-selector behavior when Moonraker was down).
-        float bed_c = 0.0f;
+        // converge on pb_policy_set_env(bed_c, bed_target_c, connected); the policy
+        // is source-agnostic and triggers AUTO on the bed SETPOINT (bed_target_c).
+        // Not-connected feeds zeros/false (identical to the pre-selector behavior
+        // when Moonraker was down).
+        float bed_c = 0.0f, bed_target_c = 0.0f;
         bool  src_connected = false;
         if (s_net_up) {
             switch (s_src) {
@@ -214,7 +215,10 @@ static void control_task(void *arg)
                     pb_bambu_status_t bs;
                     pb_bambu_get_status(&bs);
                     src_connected = (bs.state == PB_BAMBU_SUBSCRIBED);
-                    if (src_connected && isfinite(bs.bed_temp)) bed_c = bs.bed_temp;
+                    if (src_connected) {
+                        if (isfinite(bs.bed_temp))   bed_c = bs.bed_temp;
+                        if (isfinite(bs.bed_target)) bed_target_c = bs.bed_target;
+                    }
                 }
                 break;
             case PB_SRC_HA:
@@ -229,11 +233,12 @@ static void control_task(void *arg)
                     pb_moonraker_get_status(&st);
                     src_connected = (st.state == PB_MK_SUBSCRIBED);
                     bed_c = st.bed_temp;
+                    bed_target_c = st.bed_target;
                 }
                 break;
             }
         }
-        pb_policy_set_env(bed_c, src_connected);
+        pb_policy_set_env(bed_c, bed_target_c, src_connected);
 #endif
 
         // Safety/control loop: enforces every heater cutoff + fan-follows-heater.

--- a/tests/pb_policy_host_test.c
+++ b/tests/pb_policy_host_test.c
@@ -336,29 +336,43 @@ static void test_auto_requires_live_moonraker_and_uses_hysteresis(void)
     CHECK(pb_policy_set_auto(
         60.0f, 100.0f, PB_SOURCE_WEB, 1) == PB_POLICY_OK);
 
-    pb_policy_set_env(99.0f, true);
+    pb_policy_set_env(99.0f, 99.0f, true);
     pb_policy_tick();
     CHECK(snapshot().effective_target_c == 0.0f);
 
-    pb_policy_set_env(100.0f, true);
+    pb_policy_set_env(100.0f, 100.0f, true);
     pb_policy_tick();
     pb_policy_snapshot_t snap = snapshot();
     CHECK(snap.auto_engaged);
     CHECK(snap.effective_target_c == 60.0f);
 
-    pb_policy_set_env(98.0f, true);
+    pb_policy_set_env(98.0f, 98.0f, true);
     pb_policy_tick();
     CHECK(snapshot().auto_engaged);
 
-    pb_policy_set_env(96.9f, true);
+    pb_policy_set_env(96.9f, 96.9f, true);
     pb_policy_tick();
     snap = snapshot();
     CHECK(!snap.auto_engaged);
     CHECK(snap.effective_target_c == 0.0f);
 
-    pb_policy_set_env(105.0f, false);
+    pb_policy_set_env(105.0f, 105.0f, false);
     pb_policy_tick();
     CHECK(!snapshot().auto_engaged);
+
+    // Setpoint parity: AUTO triggers on the commanded bed SETPOINT, not the
+    // measured bed temperature. A cold bed with a high setpoint engages
+    // immediately; a hot bed whose setpoint has dropped disengages.
+    CHECK(pb_policy_set_auto(
+        60.0f, 100.0f, PB_SOURCE_WEB, PB_POLICY_REVISION_ANY) == PB_POLICY_OK);
+    pb_policy_set_env(20.0f /*measured cold*/, 100.0f /*setpoint*/, true);
+    pb_policy_tick();
+    CHECK(snapshot().auto_engaged);
+    CHECK(snapshot().effective_target_c == 60.0f);
+    pb_policy_set_env(99.0f /*measured hot*/, 0.0f /*setpoint cleared*/, true);
+    pb_policy_tick();
+    CHECK(!snapshot().auto_engaged);
+    CHECK(snapshot().effective_target_c == 0.0f);
 }
 
 static void test_auto_filtration_band_fan_only_not_cooldown(void)
@@ -369,14 +383,14 @@ static void test_auto_filtration_band_fan_only_not_cooldown(void)
         60.0f, 100.0f, PB_SOURCE_WEB, 1) == PB_POLICY_OK);
 
     // Bed below filter_temp: no filtration, fan off.
-    pb_policy_set_env(25.0f, true);
+    pb_policy_set_env(25.0f, 25.0f, true);
     pb_policy_tick();
     pb_policy_snapshot_t snap = snapshot();
     CHECK(!snap.auto_filtering);
     CHECK(snap.effective_fan_percent == 0);
 
     // Bed >= filter_temp but below the heat threshold: fan-only filtration band.
-    pb_policy_set_env(40.0f, true);
+    pb_policy_set_env(40.0f, 40.0f, true);
     pb_policy_tick();
     snap = snapshot();
     CHECK(snap.auto_filtering);                 // filtering
@@ -386,20 +400,20 @@ static void test_auto_filtration_band_fan_only_not_cooldown(void)
     CHECK(!snap.thermal_purge);                 // P1: must NOT read as cooldown purge
 
     // Hysteresis: stays on within [filter_temp - 3, ...); releases only below it.
-    pb_policy_set_env(28.0f, true);
+    pb_policy_set_env(28.0f, 28.0f, true);
     pb_policy_tick();
     CHECK(snapshot().auto_filtering);
-    pb_policy_set_env(26.0f, true);
+    pb_policy_set_env(26.0f, 26.0f, true);
     pb_policy_tick();
     snap = snapshot();
     CHECK(!snap.auto_filtering);
     CHECK(snap.effective_fan_percent == 0);
 
     // Moonraker disconnect fails to no-airflow even with a hot bed.
-    pb_policy_set_env(40.0f, true);
+    pb_policy_set_env(40.0f, 40.0f, true);
     pb_policy_tick();
     CHECK(snapshot().auto_filtering);
-    pb_policy_set_env(40.0f, false);
+    pb_policy_set_env(40.0f, 40.0f, false);
     pb_policy_tick();
     snap = snapshot();
     CHECK(!snap.auto_filtering);
@@ -432,7 +446,7 @@ static void test_runtime_limits_drive_auto_and_remote_lease(void)
     CHECK(pb_policy_set_auto(
         65.0f, 100.0f, PB_SOURCE_WEB, 1) == PB_POLICY_OK);
     CHECK(snapshot().requested_target_c == 52.0f);
-    pb_policy_set_env(100.0f, true);
+    pb_policy_set_env(100.0f, 100.0f, true);
     pb_policy_tick();
     CHECK(snapshot().effective_target_c == 52.0f);
 
@@ -691,12 +705,12 @@ static void test_panel_leds_track_mode(void)
     pb_policy_set_mode_off(PB_SOURCE_WEB);
     CHECK(pb_policy_set_auto(
         60.0f, 100.0f, PB_SOURCE_WEB, PB_POLICY_REVISION_ANY) == PB_POLICY_OK);
-    pb_policy_set_env(20.0f, false);
+    pb_policy_set_env(20.0f, 20.0f, false);
     pb_policy_tick();
     CHECK(led_pattern[PB_LED_AUTO] == PB_LED_BLINK_SLOW);
     CHECK(led_pattern[PB_LED_ON] == PB_LED_OFF);
 
-    pb_policy_set_env(105.0f, true);
+    pb_policy_set_env(105.0f, 105.0f, true);
     pb_policy_tick();
     CHECK(snapshot().auto_engaged);
     CHECK(led_pattern[PB_LED_AUTO] == PB_LED_SOLID);


### PR DESCRIPTION
Second rc for the control-source feature. Three fixes from bench testing + Justin's review.

## Changed
- **AUTO / fan-only filtration trigger on the bed SETPOINT, not measured temp (stock parity).** Per Justin: stock turns chamber heat on the moment the print *commands* a bed ≥ trigger, not when the bed physically reaches it (same for the cold-filter band). Heat/airflow now engage on the commanded setpoint and disengage when it drops. Applies to **both Klipper and Bambu**; the setpoint is plumbed through the AUTO seam (`pb_policy_set_env` gains `bed_target_c`) and exposed as `environment.bed_target_c`. Host test extended with cold-bed/high-setpoint assertions.

## Fixed
- **Changing config in `/setup` no longer wipes Wi-Fi → AP mode.** The browser Wi-Fi dropdown auto-selected a scanned network and submitted it with a blank password, overwriting creds. Now defaults to "keep current Wi-Fi" in STA mode. **Validated live**: switching control source over the config-only path keeps Wi-Fi and reconnects.
- **Password reveal stays a plain eye** (strikethrough = hidden) instead of swapping to a 🙈 monkey.

## Testing
- Policy host test PASS (incl. new setpoint assertions); firmware builds clean (0 warnings).
- Bench: Wi-Fi-keep confirmed live (switched source, Wi-Fi survived, HA reconnected); Klipper + HA both healthy; new `bed_target_c` field flowing.

Cuts **v0.8.0-rc2** on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)