### PR TITLE
RFC: /diag and /console web pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+### Added
+- **`/diag` diagnostics page.** A device-served live view of the `tools/diag.py`
+  telemetry — chamber/element temps, SSR output, mode, fault, running element-temp
+  peak — with a trend chart and a client-side CSV download. Read-only, SSE-driven;
+  **zero device RAM** and no persistence. Header-free, themed like `/fw`.
+- **`/console` firmware log page.** Captures the raw `ESP_LOGx` stream into a 16 KB
+  RAM ring (`esp_log_set_vprintf` hook installed at boot, UART output preserved) and
+  serves it at the auth-gated `GET /api/v2/console`; the page auto-refreshes and has
+  a `.txt` download. Motivated by the new no-USB Panda + release-build TX=LED, which
+  make the serial console otherwise unreachable. Read-only / non-interactive.
+
 ### Changed
 - **`tools/flash.py` auto-falls-back the baud rate on poor connections.** Backup,
   flash, and restore now try 460800 → 230400 → 115200 baud, retrying a failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,58 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-30
+
+The pluggable-control-source + web-tools release. **Klipper (Moonraker) remains the
+default and is unchanged**; everything below is additive and the heater safety model
+is untouched and source-independent. Consolidates the 0.8.0-rc1…rc3 pre-releases.
+
 ### Added
-- **`/diag` diagnostics page.** A device-served live view of the `tools/diag.py`
-  telemetry — chamber/element temps, SSR output, mode, fault, running element-temp
-  peak — with a trend chart and a client-side CSV download. Read-only, SSE-driven;
-  **zero device RAM** and no persistence. Header-free, themed like `/fw`.
+- **Selectable control source — Klipper / Bambu / Home Assistant.** The device binds
+  to exactly one printer/controller, chosen in `/setup` (mutually exclusive).
+  - **Home Assistant (validated on hardware).** MQTT client with MQTT-Discovery — a
+    climate entity + chamber/element temperature sensors auto-appear in HA — plus a
+    retained state topic and command topics mapped to heater target/mode (holds a
+    device lease and heartbeats it). Declares Celsius so HA converts °C↔°F correctly
+    in both directions. Verified end-to-end (device + HA + Mosquitto).
+  - **Bambu LAN — EXPERIMENTAL, not yet validated against a printer.** Read-only
+    bed-follow over the printer's on-device LAN MQTT/TLS broker (`bblp` + LAN access
+    code, subscribe `device/<serial>/report`, `pushall` on connect, scan
+    `bed_temper`) feeding AUTO. Built from the OpenBambuAPI / ha-bambulab spec. Opt-in
+    and safe by construction (the source only produces a bed temperature into the
+    already-validated safety logic) — shipped for community validation. Select
+    "Bambu" in `/setup` to test; please report results.
+- **`/diag` diagnostics page.** Live SSE view of the `tools/diag.py` telemetry
+  (chamber/element temps, SSR output, mode, fault, running element-temp peak) with a
+  trend chart and a client-side CSV download. Read-only; **zero device RAM**.
 - **`/console` firmware log page.** Captures the raw `ESP_LOGx` stream into a 16 KB
-  RAM ring (`esp_log_set_vprintf` hook installed at boot, UART output preserved) and
-  serves it at the auth-gated `GET /api/v2/console`; the page auto-refreshes and has
-  a `.txt` download. Motivated by the new no-USB Panda + release-build TX=LED, which
-  make the serial console otherwise unreachable. Read-only / non-interactive.
+  RAM ring (boot log included; UART output preserved) served at the auth-gated
+  `GET /api/v2/console`; terminal-style view with auto-refresh + `.txt` download.
+  Motivated by newer no-USB Panda hardware (and release builds using the UART TX pin
+  as the Power LED), where the serial console is otherwise unreachable.
 
 ### Changed
-- **`tools/flash.py` auto-falls-back the baud rate on poor connections.** Backup,
-  flash, and restore now try 460800 → 230400 → 115200 baud, retrying a failed
-  transfer at the next slower rate instead of aborting. Fixes flaky USB-serial
-  links (some laptops/cables/CH340 adapters) that corrupted the stock backup at the
-  old fixed 460800. `--baud` now pins a single rate; the backup's working rate
-  carries into the flash step. All backup integrity checks are unchanged.
+- **AUTO / fan-only filtration trigger on the bed SETPOINT, not the measured temp**
+  (stock parity): heat/airflow engage as soon as the print *commands* bed ≥ threshold,
+  and disengage when the setpoint drops. Applies to Klipper and Bambu; exposed as
+  `environment.bed_target_c`.
+- **Dashboard status is control-source-aware** — shows "Home Assistant" or
+  "Bambu (&lt;serial&gt;)" instead of a misleading "Printer: not connected";
+  `control_source` + `bambu_serial` added to the state API.
+- **Periodic status heartbeat deduped** (whole-degree temperature compare) so
+  `/console` and the serial log stay readable — repeated states collapse to a
+  `repeated Nx` tally with a periodic liveness flush.
+- **`tools/flash.py` auto-falls-back the baud rate** (460800 → 230400 → 115200) for
+  flaky USB-serial links; `--baud` pins a single rate. All backup integrity checks
+  (size, ESP magic, on-chip hash verify) are unchanged.
+
+### Fixed
+- **`/setup` no longer wipes Wi-Fi on a config-only save.** The Wi-Fi dropdown
+  auto-selected a scanned network and submitted it with a blank password, dropping the
+  device to AP mode; it now defaults to "keep current Wi-Fi" in STA mode, so switching
+  control source (or editing any field) leaves credentials untouched.
+- **Password reveal** on `/setup` stays a plain eye (strikethrough = hidden) instead
+  of swapping to a monkey emoji.
 
 ## [0.8.0-rc3] - 2026-07-28
 

