### PR TITLE
fix(ui): control-source-aware dashboard status row (v0.8.0-rc3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ below into the GitHub Release notes.
 ### Changed
 - **Dashboard status is control-source-aware.** In Home Assistant mode the
   "Printer" row (which read a misleading "not connected", since HA has no printer
-  to follow) is relabeled **"Source: Home Assistant"**; Bambu mode labels it
-  "Bambu". Klipper mode is unchanged. The active source is exposed as
-  `environment.control_source` in the state API.
+  to follow) is relabeled **"Source: Home Assistant"**, and the **Controller** row
+  shows **"Home Assistant"** instead of the internal "Web UI (ha)". Bambu mode
+  labels the row **"Bambu (&lt;serial&gt;)"** (the LAN report carries no friendly
+  printer name, so the configured serial is used). Klipper mode is unchanged. The
+  active source is exposed as `environment.control_source`, and the Bambu serial as
+  `environment.bambu_serial`, in the state API.
 
 ## [0.8.0-rc2] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+## [0.8.0-rc3] - 2026-07-28
+
+### Changed
+- **Dashboard status is control-source-aware.** In Home Assistant mode the
+  "Printer" row (which read a misleading "not connected", since HA has no printer
+  to follow) is relabeled **"Source: Home Assistant"**; Bambu mode labels it
+  "Bambu". Klipper mode is unchanged. The active source is exposed as
+  `environment.control_source` in the state API.
+
 ## [0.8.0-rc2] - 2026-07-28
 
 ### Changed

--- a/components/pb_httpd/CMakeLists.txt
+++ b/components/pb_httpd/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(
     SRCS "pb_httpd.c"
     INCLUDE_DIRS "include"
-    REQUIRES esp_http_server pb_heater pb_ntc pb_leds pb_policy pb_source pb_evlog json nvs_flash app_update
+    REQUIRES esp_http_server pb_heater pb_ntc pb_leds pb_policy pb_source pb_bambu pb_evlog json nvs_flash app_update
              mbedtls esp_wifi esp_timer esp_system
 )

--- a/components/pb_httpd/CMakeLists.txt
+++ b/components/pb_httpd/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(
     SRCS "pb_httpd.c"
     INCLUDE_DIRS "include"
-    REQUIRES esp_http_server pb_heater pb_ntc pb_leds pb_policy pb_evlog json nvs_flash app_update
+    REQUIRES esp_http_server pb_heater pb_ntc pb_leds pb_policy pb_source pb_evlog json nvs_flash app_update
              mbedtls esp_wifi esp_timer esp_system
 )

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -4,6 +4,7 @@
 #include "pb_ntc.h"
 #include "pb_leds.h"
 #include "pb_policy.h"
+#include "pb_source.h"
 #include "pb_evlog.h"
 
 #include "esp_http_server.h"
@@ -151,6 +152,10 @@ static cJSON *state_json(const pb_policy_snapshot_t *s)
     cJSON_AddStringToObject(ptc, "status", ntc_status_str(s->ptc_status));
 
     cJSON *environment = cJSON_AddObjectToObject(o, "environment");
+    // Active control source (klipper/bambu/ha). Read from NVS; since /setup reboots
+    // on save, this matches the running source except for the sub-second window
+    // between a save and the reboot. Lets the dashboard label the printer/source row.
+    cJSON_AddStringToObject(environment, "control_source", pb_source_str(pb_source_get()));
     cJSON_AddBoolToObject(environment, "moonraker_connected", s->moonraker_connected);
     add_num1(environment, "bed_temperature_c", s->bed_c);
     add_num1(environment, "bed_target_c", s->bed_target_c);

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -5,6 +5,7 @@
 #include "pb_leds.h"
 #include "pb_policy.h"
 #include "pb_source.h"
+#include "pb_bambu.h"
 #include "pb_evlog.h"
 
 #include "esp_http_server.h"
@@ -155,7 +156,15 @@ static cJSON *state_json(const pb_policy_snapshot_t *s)
     // Active control source (klipper/bambu/ha). Read from NVS; since /setup reboots
     // on save, this matches the running source except for the sub-second window
     // between a save and the reboot. Lets the dashboard label the printer/source row.
