### PR TITLE
feat(ota): accept stock Panda images for WiFi revert (v1.0.0-rc1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+## [1.0.0-rc1] - 2026-07-30
+
+### Added
+- **Revert to stock over WiFi: `/update` now accepts stock Panda Breath images.**
+  The OTA identity gate previously accepted only `project_name == "dragonbreath"`;
+  it now also accepts **`panda_breath`** (any version — 1.0.3 / 1.0.4 both carry that
+  project name). This lets a user flash their own stock backup's **app image** back
+  through DragonBreath's own web updater and return to stock — no USB, no opening the
+  unit. All other images are still rejected. Pairs with the no-USB *install* path
+  (stock's own updater → DragonBreath), which was validated end-to-end on hardware
+  with the v0.8.0 release image.
+  - Note: upload the stock **app** image (the OTA-type `.bin` / the app partition of
+    a backup), not a full 4 MB flash dump. Reverting to a *fully working* stock this
+    way assumes DragonBreath is running in the stock partition layout (i.e. it was
+    installed via stock's OTA), so stock's spiffs/partitions are intact.
+
 ## [0.8.0] - 2026-07-30
 
 The pluggable-control-source + web-tools release. **Klipper (Moonraker) remains the

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -947,16 +947,25 @@ static esp_err_t update_post(httpd_req_t *req)
     if (err != ESP_OK)
         return ota_fail(req, "400 Bad Request", 0, "invalid firmware image");
 
-    // Identity check: only boot images that are actually DragonBreath — reject any
-    // other (even a valid ESP32-C3) app. The app descriptor's project_name comes
-    // from CMake project(dragonbreath).
+    // Identity check: accept either a DragonBreath image OR a stock Panda Breath
+    // image ("panda_breath", any version). The latter lets a user revert to stock
+    // over WiFi by uploading their own stock backup's app image — no USB needed.
+    // Everything else (any other valid ESP32-C3 app) is still rejected. The app
+    // descriptor's project_name comes from CMake project(<name>).
     esp_app_desc_t desc;
     if (esp_ota_get_partition_description(part, &desc) != ESP_OK)
         return ota_fail(req, "400 Bad Request", 0, "cannot read image descriptor");
-    if (strcmp(desc.project_name, "dragonbreath") != 0) {
-        ESP_LOGE(TAG, "OTA rejected: project_name='%s' (not dragonbreath)", desc.project_name);
-        return ota_fail(req, "400 Bad Request", 0, "not an DragonBreath image");
+    bool is_dragonbreath = strcmp(desc.project_name, "dragonbreath") == 0;
+    bool is_panda_stock  = strcmp(desc.project_name, "panda_breath") == 0;
+    if (!is_dragonbreath && !is_panda_stock) {
+        ESP_LOGE(TAG, "OTA rejected: project_name='%s' (not dragonbreath or panda_breath)",
+                 desc.project_name);
+        return ota_fail(req, "400 Bad Request", 0,
+                        "not a DragonBreath or stock Panda Breath image");
     }
+    if (is_panda_stock)
+        ESP_LOGW(TAG, "OTA: accepting stock Panda image '%s' v%s (revert to stock)",
+                 desc.project_name, desc.version);
 
     if (esp_ota_set_boot_partition(part) != ESP_OK)
         return ota_fail(req, "500 Internal Server Error", 0, "set boot partition failed");

--- a/docs/api-v2.md
+++ b/docs/api-v2.md
@@ -232,12 +232,13 @@ These predate/sit beside the versioned control surface and are stable:
   control token; `{"token":""}` / `{"token":null}` / `{}` clears it. The secret is
   never echoed; the response is `{"ok":true,"token_set":<bool>}`. Once a token is
   set, every mutating request must carry it in `X-DragonBreath-Auth`.
-- `POST /update` — authenticated DragonBreath application-image OTA. Streams the
-  `.bin` into the inactive slot, verifies it (image checksum + `dragonbreath`
-  project identity — foreign images are rejected), reports the SHA-256 it
-  computed, sets it as the boot slot, and reboots. **Refused while the heater is
-  armed/on.** A bad image that crashes before the app marks itself healthy rolls
-  back on the next boot.
+- `POST /update` — authenticated application-image OTA. Streams the `.bin` into the
+  inactive slot, verifies it (image checksum + project identity — accepts a
+  `dragonbreath` image **or** a stock `panda_breath` image so a user can revert to
+  stock over WiFi; all other images are rejected), reports the SHA-256 it computed,
+  sets it as the boot slot, and reboots. **Refused while the heater is armed/on.** A
+  bad image that crashes before the app marks itself healthy rolls back on the next
+  boot.
 
 The device also serves the captive-portal / dashboard HTML on `GET /` (and
 `/setup`, `/fw`, `/scan.json`, `POST /save`, `/rescan`) — the human web UI, not


### PR DESCRIPTION
DragonBreath's `/update` OTA gate accepted only `project_name == "dragonbreath"`. It now **also accepts `panda_breath`** (the stock Panda Breath project name, any version — 1.0.3/1.0.4 both carry it), so a user can upload their own stock backup's **app image** through DragonBreath's web updater and **revert to stock over WiFi** — no USB, no opening the unit. All other images still rejected.

Pairs with the no-USB **install** path (stock's own web OTA → DragonBreath), which we **validated end-to-end on hardware** this session: the v0.8.0 release image installed via the stock Panda web UI, booted under the stock bootloader, and (after a USB NVS creds inject) rejoined WiFi with Moonraker connected.

Notes:
- Upload the stock **app** image (OTA-type `.bin` / app partition), not a full 4 MB dump.
- A *fully working* revert assumes DragonBreath is running in the **stock partition layout** (installed via stock's OTA), so stock's spiffs/partitions are intact.

Cuts **v1.0.0-rc1** on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)