--- a/components/pb_evlog/CMakeLists.txt
+++ b/components/pb_evlog/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "pb_evlog.c"
     INCLUDE_DIRS "include"
-    REQUIRES freertos
+    REQUIRES freertos log
 )

--- a/components/pb_evlog/include/pb_evlog.h
+++ b/components/pb_evlog/include/pb_evlog.h
@@ -29,3 +29,20 @@ void pb_evlog_add(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 // Copy up to `max` most-recent entries into `out`, newest first. Returns how
 // many were copied.
 size_t pb_evlog_snapshot(pb_evlog_entry_t *out, size_t max);
+
+// ---- firmware console capture (raw ESP_LOGx stream) ----
+// Separate from the curated event ring above: a fixed byte ring that captures the
+// full ESP_LOGx output via an esp_log_set_vprintf hook while still forwarding to
+// UART. Motivation: newer Panda hardware has no external USB, and release builds
+// repurpose the UART TX pin (GPIO21) as the Power LED — so the serial console is
+// otherwise unreachable. Served by the /console page.
+#define PB_EVLOG_CONSOLE_BYTES  16384   // ~180 lines; ~3% of worst-case free heap
+
+// Install the log-capture hook. Call ONCE, as early as possible in app_main, so
+// the boot log is captured. Idempotent. Uses a spinlock (safe from any context);
+// never logs from within the hook (no recursion).
+void pb_evlog_console_init(void);
+
+// Copy the console ring, oldest -> newest, into `out` (always NUL-terminated).
+// Returns bytes written (excluding the NUL). `max` should be >= the ring size + 1.
+size_t pb_evlog_console_snapshot(char *out, size_t max);

--- a/components/pb_evlog/pb_evlog.c
+++ b/components/pb_evlog/pb_evlog.c
@@ -3,6 +3,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
 #include "freertos/task.h"
+#include "esp_log.h"
 
 #include <stdarg.h>
 #include <stdio.h>
@@ -12,6 +13,44 @@ static SemaphoreHandle_t s_lock = NULL;
 static pb_evlog_entry_t  s_buf[PB_EVLOG_MAX_ENTRIES];
 static size_t            s_head = 0;   // next write slot
 static size_t            s_count = 0;  // number of valid entries (<= MAX)
+
+// ---- firmware console capture (raw ESP_LOGx byte ring) ----
+// Independent of the curated event ring above. A spinlock (not a mutex) guards it
+// because the esp_log vprintf hook can be reached from many contexts and must never
+// block or assert; the critical sections are a short append (<=CON_LINE bytes) and
+// a rarely-called full-ring snapshot. We NEVER log from inside the hook.
+#define CON_LINE  200
+static portMUX_TYPE     s_con_mux = portMUX_INITIALIZER_UNLOCKED;
+static char             s_con[PB_EVLOG_CONSOLE_BYTES];
+static size_t           s_con_head = 0;    // next write index
+static bool             s_con_full = false;
+static vprintf_like_t   s_prev_vprintf = NULL;
+static bool             s_con_on = false;
+
+static void con_append(const char *p, int n)
+{
+    if (n <= 0) return;
+    portENTER_CRITICAL(&s_con_mux);
+    for (int i = 0; i < n; i++) {
+        s_con[s_con_head++] = p[i];
+        if (s_con_head >= PB_EVLOG_CONSOLE_BYTES) { s_con_head = 0; s_con_full = true; }
+    }
+    portEXIT_CRITICAL(&s_con_mux);
+}
+
+// esp_log hook: tee the formatted line into the ring, then forward to the original
+// writer (UART) via a va_copy so the serial console is unchanged.
+static int con_vprintf(const char *fmt, va_list ap)
+{
+    char line[CON_LINE];
+    va_list ap2;
+    va_copy(ap2, ap);
+    int n = vsnprintf(line, sizeof line, fmt, ap);
+    con_append(line, n < (int)sizeof line ? n : (int)sizeof line - 1);
+    int r = s_prev_vprintf ? s_prev_vprintf(fmt, ap2) : 0;
+    va_end(ap2);
+    return r;
+}
 
 void pb_evlog_init(void)
 {
@@ -55,4 +94,38 @@ size_t pb_evlog_snapshot(pb_evlog_entry_t *out, size_t max)
 
     xSemaphoreGive(s_lock);
     return want;
+}
+
+void pb_evlog_console_init(void)
+{
+    if (s_con_on) return;
+    s_con_on = true;
+    s_prev_vprintf = esp_log_set_vprintf(con_vprintf);   // returns the UART writer
+}
+
+size_t pb_evlog_console_snapshot(char *out, size_t max)
+{
+    if (out == NULL || max == 0) return 0;
+    size_t cap = max - 1;   // leave room for the NUL
+    size_t len = 0;
+
+    portENTER_CRITICAL(&s_con_mux);
+    if (s_con_full) {
+        // Ring wrapped: oldest byte is at s_con_head. Emit [head..end) then [0..head).
+        size_t tail = PB_EVLOG_CONSOLE_BYTES - s_con_head;
+        size_t a = tail < cap ? tail : cap;
+        memcpy(out, s_con + s_con_head, a);
+        len = a;
+        size_t b = s_con_head < (cap - len) ? s_con_head : (cap - len);
+        memcpy(out + len, s_con, b);
+        len += b;
+    } else {
+        size_t a = s_con_head < cap ? s_con_head : cap;
+        memcpy(out, s_con, a);
+        len = a;
+    }
+    portEXIT_CRITICAL(&s_con_mux);
+
+    out[len] = '\0';
+    return len;
 }

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -1093,6 +1093,28 @@ static esp_err_t logs_get(httpd_req_t *req)
     return send_json(req, o);
 }
 
