### PR TITLE
feat: carry WiFi + Moonraker + HA over from stock on first boot (v1.0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-07-31
+
+**Seamless config carry-over when installing over stock — WiFi, Moonraker, and Home
+Assistant now transfer automatically, with no captive-portal re-provisioning.**
+
+### Added
+- **Stock → DragonBreath NVS carry-over shim.** When DragonBreath is OTA-installed over
+  the stock Panda firmware, it reads stock's `app_nvs` blobs on first boot and populates
+  its own keys, so the device **rejoins the same WiFi and reconnects to Moonraker/HA
+  automatically:**
+  - `wifi_info` → `ssid` / `password` (rejoins WiFi — previously the OTA dropped to AP
+    setup, because stock stores WiFi as a blob under different keys than we read).
+  - `moonraker_info` → `mk_host` (`mk_port` defaults to Moonraker's `7125`, since stock's
+    port field is the printer's HTTP port).
+  - `ha_mqtt_info` → `ha_host` / `ha_user` / `ha_pass` / `ha_port` (Home Assistant MQTT).
+
+  Runs once and is non-destructive: it only fills in keys that are absent (never
+  overrides a user who provisioned via `/setup`), and the stock blobs are left intact.
+  Verified on hardware for all three (blob layouts RE'd with distinctive dummy values;
+  identical on stock 1.0.3/1.0.4). This is the linchpin for the no-USB Panda→DragonBreath
+  migration (`plans/panda-to-dragon-migration.md`).
+  Bambu (`bambu_mqtt_info`) is intentionally not carried yet — stock won't persist a
+  Bambu config without a live printer to bind, so there's no populated sample to RE from.
+
 ## [1.0.1] - 2026-07-31
 
 Makes the automatic fan-only **filtration band** work without arming AUTO mode — it now

--- a/README.md
+++ b/README.md
@@ -53,9 +53,12 @@ is still sitting there to go back to.
    ESP-IDF version, vendored-core provenance + per-artifact SHA-256).
 2. Open the **stock** Panda web UI and use its **Firmware Update** to upload that
    `.bin`. Stock writes it to the inactive OTA slot and reboots into it.
-3. DragonBreath comes up. If it doesn't rejoin your WiFi, connect to the
-   **`DragonBreath_XXXX`** AP (password **`987654321`**, same as the stock Panda) and
-   a browser should pop the setup page automatically (or open `http://192.168.4.1`).
+3. DragonBreath comes up and **rejoins your WiFi automatically** — it carries the WiFi
+   credentials (and the Moonraker host) over from the stock firmware's stored config on
+   first boot, so there's normally nothing to re-enter. If it can't join (e.g. you've
+   since changed networks), connect to the **`DragonBreath_XXXX`** AP (password
+   **`987654321`**, same as the stock Panda) and a browser should pop the setup page
+   automatically (or open `http://192.168.4.1`).
 
 > ⚠️ **Don't hold a front-panel button while powering the board on.** Power, Auto,
 > and Dry sit on ESP32-C3 strapping pins (GPIO9 is ROM download-mode); a held

--- a/components/pb_wifi/pb_wifi.c
+++ b/components/pb_wifi/pb_wifi.c
@@ -95,6 +95,89 @@ static esp_err_t nvs_write_str(const char *key, const char *value)
     return err;
 }
 