-    cJSON_AddStringToObject(environment, "control_source", pb_source_str(pb_source_get()));
+    pb_ctl_source_t ctl_src = pb_source_get();
+    cJSON_AddStringToObject(environment, "control_source", pb_source_str(ctl_src));
+    // In Bambu mode, surface the configured serial so the dashboard can label the
+    // row "Bambu (<serial>)" — the LAN report carries no friendly printer name.
+    if (ctl_src == PB_SRC_BAMBU) {
+        pb_bambu_config_t bc;
+        if (pb_bambu_get_config(&bc) == ESP_OK && bc.serial[0])
+            cJSON_AddStringToObject(environment, "bambu_serial", bc.serial);
+    }
     cJSON_AddBoolToObject(environment, "moonraker_connected", s->moonraker_connected);
     add_num1(environment, "bed_temperature_c", s->bed_c);
     add_num1(environment, "bed_target_c", s->bed_target_c);

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -934,6 +934,9 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
   }
   function controllerLabel(s){
     var l=(s.control||{}).lease||{};
+    /* In Home Assistant mode HA is the controller — show "Home Assistant" rather
+       than the internal transport/owner (which is Web/"ha"). */
+    if((s.environment||{}).control_source==='ha') return 'Home Assistant';
     if(l.active) return sourceLabel(s.source)+(l.owner? ' ('+l.owner+')':'');
     return s.mode==='off' ? '—' : sourceLabel(s.source);
   }
@@ -1003,7 +1006,9 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
       if(plabel) plabel.textContent='Source';
       u('db-printer','Home Assistant');
     } else {
-      if(plabel) plabel.textContent = (src==='bambu') ? 'Bambu' : 'Printer';
+      var plabelText = 'Printer';
+      if(src==='bambu') plabelText = 'Bambu'+(s.environment.bambu_serial ? ' ('+s.environment.bambu_serial+')' : '');
+      if(plabel) plabel.textContent = plabelText;
       u('db-printer', s.environment.moonraker_connected
         ? 'connected'+(s.environment.bed_temperature_c!=null ? ' · bed '+Math.round(s.environment.bed_temperature_c)+' °C' : '')
         : 'not connected');

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -455,7 +455,7 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
             <div><dt>Controller</dt><dd id="db-controller">--</dd></div>
             <div id="db-auto-row" hidden><dt>Auto</dt><dd id="db-auto">--</dd></div>
             <div id="db-drying-row" hidden><dt>Drying</dt><dd id="db-drying">--</dd></div>
-            <div><dt>Printer</dt><dd id="db-printer">--</dd></div>
+            <div><dt id="db-printer-label">Printer</dt><dd id="db-printer">--</dd></div>
             <div><dt>Fault</dt><dd id="db-fault">--</dd></div>
           </dl>
           <div class="actions">
@@ -994,9 +994,20 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
     var dryRow = s.drying.active;
     $('db-drying-row').hidden = !dryRow;
     if(dryRow) u('db-drying', fmtDur(s.drying.remaining_seconds)+' left');
-    u('db-printer', s.environment.moonraker_connected
-      ? 'connected'+(s.environment.bed_temperature_c!=null ? ' · bed '+Math.round(s.environment.bed_temperature_c)+' °C' : '')
-      : 'not connected');
+    /* Printer/source row is source-aware: Klipper/Bambu follow a printer bed (show
+       link + bed); Home Assistant has no printer to follow (HA is the controller),
+       so relabel the row and show the source instead of a misleading "not connected". */
+    var src = s.environment.control_source || 'klipper';
+    var plabel = $('db-printer-label');
+    if(src==='ha'){
+      if(plabel) plabel.textContent='Source';
+      u('db-printer','Home Assistant');
+    } else {
+      if(plabel) plabel.textContent = (src==='bambu') ? 'Bambu' : 'Printer';
+      u('db-printer', s.environment.moonraker_connected
+        ? 'connected'+(s.environment.bed_temperature_c!=null ? ' · bed '+Math.round(s.environment.bed_temperature_c)+' °C' : '')
+        : 'not connected');
+    }
     u('db-fault', s.safety.inhibited ? ('inhibited: '+(s.safety.reason||'unknown'))
       : s.safety.fault_latched ? ('latched: '+(s.safety.reason||'unknown')) : 'none');
 


### PR DESCRIPTION
In Home Assistant mode the dashboard "Printer" row showed a misleading **"not connected"** — there's no printer to follow in HA mode (HA is the controller).

The status row is now **source-aware**:
- **HA mode** → relabeled **"Source: Home Assistant"**
- **Bambu mode** → "Bambu" (link + bed)
- **Klipper mode** → unchanged "Printer" (link + bed)

The active source is exposed as `environment.control_source` in the state API (read from NVS; matches the running source since `/setup` reboots on save).

Verified on the bench: `control_source: ha` present in the state API; dashboard JS syntax check PASS; builds clean.

Cuts **v0.8.0-rc3** on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)