+// GET /api/v2/console — auth-gated (raw firmware log is chattier than the curated
+// event ring: IPs, Wi-Fi/mDNS detail). Snapshots the pb_evlog console byte ring as
+// text/plain, oldest -> newest. Read-only; never energizes the heater.
+static esp_err_t console_get(httpd_req_t *req)
+{
+    if (!pb_httpd_auth_ok(req)) {
+        httpd_resp_set_status(req, "403 Forbidden");
+        httpd_resp_set_type(req, "application/json");
+        return httpd_resp_sendstr(req, "{\"error\":\"missing/invalid X-DragonBreath-Auth header\"}");
+    }
+    char *buf = malloc(PB_EVLOG_CONSOLE_BYTES + 1);
+    if (!buf) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "oom");
+        return ESP_FAIL;
+    }
+    size_t n = pb_evlog_console_snapshot(buf, PB_EVLOG_CONSOLE_BYTES + 1);
+    httpd_resp_set_type(req, "text/plain; charset=utf-8");
+    esp_err_t r = httpd_resp_send(req, buf, n);
+    free(buf);
+    return r;
+}
+
 // POST /api/v2/token — auth-gated. Body {"token":"..."} sets the control token
 // (<=64 chars); {"token":""} / {"token":null} / {} clears it. Setting a token
 // means subsequent mutating requests must send it (the caller keeps using it).
@@ -1140,7 +1162,7 @@ esp_err_t pb_httpd_start(void)
     httpd_config_t cfg = HTTPD_DEFAULT_CONFIG();
     cfg.lru_purge_enable = true;
     cfg.uri_match_fn = httpd_uri_match_wildcard;   // lets pb_portal add a "/*" captive catch-all
-    cfg.max_uri_handlers = 23;                     // 22 used (+ /favicon.ico) + 1 spare
+    cfg.max_uri_handlers = 27;                     // 25 used (+ /diag, /console, /api/v2/console) + spare
     // The OTA handler hashes the image (mbedtls) with a 1 KB read buffer + the
     // app descriptor on-stack, which overflows the 4 KB default httpd task stack
     // (stack-protection panic). Give it headroom.
@@ -1179,6 +1201,7 @@ esp_err_t pb_httpd_start(void)
     httpd_uri_t setg   = { .uri = "/settings",         .method = HTTP_GET,  .handler = settings_get };
     httpd_uri_t setp   = { .uri = "/settings",         .method = HTTP_POST, .handler = settings_post };
     httpd_uri_t logs   = { .uri = "/api/v2/logs",      .method = HTTP_GET,  .handler = logs_get };
+    httpd_uri_t cons   = { .uri = "/api/v2/console",   .method = HTTP_GET,  .handler = console_get };
     httpd_uri_t rst    = { .uri = "/api/v2/restart",   .method = HTTP_POST, .handler = restart_post };
     httpd_uri_t frst   = { .uri = "/api/v2/factory-reset", .method = HTTP_POST, .handler = factory_reset_post };
     httpd_uri_t tok    = { .uri = "/api/v2/token",     .method = HTTP_POST, .handler = token_post };
@@ -1194,6 +1217,7 @@ esp_err_t pb_httpd_start(void)
     httpd_register_uri_handler(s_server, &setg);
     httpd_register_uri_handler(s_server, &setp);
     httpd_register_uri_handler(s_server, &logs);
+    httpd_register_uri_handler(s_server, &cons);
     httpd_register_uri_handler(s_server, &rst);
     httpd_register_uri_handler(s_server, &frst);
     httpd_register_uri_handler(s_server, &tok);

--- a/components/pb_portal/pb_portal.c
+++ b/components/pb_portal/pb_portal.c
@@ -371,6 +371,168 @@ static esp_err_t fw_page(httpd_req_t *req)
     return httpd_resp_send_chunk(req, NULL, 0);
 }
 