+// One-time stock->DragonBreath NVS migration. When DragonBreath is OTA-installed over
+// stock (Panda 1.0.3/1.0.4) it inherits stock's `app_nvs`, where WiFi lives in a
+// "wifi_info" blob and Moonraker in "moonraker_info" — different keys than ours. If our
+// own keys are absent, lift the creds out of the stock blobs so the OTA carries WiFi +
+// Moonraker across with NO re-provisioning. Runs once: writes our keys, then it's a
+// no-op every subsequent boot (and never overwrites a user who set creds via /setup).
+// Blob layouts RE'd from stock 1.0.4 NVS (confirmed with distinctive dummy values):
+//   wifi_info[228]:      char ssid[33]@0, char password[64]@33, ap_ssid[33]@97, ...
+//   moonraker_info[132]: char host[64]@0, uint32 port@64 (=printer :80, NOT :7125), name@68
+//   ha_mqtt_info[146]:   char host[16]@0, char user[64]@16, char pass[64]@80, uint16 port@144
+static void migrate_stock_nvs(void)
+{
+    nvs_handle_t h;
+    if (nvs_open(NVS_NS, NVS_READWRITE, &h) != ESP_OK) return;
+    size_t sz;
+
+    if (nvs_get_str(h, KEY_SSID, NULL, &sz) == ESP_ERR_NVS_NOT_FOUND) {
+        size_t blen = 0;
+        if (nvs_get_blob(h, "wifi_info", NULL, &blen) == ESP_OK && blen >= 97) {
+            uint8_t *b = calloc(1, blen);
+            if (b && nvs_get_blob(h, "wifi_info", b, &blen) == ESP_OK) {
+                char ssid[33] = {0}, pass[64] = {0};
+                memcpy(ssid, b, 32);       // ssid[33]@0, keep the trailing NUL
+                memcpy(pass, b + 33, 63);  // password[64]@33
+                if (ssid[0]) {
+                    nvs_set_str(h, KEY_SSID, ssid);
+                    nvs_set_str(h, KEY_PASS, pass);
+                    ESP_LOGW(TAG, "migrated stock WiFi (ssid '%s') from wifi_info blob", ssid);
+                }
+            }
+            free(b);
+        }
+    }
+
+    if (nvs_get_str(h, "mk_host", NULL, &sz) == ESP_ERR_NVS_NOT_FOUND) {
+        size_t blen = 0;
+        if (nvs_get_blob(h, "moonraker_info", NULL, &blen) == ESP_OK && blen >= 64) {
+            uint8_t *b = calloc(1, blen);
+            if (b && nvs_get_blob(h, "moonraker_info", b, &blen) == ESP_OK) {
+                char host[64] = {0};
+                memcpy(host, b, 63);   // host[64]@0
+                if (host[0]) {
+                    nvs_set_str(h, "mk_host", host);
+                    nvs_set_u16(h, "mk_port", 7125);   // stock stores printer :80; DB wants Moonraker :7125
+                    ESP_LOGW(TAG, "migrated stock Moonraker host '%s' (port->7125)", host);
+                }
+            }
+            free(b);
+        }
+    }
+
+    // Home Assistant MQTT: stock "ha_mqtt_info" blob (146 B):
+    //   char host[16]@0, char user[64]@16, char pass[64]@80, uint16 port@144 (no topic).
+    if (nvs_get_str(h, "ha_host", NULL, &sz) == ESP_ERR_NVS_NOT_FOUND) {
+        size_t blen = 0;
+        if (nvs_get_blob(h, "ha_mqtt_info", NULL, &blen) == ESP_OK && blen >= 146) {
+            uint8_t *b = calloc(1, blen);
+            if (b && nvs_get_blob(h, "ha_mqtt_info", b, &blen) == ESP_OK) {
+                char host[16] = {0}, user[64] = {0}, pass[64] = {0};
+                memcpy(host, b, 15);
+                memcpy(user, b + 16, 63);
+                memcpy(pass, b + 80, 63);
+                uint16_t port = (uint16_t)(b[144] | (b[145] << 8));
+                if (host[0]) {
+                    nvs_set_str(h, "ha_host", host);
+                    nvs_set_str(h, "ha_user", user);
+                    nvs_set_str(h, "ha_pass", pass);
+                    if (port) nvs_set_u16(h, "ha_port", port);
+                    ESP_LOGW(TAG, "migrated stock HA MQTT broker '%s' from ha_mqtt_info", host);
+                }
+            }
+            free(b);
+        }
+    }
+    // NOTE: stock "bambu_mqtt_info" (169 B) is intentionally NOT migrated — its blob
+    // layout is unknown (stock refuses to persist Bambu without a live printer to bind,
+    // so we have no populated sample to RE from). DragonBreath's Bambu source is
+    // experimental anyway; add this once we have a real Bambu-configured stock backup.
+
+    nvs_commit(h);
+    nvs_close(h);
+}
+
 static bool load_saved_creds(char *ssid, size_t ssid_sz, char *pass, size_t pass_sz)
 {
     esp_err_t err = nvs_read_str(KEY_SSID, ssid, ssid_sz);
@@ -294,6 +377,10 @@ esp_err_t pb_wifi_start(void)
     } else if (err != ESP_OK) {
         return err;
     }
+
+    // First boot after an OTA-over-stock: carry WiFi + Moonraker across from stock's
+    // app_nvs blobs so the device rejoins without re-provisioning.
+    migrate_stock_nvs();
 
     // Netif + event loop
     ESP_ERROR_CHECK(esp_netif_init());


### PR DESCRIPTION
**Seamless config carry-over when installing over stock — no more captive-portal re-provisioning after an OTA-over-stock.**

## Problem
DragonBreath installs over stock as an app-only OTA and inherits stock's `app_nvs`. Stock stores config as **blobs** (`wifi_info`, `moonraker_info`, `ha_mqtt_info`) under **different keys** than DragonBreath reads (`ssid`/`password`/`mk_host`/`ha_*`). So after the flip the device dropped to AP setup even though the creds were right there.

## Fix
A one-time first-boot shim (`pb_wifi`) that, when our own keys are absent, lifts creds out of the stock blobs:

| stock blob | → DragonBreath keys |
|---|---|
| `wifi_info[228]` | `ssid`, `password` |
| `moonraker_info[132]` | `mk_host` (port → Moonraker's `7125`; stock's field is the printer HTTP port) |
| `ha_mqtt_info[146]` | `ha_host`, `ha_user`, `ha_pass`, `ha_port` |

Non-destructive + idempotent: only fills keys that are **absent** (never overrides a user who set them via `/setup`), leaves the stock blobs intact, no-op on later boots.

## Validation (on hardware)
- Blob layouts RE'd from stock 1.0.4 NVS and **confirmed with distinctive dummy values** (e.g. the HA port `31883` read correctly as a u16 at offset 144); identical on 1.0.3/1.0.4.
- Flashed stock NVS → DragonBreath boots straight onto **WiFi + Moonraker** (reachable at `dragonbreath.local`, `moonraker_connected=true`).
- **HA** proven with a crafted valid `ha_mqtt_info` blob → `/setup` pre-fills host/user/port.
- pb_policy host tests green.

## Not included
**Bambu** (`bambu_mqtt_info`) — stock won't persist a Bambu config without a live printer to bind, so there's no populated sample to RE the layout from; DragonBreath's Bambu source is experimental anyway. Add later from a real Bambu-configured backup.

This is the linchpin for the no-USB Panda→DragonBreath migration (`plans/panda-to-dragon-migration.md`), and it helps **every** OTA-from-stock user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)