### PR TITLE
feat(build): stock partition layout + app-only releases (v1.0.0-rc2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,15 +72,15 @@ jobs:
             f {print}
           ' CHANGELOG.md 2>/dev/null || true)"
           install="$(cat <<EOF
-          **First install (USB, recommended — backs up stock):** download \`dragonbreath-${VERSION}-install-bundle.zip\`, verify (\`sha256sum -c SHA256SUMS.txt\`), unzip, then \`python3 flash.py --build-dir .\`.
-          Advanced single-image (only if already backed up): \`esptool.py --chip esp32c3 write_flash 0x0 dragonbreath-${VERSION}-factory.bin\`.
-          **OTA** (device already on DragonBreath): upload \`dragonbreath-${VERSION}.bin\` via the web UI (\`/fw\`).
+          **Install (no USB — recommended):** on the stock Panda web UI ("Firmware Update"), upload \`dragonbreath-${VERSION}.bin\`. It installs as an app through the stock firmware's own OTA — the stock bootloader/partitions stay in place, so you can revert to Panda later over WiFi.
+          **Update / revert (already on DragonBreath):** upload \`dragonbreath-${VERSION}.bin\` via \`/fw\`; to return to Panda, upload your stock backup's **app** image via \`/fw\`.
+          **Recovery only (USB):** from a source checkout, \`python3 tools/flash.py\` (backs up stock first). The full/factory image is not published — build it locally if you need it.
+
+          > **Alpha/beta testers:** if your unit was USB-flashed, **restore your stock backup first, then install this via the stock updater** — a stock-layout install can't be reached by OTA from a native-layout one.
 
           | asset | purpose |
           |---|---|
-          | \`dragonbreath-${VERSION}-factory.bin\` | single-file first install (flash @ 0x0) |
-          | \`dragonbreath-${VERSION}.bin\` | application image for OTA |
-          | \`dragonbreath-${VERSION}-install-bundle.zip\` | all components + flasher + FLASHING.txt |
+          | \`dragonbreath-${VERSION}.bin\` | application image — install via stock's OTA, or update/revert via \`/fw\` |
           | \`manifest.json\` | provenance (source SHA, ESP-IDF, vendored-core) + per-artifact SHA-256 |
           | \`SHA256SUMS.txt\` | \`sha256sum -c SHA256SUMS.txt\` |
           EOF
@@ -95,9 +95,10 @@ jobs:
           flags=(--title "${VERSION}" --notes "$notes")
           [ "$IS_TAG" = "true" ] || flags+=(--draft)
           case "$VERSION" in *alpha*|*beta*|*rc*) flags+=(--prerelease);; esac
+          # App-only release: the OTA app image is the product. The factory image
+          # + install bundle are still built (recovery/dev machinery stays in the
+          # repo) but no longer published — install/revert is app-only over stock OTA.
           gh release create "$VERSION" "${flags[@]}" \
             "dist/dragonbreath-${VERSION}.bin" \
-            "dist/dragonbreath-${VERSION}-factory.bin" \
-            "dist/dragonbreath-${VERSION}-install-bundle.zip" \
             dist/manifest.json \
             dist/SHA256SUMS.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+## [1.0.0-rc2] - 2026-07-30
+
+### Changed
+- **Canonical partition layout is now the stock Panda layout.** `partitions.csv`
+  matches stock byte-for-byte (app slots 1920 K @ 0x10000 / 0x1f0000, otadata @
+  0xe000, nvs 20 K, plus spiffs + coredump; `phy_init` dropped — PHY is embedded in
+  the app). DragonBreath now installs and reverts as a plain **app through stock's
+  own OTA**, leaving the stock bootloader / partition table / spiffs in place — which
+  is what makes the WiFi revert-to-Panda (rc1) reliable. Layout confirmed **identical
+  on stock 1.0.3 AND 1.0.4.**
+- **Releases are app-only.** Only the OTA app image (`dragonbreath-vX.Y.Z.bin`) +
+  `manifest.json` + `SHA256SUMS.txt` are published. The full/factory image and USB
+  install bundle are **no longer attached to releases** — the build machinery and
+  `tools/flash.py` stay in the repo for recovery/dev. Install via the stock updater;
+  USB is recovery-only.
+- `tools/flash.py` USB offsets updated to the stock layout (otadata @ 0xe000, app
+  slot @ 0x10000).
+
+### Upgrade note (alpha/beta testers — do this before 1.0)
+- If your unit was **USB-flashed** (native layout), **restore your stock backup
+  first, then install 1.0 via the stock updater.** A stock-layout install can't be
+  reached by OTA from a native-layout one; reverting to a clean stock baseline first
+  removes the variability.
+
 ## [1.0.0-rc1] - 2026-07-30
 
 ### Added

--- a/partitions.csv
+++ b/partitions.csv
@@ -1,17 +1,14 @@
-# DragonBreath partition table — ESP32-C3, 4MB flash, dual-OTA.
+# DragonBreath partition table — matches the STOCK Panda Breath layout byte-for-byte
+# (confirmed identical on stock 1.0.3 AND 1.0.4). DragonBreath ships as an app that
+# installs and reverts through stock's OWN OTA, so the stock bootloader + partition
+# table + spiffs stay on the chip untouched. This table is used only for the
+# USB/recovery "factory" image and to size the app partition; PHY data is embedded
+# in the app (no phy_init partition, matching stock).
 #
-# TODO (before first flash): reconcile the flashing strategy.
-#   - If we KEEP the stock 2nd-stage bootloader, this table's offsets/layout must
-#     match what that bootloader expects, or we flash our own bootloader + table
-#     (full image) via the CH340K UART in download mode. The stock bootloader is
-#     NOT to be modified per project constraint; a full own-image flash replaces
-#     it wholesale and is the cleaner path. Verify before writing to hardware.
-#   - `nvs` is kept at the conventional offset; if we want to preserve/read stock
-#     NVS ("app_nvs" namespace) confirm the stock nvs offset/size and match it.
-#
-# Name,     Type, SubType, Offset,   Size
-nvs,        data, nvs,     0x9000,   0x6000,
-otadata,    data, ota,     0xf000,   0x2000,
-phy_init,   data, phy,     0x11000,  0x1000,
-ota_0,      app,  ota_0,   0x20000,  0x1D0000,
-ota_1,      app,  ota_1,   0x1F0000, 0x1D0000,
+# Name,     Type, SubType,  Offset,   Size
+nvs,        data, nvs,      0x9000,   0x5000,
+otadata,    data, ota,      0xe000,   0x2000,
+app0,       app,  ota_0,    0x10000,  0x1E0000,
+app1,       app,  ota_1,    0x1f0000, 0x1E0000,
+spiffs,     data, spiffs,   0x3d0000, 0x2F000,
+coredump,   data, coredump, 0x3ff000, 0x1000,

--- a/plans/stock-layout-canonical.md
+++ b/plans/stock-layout-canonical.md
@@ -1,0 +1,105 @@
+# RFC: Stock partition layout as canonical + app-only releases (the 1.0 model)
+
+Status: **Draft / design — for review.** Make DragonBreath a stock-layout app that
+installs and reverts entirely through the stock firmware's own OTA, ship **only the
+app image**, and keep the full-image/USB machinery in the repo for recovery only.
+
+## Why (recap of the reversibility analysis)
+
+Reverting to Panda over WiFi (v1.0.0-rc1's `/update` accepting `panda_breath` images)
+only works cleanly when the **stock bootloader, partition table, and spiffs/nvs data
+are still on the chip** — i.e. when DragonBreath was installed via stock's OTA and
+lives in a stock app slot. A USB full-flash wipes all of that, so it can't cleanly
+revert. The fix isn't "match the layout and keep full-flashing" — it's **never
+replace the stock bootloader/spiffs at all**: ship DragonBreath as an app that runs
+inside the stock partition environment.
+
+This also means we **stop distributing (and stop replacing BIQU's) bootloader +
+partition table** — a lighter footprint and a cleaner story.
+
+## The change
+
+### 1. Canonical partition table = stock layout
+Replace `partitions.csv` with the stock geometry (decoded from the 1.0.3 image):
+
+```
+# was (native)                             # now (stock-matching)
+nvs      nvs   0x9000  0x6000              nvs      nvs      0x9000  0x5000 (20K)
+otadata  ota   0xf000  0x2000              otadata  ota      0xe000  0x2000
+phy_init phy   0x11000 0x1000       →      (dropped — PHY is embedded in the app)
+ota_0    app   0x20000 0x1D0000            ota_0    app      0x10000 0x1E0000 (1920K)
+ota_1    app   0x1F0000 0x1D0000           ota_1    app      0x1f0000 0x1E0000 (1920K)
+                                           spiffs   spiffs   0x3d0000 0x2F000 (188K)
+                                           coredump coredump 0x3ff000 0x1000
+```
+
+Our app (~1.05 MB) fits the 1920 K slots. We don't use `spiffs`, but keep it at
+stock's offset so the layout is byte-for-byte stock (so a reverted `panda_breath`
+app finds its assets region). PHY stays embedded (already the case). Keep the table
+MD5 (stock uses it).
+
+### 2. Releases ship the app OTA image only
+- **Publish:** `dragonbreath-vX.Y.Z.bin` (the app), `manifest.json`, `SHA256SUMS.txt`.
+- **Stop publishing:** `-factory.bin` and `-install-bundle.zip`.
+- **Keep in the repo:** the full-image build (bootloader + table + app), `tools/flash.py`,
+  and the factory/bundle machinery — for **recovery/dev only**, just not attached to
+  releases. (Anyone can still `idf.py build` a factory image locally.)
+
+Rationale: with app-only-over-stock-OTA as the one supported install, the factory
+image and USB flasher are no longer the product — they're the safety net.
+
+### 3. Install & revert (the only supported flows)
+- **Install:** stock web UI → Firmware Update → upload `dragonbreath-vX.Y.Z.bin`
+  → boots under the stock bootloader in a stock slot. (Validated on hardware with
+  v0.8.0.)
+- **Revert:** DragonBreath web UI → `/update` → upload the stock **app** image from
+  your backup → back to Panda. (v1.0.0-rc1; stock bootloader/spiffs intact → clean.)
+- **Recovery (rare):** USB `tools/flash.py --restore <backup>` — unchanged.
+
+## Alpha/beta tester migration (important — do before 1.0)
+
+Most alpha/beta units were **USB-flashed in the native layout** this session, so they
+can't cleanly OTA-upgrade to a stock-layout 1.0 app. **Strong recommendation, to
+eliminate layout variability:**
+
+1. **Revert to your stock backup first** — `tools/flash.py --restore <your-stock-backup.bin>`
+   over USB (the one USB step). You're back on clean stock.
+2. **Install 1.0 via stock's own Firmware Update** — upload `dragonbreath-v1.0.0.bin`.
+
+Now you're on the same stock-layout footing as every new user, and every future
+update/revert is app-only over WiFi. (Skipping step 1 and trying to OTA 1.0 onto a
+native-layout install will land you in a mismatched partition state.)
+
+## Version-compat checklist (before shipping 1.0 final)
+- Layout **confirmed identical on stock 1.0.3 AND 1.0.4** (decoded both backups:
+  same nvs/otadata/ota_0/ota_1/spiffs/coredump offsets + sizes). Coupling risk is
+  minimal. Re-check on any future stock that changes slot geometry.
+- Confirm a first boot on a stock-populated NVS is clean (ignore unknown stock keys).
+- Confirm the stock bootloader boots the 1.0 app on both 1.0.3 and 1.0.4.
+
+## Tradeoffs
+- **Pro:** one image; clean WiFi install *and* revert; we don't ship/replace BIQU's
+  bootloader; simpler releases; smaller attack/impact surface.
+- **Con:** DragonBreath is now **coupled to the stock bootloader + partition scheme**
+  — a future stock layout change could require an app that still fits it (hence the
+  version-compat check). We inherit stock's 20 K nvs (fine) and carry an unused spiffs.
+- **Inherent:** a USB full-flash still wipes stock spiffs/bootloader, so USB-installed
+  units still can't cleanly revert — which is why USB is demoted to recovery only.
+
+## Implementation checklist (once approved)
+1. Swap `partitions.csv` → stock layout; drop `phy_init`; rebuild; host tests + CI green.
+2. Re-validate on hardware: stock-OTA install of the new app, then a revert pass
+   (upload a stock `panda_breath` app back).
+3. `release.yml`: publish only the app image + manifest + sums; stop attaching
+   factory/bundle (keep the build steps/machinery, just don't upload).
+4. Docs: README/FEATURES — "install via stock's updater; USB is recovery-only";
+   add the tester-migration note; update the SAFETY/partition notes.
+5. Cut **v1.0.0** (final) once 1.0.4 layout is verified.
+
+## Out of scope
+- Shipping any Panda image (unchanged hard line — backups are user-generated).
+- Removing the USB flasher / factory build from the repo (we keep them).
+
+Related: `plans/webflash-installer.md` (#53), which this supersedes on the install
+model (app-only, no separate installer needed for install; the backup-tool idea is
+now optional since revert is a plain `/update`).

--- a/tools/flash.py
+++ b/tools/flash.py
@@ -34,12 +34,13 @@ import sys
 
 CHIP = "esp32c3"
 FLASH_SIZE = 0x400000  # 4 MB
-# DragonBreath image layout (matches build/flash_args / partitions.csv).
+# DragonBreath image layout — matches partitions.csv (stock Panda layout: otadata
+# @ 0xe000, app slot ota_0 @ 0x10000). This is the USB/recovery "factory" write.
 IMAGES = [
     ("0x0",      "bootloader/bootloader.bin"),
     ("0x8000",   "partition_table/partition-table.bin"),
-    ("0xf000",   "ota_data_initial.bin"),
-    ("0x20000",  "dragonbreath.bin"),
+    ("0xe000",   "ota_data_initial.bin"),
+    ("0x10000",  "dragonbreath.bin"),
 ]
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 


### PR DESCRIPTION
The 1.0 delivery model: DragonBreath becomes a **stock-layout app** that installs and reverts entirely through the stock firmware's own OTA — the stock bootloader / partition table / spiffs are never replaced, which is what makes WiFi revert-to-Panda (rc1) actually reliable.

## Changes
- **`partitions.csv` = stock layout, byte-for-byte** (app slots 1920 K @ 0x10000 / 0x1f0000, otadata @ 0xe000, nvs 20 K, spiffs, coredump; `phy_init` dropped — PHY is embedded). **Confirmed identical on stock 1.0.3 AND 1.0.4** (decoded both backups). Build verified: generated table matches; app is 1.05 MB (fits 1920 K).
- **App-only releases** (`release.yml`): publish the OTA image + `manifest.json` + `SHA256SUMS.txt` only. Factory image + install bundle are still built but no longer attached — the machinery + `tools/flash.py` stay in-repo for recovery/dev. Install via the stock updater; USB is recovery-only.
- **`tools/flash.py`** USB offsets updated to the stock layout (otadata 0xe000, app 0x10000).
- Design doc: `plans/stock-layout-canonical.md`.

## Migration (alpha/beta testers)
If your unit was USB-flashed (native layout), **restore your stock backup first, then install via the stock updater** — a stock-layout install can't be reached by OTA from a native-layout one.

Cuts **v1.0.0-rc2** on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)