+// Diagnostics page (GET /diag): the tools/diag.py logger in the browser. Pure
+// client-side over the existing read-only SSE stream (/api/v2/events) + /api/v2/info
+// — no new device state, no persistence. Shows chamber/element temps, SSR output,
+// mode, fault, a running element-temp peak, a live trend, and a client-side CSV
+// download of everything sampled since the page opened.
+static const char DIAG_BODY[] =
+    "<style>"
+    ".dgrid{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin:.6em 0}"
+    ".dgrid>div{background:var(--input);border-radius:8px;padding:10px}"
+    ".dlab{font-size:.72rem;color:var(--muted)}"
+    ".dval{font-size:1.2rem;font-weight:700;margin-top:2px}"
+    ".dval.warn{color:var(--bad)}"
+    "#d-chart{display:block;width:100%;height:120px;background:var(--input);border-radius:8px;margin:.5em 0}"
+    ".drow{display:flex;gap:8px}.drow button{flex:1;margin-top:0}"
+    "</style>"
+    "<div class=card><h2>Diagnostics</h2>"
+    "<div id=d-meta><small>connecting\xE2\x80\xA6</small></div>"
+    "<div class=dgrid>"
+    "<div><div class=dlab>Chamber</div><div class=dval id=d-ch>--</div></div>"
+    "<div><div class=dlab>Element (PTC)</div><div class=dval id=d-ptc>--</div></div>"
+    "<div><div class=dlab>Peak element</div><div class=dval id=d-peak>--</div></div>"
+    "<div><div class=dlab>SSR output</div><div class=dval id=d-ssr>--</div></div>"
+    "<div><div class=dlab>Mode</div><div class=dval id=d-mode>--</div></div>"
+    "<div><div class=dlab>Fault</div><div class=dval id=d-fault>--</div></div>"
+    "</div>"
+    "<canvas id=d-chart></canvas>"
+    "<div style='display:flex;justify-content:space-between;align-items:center'>"
+    "<small><span style='color:#3399ff'>\xE2\x97\x8F</span> chamber "
+    "<span style='color:#ff8a49'>\xE2\x97\x8F</span> element</small>"
+    "<small id=d-stat>0 samples</small></div>"
+    "<div class=drow style='margin-top:10px'>"
+    "<button type=button class=go id=d-dl>Download CSV</button>"
+    "<button type=button class=sec id=d-clear>Clear</button>"
+    "</div></div>"
+    "<p style='text-align:center'><small><a href='/'>\xE2\x86\x90 Back to status</a></small></p>"
+    "<div id=ver style='text-align:center;color:var(--muted);font-size:.72rem;margin-top:2px'></div>"
+    "<script>(function(){"
+    "var peak=0,samples=[],t0=null,MAX=900;"      // cap ~30 min at 2 s to bound the tab's memory
+    "function $(i){return document.getElementById(i);}"
+    "if(window.DB_VER)$('ver').textContent='DragonBreath '+window.DB_VER;"
+    "fetch('/api/v2/info',{cache:'no-store'}).then(function(r){return r.json();}).then(function(i){"
+    "$('d-meta').innerHTML='<small>device '+i.device_id+' \\u00b7 fw '+i.firmware+' \\u00b7 Rref '+i.rref_kohm+'k</small>';"
+    "}).catch(function(){});"
+    "function f1(x){return (x==null)?'--':Number(x).toFixed(1);}"
+    "function apply(s){"
+    "if(!s||s.api_version!==2)return;"
+    "var ch=s.sensors.chamber,pt=s.sensors.ptc,saf=s.safety||{};"
+    "var chv=ch.temperature_c,ptv=pt.temperature_c,out=!!s.heater.output,fl=!!saf.fault_latched;"
+    "if(ptv!=null&&ptv>peak)peak=ptv;"
+    "$('d-ch').textContent=f1(chv)+' \\u00b0C';"
+    "$('d-ptc').textContent=f1(ptv)+' \\u00b0C'+(pt.status!=='ok'?' ('+pt.status+')':'');"
+    "$('d-peak').textContent=f1(peak)+' \\u00b0C';"
+    "$('d-ssr').textContent=out?'ON':'off';"
+    "$('d-mode').textContent=s.mode;"
+    "var fe=$('d-fault');fe.textContent=fl?('FAULT: '+(saf.reason||'?')):'none';fe.className='dval'+(fl?' warn':'');"
+    "var now=Date.now()/1000;if(t0==null)t0=now;"
+    "samples.push({t:now-t0,ch:chv,pt:ptv,ps:pt.status,o:out?1:0,m:s.mode,fl:fl?1:0,rs:saf.reason||'',pk:peak});"
+    "if(samples.length>MAX)samples.shift();"
+    "$('d-stat').textContent=samples.length+' samples';draw();"
+    "}"
+    "function draw(){"
+    "var c=$('d-chart');var w=c.clientWidth||300,h=120;c.width=w;c.height=h;"
+    "var x=c.getContext('2d');x.clearRect(0,0,w,h);if(samples.length<2)return;"
+    "var mx=1;samples.forEach(function(s){if(s.ch!=null&&s.ch>mx)mx=s.ch;if(s.pt!=null&&s.pt>mx)mx=s.pt;});"
+    "mx=Math.ceil(mx/20)*20;"
+    "function px(i){return i*(w-4)/(samples.length-1)+2;}"
+    "function py(v){return h-4-(v/mx)*(h-8);}"
+    "function ln(k,col){x.beginPath();x.strokeStyle=col;x.lineWidth=1.5;var st=false;"
+    "for(var i=0;i<samples.length;i++){var v=samples[i][k];if(v==null){st=false;continue;}"
+    "if(!st){x.moveTo(px(i),py(v));st=true;}else x.lineTo(px(i),py(v));}x.stroke();}"
+    "ln('pt','#ff8a49');ln('ch','#3399ff');"
+    "}"
+    "$('d-dl').addEventListener('click',function(){"
+    "var r=['t_s,chamber_c,ptc_c,ptc_status,out,mode,fault,reason,peak_c'];"
+    "samples.forEach(function(s){r.push([s.t.toFixed(1),(s.ch==null?'':s.ch.toFixed(1)),(s.pt==null?'':s.pt.toFixed(1)),s.ps,s.o,s.m,s.fl,'\"'+String(s.rs).replace(/\"/g,'\"\"')+'\"',s.pk.toFixed(1)].join(','));});"
+    "var b=new Blob([r.join('\\n')+'\\n'],{type:'text/csv'});"
+    "var a=document.createElement('a');a.href=URL.createObjectURL(b);a.download='dragonbreath_diag.csv';a.click();"
+    "setTimeout(function(){URL.revokeObjectURL(a.href);},1000);"
+    "});"
+    "$('d-clear').addEventListener('click',function(){samples=[];peak=0;t0=null;$('d-stat').textContent='0 samples';draw();});"
+    "window.addEventListener('resize',draw);"
+    "var es=new EventSource('/api/v2/events');"
+    "function ev(e){try{apply(JSON.parse(e.data));}catch(_){}}"
+    "es.addEventListener('state',ev);es.addEventListener('telemetry',ev);"
+    "})();</script></body></html>";
+
+// Live diagnostics page (GET /diag). Read-only; reuses the SSE stream.
+static esp_err_t diag_page(httpd_req_t *req)
+{
+    httpd_resp_set_type(req, "text/html; charset=utf-8");
+    SEND(req, PAGE_HEAD);           // header-free (like /fw) — no PAGE_HDR
+    SEND(req, WRAP_OPEN);
+    send_version_inject(req);       // window.DB_VER for the footer
+    SEND(req, DIAG_BODY);
+    return httpd_resp_send_chunk(req, NULL, 0);
+}
+
+// Firmware console page (GET /console): the raw ESP_LOGx stream captured into the
+// pb_evlog byte ring, fetched from the auth-gated GET /api/v2/console and shown in a
+// scrolling monospace view with auto-refresh + Download. Read-only / non-interactive.
+// The device page itself is open (a GET can't carry the auth header); the DATA fetch
+// is gated (JS sends X-DragonBreath-Auth), so the chatty log isn't world-readable.
+static const char CONSOLE_BODY[] =
+    "<style>"
+    // Widen the console page well past the default 28em so ~80-column log lines fit
+    // as real lines instead of wrapping mid-content.
+    ".wrap{max-width:min(96vw,900px)}"
+    // Terminal-style: monospace, NO wrap, horizontal scroll for long lines.
+    "#c-log{font:12px/1.4 ui-monospace,Menlo,Consolas,monospace;white-space:pre;tab-size:4;"
+    "background:var(--input);border-radius:8px;padding:10px 12px;"
+    "max-height:70vh;overflow:auto;margin:.4em 0}"
+    ".drow{display:flex;gap:8px}.drow button{flex:1;margin-top:0}"
+    "</style>"
+    "<div class=card><h2>Console</h2>"
+    "<div id=c-meta><small>firmware log\xE2\x80\xA6</small></div>"
+    "<pre id=c-log>loading\xE2\x80\xA6</pre>"
+    "<div class=drow>"
+    "<button type=button class=go id=c-dl>Download</button>"
+    "<button type=button class=sec id=c-pause>Pause</button>"
+    "</div></div>"
+    "<p style='text-align:center'><small><a href='/'>\xE2\x86\x90 Back to status</a></small></p>"
+    "<div id=ver style='text-align:center;color:var(--muted);font-size:.72rem;margin-top:2px'></div>"
+    "<script>" DB_AUTH_JS
+    "(function(){"
+    "var paused=false,last='';"
+    "function $(i){return document.getElementById(i);}"
+    "if(window.DB_VER)$('ver').textContent='DragonBreath '+window.DB_VER;"
+    "function load(){"
+    "fetch('/api/v2/console',{cache:'no-store',headers:hdr()}).then(function(r){"
+    "if(r.status==403){localStorage.removeItem('db_tok');"
+    "$('c-meta').innerHTML='<small class=warn>Auth rejected \\u2014 reload and re-enter the control token.</small>';return null;}"
+    "return r.text();"
+    "}).then(function(t){"
+    "if(t==null)return;t=t.replace(/\\x1b\\[[0-9;]*m/g,'');last=t;var pre=$('c-log');"
+    "var atEnd=pre.scrollTop+pre.clientHeight>=pre.scrollHeight-6;"
+    "pre.textContent=t||'(no log captured yet)';"
+    "if(atEnd)pre.scrollTop=pre.scrollHeight;"
+    "$('c-meta').innerHTML='<small>'+t.length+' bytes \\u00b7 '+(paused?'paused':'auto-refresh 2s')+'</small>';"
+    "}).catch(function(){});"
+    "}"
+    "$('c-dl').addEventListener('click',function(){"
+    "var b=new Blob([last||''],{type:'text/plain'});"
+    "var a=document.createElement('a');a.href=URL.createObjectURL(b);a.download='dragonbreath-console.txt';a.click();"
+    "setTimeout(function(){URL.revokeObjectURL(a.href);},1000);"
+    "});"
+    "$('c-pause').addEventListener('click',function(){paused=!paused;this.textContent=paused?'Resume':'Pause';if(!paused)load();});"
+    "load();setInterval(function(){if(!paused)load();},2000);"
+    "})();</script></body></html>";
+
+// Firmware console page (GET /console). Header-free (like /fw); auth bootstrap so
+// the JS can fetch the gated /api/v2/console.
+static esp_err_t console_page(httpd_req_t *req)
+{
+    httpd_resp_set_type(req, "text/html; charset=utf-8");
+    SEND(req, PAGE_HEAD);
+    SEND(req, WRAP_OPEN);
+    send_auth_inject(req);          // DB_TOK / DB_NEEDTOK for the gated fetch
+    send_version_inject(req);
+    SEND(req, CONSOLE_BODY);
+    return httpd_resp_send_chunk(req, NULL, 0);
+}
+
 // Wi-Fi + control-source config page (AP captive root, and /setup in STA mode).
 // The device binds to exactly ONE control source; the card carries all three
 // field groups and reveals only the selected one (JS). Non-secret values are
@@ -642,6 +804,8 @@ esp_err_t pb_portal_start(void)
     httpd_uri_t scan   = { .uri = "/scan.json", .method = HTTP_GET,  .handler = scan_json };
     httpd_uri_t setup  = { .uri = "/setup",     .method = HTTP_GET,  .handler = config_page };
     httpd_uri_t fw     = { .uri = "/fw",        .method = HTTP_GET,  .handler = fw_page };
+    httpd_uri_t diag   = { .uri = "/diag",      .method = HTTP_GET,  .handler = diag_page };
+    httpd_uri_t cons   = { .uri = "/console",   .method = HTTP_GET,  .handler = console_page };
     httpd_uri_t favic  = { .uri = "/favicon.ico", .method = HTTP_GET, .handler = favicon_ico };
     httpd_uri_t root   = { .uri = "/*",          .method = HTTP_GET,  .handler = root_page };
     httpd_register_uri_handler(s, &save);
@@ -649,6 +813,8 @@ esp_err_t pb_portal_start(void)
     httpd_register_uri_handler(s, &scan);
     httpd_register_uri_handler(s, &setup);
     httpd_register_uri_handler(s, &fw);
+    httpd_register_uri_handler(s, &diag);
+    httpd_register_uri_handler(s, &cons);
     httpd_register_uri_handler(s, &favic);  // before the catch-all so /favicon.ico != SPA
     httpd_register_uri_handler(s, &root);   // catch-all LAST (captive-portal probes)
 

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -18,6 +18,7 @@
 #include "nvs.h"
 #include <stdbool.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "pb_board.h"
 #include "pb_ntc.h"
@@ -254,16 +255,40 @@ static void control_task(void *arg)
             pb_policy_get_snapshot(&snap);
             uint32_t zc = 0, zciv = 0;
             pb_fan_zc_diag(&zc, &zciv);
-            ESP_LOGI(TAG,
+            // Build the status line WITHOUT the ZC counters (which change every
+            // sample). Collapse consecutive identical states into a single
+            // "repeated Nx" instead of spamming a line every 2 s — this keeps the
+            // /console ring (and the serial log) readable. A liveness flush every
+            // ~30 samples (~60 s) still shows the device is alive during a long
+            // unchanged run.
+            static char     s_dbg_last[224];
+            static uint32_t s_dbg_rep;
+            char line[224];
+            snprintf(line, sizeof line,
                 "rev=%lu mode=%s source=%s target=%.0fC heater=%s | chamber=%.1fC ptc=%.1fC | "
-                "wifi=%d src=%s mk=%d printer=%s bed=%.1f | ZC n=%lu dt=%luus",
+                "wifi=%d src=%s mk=%d printer=%s bed=%.1f",
                 (unsigned long)snap.state_revision,
                 pb_policy_mode_str(snap.mode), pb_policy_source_str(snap.source),
                 snap.effective_target_c, snap.heater_output ? "ON" : "off",
                 snap.chamber_c, snap.ptc_c,
                 net ? (int)pb_wifi_state() : -1, pb_source_str(s_src), (int)st.state,
-                pb_printer_state_str(st.printer), st.bed_temp,
-                (unsigned long)zc, (unsigned long)zciv);
+                pb_printer_state_str(st.printer), st.bed_temp);
+
+            if (strcmp(line, s_dbg_last) == 0) {
+                s_dbg_rep++;
+                if (s_dbg_rep % 30 == 0)   // ~60 s liveness flush during a long run
+                    ESP_LOGI(TAG, "%s | repeated %lux | ZC n=%lu dt=%luus",
+                             line, (unsigned long)s_dbg_rep,
+                             (unsigned long)zc, (unsigned long)zciv);
+            } else {
+                if (s_dbg_rep > 0)
+                    ESP_LOGI(TAG, "(previous line repeated %lux)", (unsigned long)s_dbg_rep);
+                ESP_LOGI(TAG, "%s | ZC n=%lu dt=%luus",
+                         line, (unsigned long)zc, (unsigned long)zciv);
+                strncpy(s_dbg_last, line, sizeof s_dbg_last - 1);
+                s_dbg_last[sizeof s_dbg_last - 1] = '\0';
+                s_dbg_rep = 0;
+            }
         }
 
         // Wait for the next periodic deadline, but wake early on a notification

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -295,6 +295,11 @@ static void control_task(void *arg)
 
 void app_main(void)
 {
+    // Install the console-capture hook FIRST so the whole app_main boot log is
+    // teed into the ring served by /console (the device may have no reachable
+    // serial port). Cheap + no dependencies; safe before anything else.
+    pb_evlog_console_init();
+
     ESP_LOGI(TAG, "DragonBreath starting");
 
     pb_evlog_init();

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -263,6 +263,8 @@ static void control_task(void *arg)
             // unchanged run.
             static char     s_dbg_last[224];
             static uint32_t s_dbg_rep;
+            int wifi = net ? (int)pb_wifi_state() : -1;
+            // Displayed line: 0.1 °C precision.
             char line[224];
             snprintf(line, sizeof line,
                 "rev=%lu mode=%s source=%s target=%.0fC heater=%s | chamber=%.1fC ptc=%.1fC | "
@@ -271,10 +273,22 @@ static void control_task(void *arg)
                 pb_policy_mode_str(snap.mode), pb_policy_source_str(snap.source),
                 snap.effective_target_c, snap.heater_output ? "ON" : "off",
                 snap.chamber_c, snap.ptc_c,
-                net ? (int)pb_wifi_state() : -1, pb_source_str(s_src), (int)st.state,
+                wifi, pb_source_str(s_src), (int)st.state,
+                pb_printer_state_str(st.printer), st.bed_temp);
+            // Dedup key: same fields but temps rounded to whole degrees, so sub-degree
+            // sensor drift/jitter doesn't re-trigger a fresh line every 2 s.
+            char key[224];
+            snprintf(key, sizeof key,
+                "rev=%lu mode=%s source=%s target=%.0fC heater=%s | chamber=%.0fC ptc=%.0fC | "
+                "wifi=%d src=%s mk=%d printer=%s bed=%.0f",
+                (unsigned long)snap.state_revision,
+                pb_policy_mode_str(snap.mode), pb_policy_source_str(snap.source),
+                snap.effective_target_c, snap.heater_output ? "ON" : "off",
+                snap.chamber_c, snap.ptc_c,
+                wifi, pb_source_str(s_src), (int)st.state,
                 pb_printer_state_str(st.printer), st.bed_temp);
 
-            if (strcmp(line, s_dbg_last) == 0) {
+            if (strcmp(key, s_dbg_last) == 0) {
                 s_dbg_rep++;
                 if (s_dbg_rep % 30 == 0)   // ~60 s liveness flush during a long run
                     ESP_LOGI(TAG, "%s | repeated %lux | ZC n=%lu dt=%luus",
@@ -285,7 +299,7 @@ static void control_task(void *arg)
                     ESP_LOGI(TAG, "(previous line repeated %lux)", (unsigned long)s_dbg_rep);
                 ESP_LOGI(TAG, "%s | ZC n=%lu dt=%luus",
                          line, (unsigned long)zc, (unsigned long)zciv);
-                strncpy(s_dbg_last, line, sizeof s_dbg_last - 1);
+                strncpy(s_dbg_last, key, sizeof s_dbg_last - 1);
                 s_dbg_last[sizeof s_dbg_last - 1] = '\0';
                 s_dbg_rep = 0;
             }

--- a/plans/diag-console-pages.md
+++ b/plans/diag-console-pages.md
@@ -1,0 +1,137 @@
+# RFC: `/diag` and `/console` web pages
+
+Status: **Draft / design.** Two read-only, non-interactive web pages served by the
+device — a diagnostics telemetry view and a firmware console log — themed to match
+`/fw` and `/setup`, each with a `[Download]` button. No on-device persistence.
+
+## Motivation
+
+The new BIGTREETECH Panda revision **has no external USB port** — the first
+DragonBreath install means opening the unit, and after that there is **no way to
+reach the serial console without opening it again**. On top of that, **release
+builds repurpose the UART TX pin (GPIO21) as the Power LED** (`CONFIG_PB_POWER_LED`),
+so a shipped device effectively has *no* serial console at all: `ESP_LOGx` output is
+generated but goes nowhere reachable.
+
+So the only practical way to see what the firmware is doing — boot sequence,
+Wi-Fi/mDNS/broker chatter, warnings, a fault's context — is **over the web**. That
+is what `/console` is for. `/diag` is the companion: a live telemetry view (the
+`tools/diag.py` logger, in the browser) so you don't have to run a host script.
+
+## What already exists (so we don't rebuild it)
+
+- **`/api/v2/state` + SSE `/api/v2/events`** — full telemetry (chamber, PTC/element,
+  SSR output, mode, fault+reason, sensor status), pushed ~every 2 s and on every
+  transition. `tools/diag.py` is just a 2 Hz poll of this plus a client-side running
+  peak + CSV.
+- **`/api/v2/logs`** — the **event ring** (`pb_evlog`, 64 × 96 B `{ms,text}`), the
+  *curated* notable events (mode/fault transitions). **Already rendered** in the
+  dashboard's Settings → "Event log". This is NOT the raw `ESP_LOGx` stream — nothing
+  captures that today.
+
+Implication: `/diag` is almost entirely a **new front-end over existing data**;
+`/console` needs a **new capture path** (the raw log stream is not retained anywhere).
+
+## Feature 1 — `/diag` (telemetry view)
+
+Client-side page, **zero new device RAM**. Reuses SSE + `/api/v2/info` (for
+`rref_kohm`). Presents what `diag.py` prints:
+
+- chamber temp, element (PTC) temp, SSR output, mode, fault + reason, sensor status,
+- **running peak element temp** (computed in-browser since page open),
+- a live trend (reuse the dashboard's chart),
+- **`[Download]` → CSV** of everything accumulated in the browser since the page was
+  opened (same columns as `diag.py`: `t_s,chamber_c,ptc_c,ptc_status,out,mode,fault,reason,peak_c`).
+  Generated in-page; nothing is stored on the device.
+
+Caveat: it's a *live* view at SSE cadence (~2 s + transitions). It cannot back-fill
+history from before the page opened — the device keeps no telemetry log (only the
+64-event ring). Reviewing a *past* print's full time-series would require on-device
+flash logging, which is explicitly **out of scope** (see below).
+
+## Feature 2 — `/console` (firmware log stream)
+
+The genuinely new capability: capture the `ESP_LOGx` stream into a RAM ring and serve
+it.
+
+- **Capture:** install an `esp_log_set_vprintf` hook that (a) formats the line into a
+  fixed **static byte ring** and (b) forwards to the original vprintf so UART output
+  (where wired) is unchanged. Byte ring (not fixed line slots) to avoid per-line
+  padding waste and handle variable-length lines.
+- **Size:** **16 KB** (~180 lines). Static allocation, never grows. See RAM analysis.
+- **Boot capture:** initialise the ring + hook **very early in `app_main`**, before
+  other subsystem init, so the **boot sequence is captured** (the whole point on a
+  no-USB device).
+- **Concurrency:** the hook runs from many task contexts and must be **lock-safe,
+  non-blocking, and non-recursive** (never log from inside the hook; guard the ring
+  with a portMUX spinlock or a lock-free single-writer discipline). It must not call
+  anything that can block or re-enter the logger.
+- **Endpoint:** `GET /api/v2/console` returns the ring as `text/plain` (oldest →
+  newest, wrap handled). The page polls it (~1–2 s; SSE is possible later but polling
+  is simpler and the volume is low).
+- **`[Download]`** → save the current ring as `dragonbreath-console.txt`.
+
+## RAM analysis (measured on the bench)
+
+The `/diag` view costs zero device RAM. The console ring is the only new cost.
+
+| Mode | Transport | Free heap | Min watermark |
+|---|---|---|---|
+| Klipper | WebSocket (no TLS) | ~156 KB | **~121 KB** (14 h uptime) |
+| HA | plain MQTT :1883 (no TLS) | ~153 KB | ~142 KB (fresh boot) |
+| Bambu | MQTT-over-TLS (mbedTLS) | — | **not yet measurable** (no printer) |
+
+Bambu is the RAM worst case (only mode pulling in mbedTLS); a TLS 1.2 handshake peaks
+~25–45 KB. Pessimistically: ~121 KB − ~45 KB TLS − 16 KB ring ≈ **~60 KB free** at the
+worst instant — comfortable. A 16 KB static ring is a fixed, one-time reduction and
+does not interact with the TLS spike dynamically. **RAM is not a constraint**; re-check
+the Bambu/TLS headroom on hardware once a tester has a printer.
+
+## Shared scaffolding
+
+Both pages reuse the existing themed chrome (`PAGE_HEAD` / `PAGE_HDR` / `WRAP_OPEN`,
+light-dark tokens, product header, `DB_AUTH_JS`) exactly like `/fw` and `/setup`.
+Registered as `GET /diag` and `GET /console` in `pb_portal`. Factor the shared bits
+while adding `/diag` first.
+
+## Decisions
+
+- **Ring size:** 16 KB (~180 lines) — headroom is ample and more scrollback is more
+  useful for a boot/debug log reachable only over the web.
+- **Auth:** `/diag` **open** (telemetry only, same as the dashboard reads).
+  `/console` **gated behind the control token** — the raw log is chattier (IPs,
+  Wi-Fi/mDNS detail) and it's a debug tool; falls back to open when no token is set,
+  consistent with the rest of the UI.
+- **Non-interactive:** both are strictly read-only. No command input on `/console`,
+  so there is no injection surface.
+- **Capture scope:** tee whatever the build already logs (release = INFO and up);
+  no separate log-level control in v1.
+
+## Implementation plan
+
+1. **`/diag`** (front-end only, zero firmware risk): shared page scaffolding + the
+   SSE-driven telemetry view + client-side CSV download.
+2. **`/console`**:
+   - `pb_evlog` (or a new `pb_conlog`) gains a 16 KB byte ring + `esp_log_set_vprintf`
+     hook, initialised early in `app_main`.
+   - `GET /api/v2/console` (auth-gated) returns the ring as text.
+   - `/console` page (themed, polling, auto-scroll, `[Download]`).
+3. Docs: `FEATURES.md` / `api-v2.md` note the two pages + the `/api/v2/console`
+   endpoint; mention the no-USB / TX=LED rationale.
+
+## Out of scope
+
+- **On-device persistence / flash logging.** Neither page stores data; both are live
+  windows (telemetry since page-open; the rolling 16 KB log ring). Reviewing a past
+  print's full history is a separate, larger design (wear, flash budget) and is not
+  part of this.
+- Interactive console / command input.
+- An SSE log stream (polling is enough for v1; can add later).
+
+## Open questions
+
+- Confirm the `esp_log_set_vprintf` hook composes cleanly with the existing UART
+  console and the `CONFIG_PB_POWER_LED` TX-repurposing (verify on a release build).
+- Ring size final (16 KB proposed) vs. a `Kconfig`-tunable.
+- Whether `/console` should also fold in the `pb_evlog` curated events inline, or keep
+  them separate (Settings already shows the event ring).


### PR DESCRIPTION
Design doc (docs-only) for two read-only, non-interactive pages served by the device, themed like `/fw` and `/setup`, each with a `[Download]` button and **no on-device persistence**.

## Why
The new Panda revision has **no external USB**, and **release builds repurpose UART TX (GPIO21) as the Power LED** — so the serial console is physically unreachable on a shipped unit. `/console` makes the firmware log readable over the web; `/diag` puts the `diag.py` telemetry logger in the browser.

## `/diag` — telemetry (zero new device RAM)
Client-side over existing SSE + `/api/v2/info`: chamber/element temps, SSR output, mode, fault+reason, running peak, live trend, and a client-side **CSV** download. Live-only (no back-fill; the device keeps no telemetry history).

## `/console` — firmware log (the only new device RAM)
`esp_log_set_vprintf` hook tees every `ESP_LOGx` line into a **16 KB static ring** (init early to capture boot), served at a new **`GET /api/v2/console`**; the page polls it and offers a `.txt` download. Lock-safe / non-blocking / non-recursive hook.

## RAM (measured on the bench)
| Mode | Transport | Min free heap |
|---|---|---|
| Klipper | WebSocket | ~121 KB |
| HA | plain MQTT :1883 | ~142 KB |
| Bambu | MQTT/TLS | not yet measurable |

Even pessimistically (Bambu/TLS: ~121 − 45 TLS − 16 ring ≈ 60 KB free), a 16 KB static ring is safe in every mode. `/diag` adds none.

## Decisions
- Ring size **16 KB** (~180 lines).
- Auth: `/diag` **open**; `/console` **token-gated** (raw log is chattier).
- Sequence: `/diag` first (zero firmware risk), then `/console`.

## Out of scope
On-device/flash logging + history; interactive console; SSE log stream.

Doc: `plans/diag-console-pages.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)