### PR TITLE
Bambu filament-based chamber zones (WIP)

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Test heater safety-trip decision (over-temp / fail-closed / watchdog)
         run: sh tests/run_heater_safety_host_test.sh
 
+      - name: Test Bambu report parser (filament tri-state + zone match)
+        run: sh tests/run_bambu_host_test.sh
+
       - name: Test HIL scenario runner
         run: python3 -m unittest tests/test_hil_runner.py
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+## [1.0.4-rc1]
+
+**Bambu filament heating zones — the chamber target now follows the filament type of
+the active Bambu print (issue #64). Pre-release for community testing.**
+
+### Added
+- **Filament chamber zones (Bambu source only).** During a Bambu print, DragonBreath
+  reads the active tray's filament type from the LAN report and sets the chamber target
+  from a per-filament map — e.g. PETG → 40 °C — instead of the bed-threshold AUTO seam.
+  Preheats on `PREPARE`, holds through `PAUSE`, reverts to idle/AUTO when the print ends.
+  A zone target of `0` means "no zone / off"; an unrecognised filament also resolves to 0.
+  (Klipper is unaffected — it drives the chamber via `M141`/`M191` macros.)
+- **Six built-in filament types** with sensible defaults (PLA/TPU off; PETG 40; ABS/ASA
+  55; PC 60), each editable. Built-in targets can be set during initial config on `/setup`.
+- **User-defined custom profiles.** Add up to 8 custom filament profiles (PA, PCTG, …)
+  from the dashboard's **Custom profiles** card; add/update/remove applies live (no
+  reboot) and persists across reboots. Longest-prefix matching means a custom `PETG-CF`
+  wins over the built-in `PETG`.
+- **Dashboard:** a Bambu-only **Filament** row in the system-status card shows the active
+  print's filament; the **Filament zones** + **Custom profiles** cards appear when the
+  control source is Bambu. New API `GET/POST /api/v2/zones` (live edits, auth-gated POST).
+
 ## [1.0.2] - 2026-07-31
 
 **Seamless config carry-over when installing over stock — WiFi, Moonraker, and Home

--- a/components/pb_bambu/include/pb_bambu.h
+++ b/components/pb_bambu/include/pb_bambu.h
@@ -33,6 +33,8 @@ typedef struct {
     float chamber_temp;   // chamber_temper (°C); NaN if the model has no sensor
     char  filament[16];   // active filament type from AMS / ext spool (e.g. "PETG");
                           // "" if unknown. Feeds filament-based chamber zones.
+    bool  printing;       // gcode_state is PREPARE/RUNNING/PAUSE (a print is active);
+                          // gates when a filament zone is applied.
 } pb_bambu_status_t;
 
 esp_err_t pb_bambu_start(void);

--- a/components/pb_bambu/include/pb_bambu.h
+++ b/components/pb_bambu/include/pb_bambu.h
@@ -31,6 +31,8 @@ typedef struct {
     float bed_temp;       // bed_temper (°C); NaN until first report
     float bed_target;     // bed_target_temper (°C, the setpoint AUTO triggers on)
     float chamber_temp;   // chamber_temper (°C); NaN if the model has no sensor
+    char  filament[16];   // active filament type from AMS / ext spool (e.g. "PETG");
+                          // "" if unknown. Feeds filament-based chamber zones.
 } pb_bambu_status_t;
 
 esp_err_t pb_bambu_start(void);

--- a/components/pb_bambu/include/pb_bambu.h
+++ b/components/pb_bambu/include/pb_bambu.h
@@ -53,20 +53,32 @@ esp_err_t pb_bambu_clear_config(void);
 // Maps the active filament type to a chamber target so a Bambu print gets a warm
 // chamber (e.g. PETG -> 40 C) without any bed-threshold AUTO. Klipper doesn't use
 // this — it drives the chamber via M141/M191. A zone target of 0 = "no zone" (off).
-#define PB_BAMBU_ZONE_COUNT 6
+//
+// There are 6 BUILT-IN filament types (fixed defaults, editable target) plus up to
+// PB_BAMBU_CUSTOM_MAX USER profiles the operator can add/remove for filaments not in
+// the built-in set (PA, PCTG, ...). get_all returns the built-ins first, then customs.
+#define PB_BAMBU_ZONE_COUNT  6                                        // built-in types
+#define PB_BAMBU_CUSTOM_MAX  8                                        // user profiles
+#define PB_BAMBU_ZONE_MAX    (PB_BAMBU_ZONE_COUNT + PB_BAMBU_CUSTOM_MAX)
 
 typedef struct {
-    char    name[8];     // base filament type, e.g. "PETG"
+    char    name[12];    // filament type ("PETG", or a custom name like "PCTG")
     uint8_t target_c;    // chamber target (°C); 0 = no zone / off
+    uint8_t default_c;   // built-in default (for the UI's "default N" hint); 0 for customs
+    bool    custom;      // true = a user-added profile (removable)
 } pb_bambu_zone_t;
 
-// Resolve the chamber target for a filament type string (case-insensitive prefix
-// match, so "PETG-CF"/"PLA Basic" resolve to PETG/PLA). 0 = no zone / unknown.
+// Resolve the chamber target for a filament type string. Longest case-insensitive
+// prefix match over built-ins + customs (so a custom "PETG-CF" beats "PETG"). 0 = none.
 uint8_t pb_bambu_zone_target(const char *filament);
 
-// Fill `out` (capacity `max`) with the current zone map (NVS overrides or defaults);
-// returns the number written.
+// Fill `out` (capacity `max`) with built-in zones then custom profiles; returns the
+// number written (<= PB_BAMBU_ZONE_MAX).
 int pb_bambu_zone_get_all(pb_bambu_zone_t *out, int max);
 
-// Set one zone's target by name (case-insensitive). Persists to NVS. 0 disables it.
+// Set/update a zone by name (case-insensitive). A built-in name updates its target;
+// an unknown name ADDS a custom profile (up to PB_BAMBU_CUSTOM_MAX). Persists.
 esp_err_t pb_bambu_zone_set(const char *name, uint8_t target_c);
+
+// Remove a custom profile by name (built-ins cannot be removed). Persists.
+esp_err_t pb_bambu_zone_remove(const char *name);

--- a/components/pb_bambu/include/pb_bambu.h
+++ b/components/pb_bambu/include/pb_bambu.h
@@ -46,3 +46,25 @@ esp_err_t pb_bambu_get_status(pb_bambu_status_t *out);
 
 // Wipe saved Bambu config (factory reset).
 esp_err_t pb_bambu_clear_config(void);
+
+// --- Filament chamber zones (Bambu only, issue #64) -------------------------
+// Maps the active filament type to a chamber target so a Bambu print gets a warm
+// chamber (e.g. PETG -> 40 C) without any bed-threshold AUTO. Klipper doesn't use
+// this — it drives the chamber via M141/M191. A zone target of 0 = "no zone" (off).
+#define PB_BAMBU_ZONE_COUNT 6
+
+typedef struct {
+    char    name[8];     // base filament type, e.g. "PETG"
+    uint8_t target_c;    // chamber target (°C); 0 = no zone / off
+} pb_bambu_zone_t;
+
+// Resolve the chamber target for a filament type string (case-insensitive prefix
+// match, so "PETG-CF"/"PLA Basic" resolve to PETG/PLA). 0 = no zone / unknown.
+uint8_t pb_bambu_zone_target(const char *filament);
+
+// Fill `out` (capacity `max`) with the current zone map (NVS overrides or defaults);
+// returns the number written.
+int pb_bambu_zone_get_all(pb_bambu_zone_t *out, int max);
+
+// Set one zone's target by name (case-insensitive). Persists to NVS. 0 disables it.
+esp_err_t pb_bambu_zone_set(const char *name, uint8_t target_c);

--- a/components/pb_bambu/include/pb_bambu_parse.h
+++ b/components/pb_bambu/include/pb_bambu_parse.h
@@ -1,0 +1,92 @@
+#pragma once
+// Pure, host-testable Bambu report parsing (no ESP deps) — mirrors the pb_ntc /
+// pb_heater convention of keeping decision logic inline in a header so it can be
+// unit-tested on the host. Used by pb_bambu.c and tests/pb_bambu_host_test.c.
+#include <string.h>
+#include <strings.h>   // strncasecmp
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+
+// Result of resolving the active filament from a report. The tri-state matters:
+// a delta report that OMITS filament state must NOT clobber the last known value,
+// whereas an explicit "nothing loaded" MUST clear it (else a stale zone applies).
+typedef enum {
+    PB_FILA_ABSENT = 0,   // no filament state in this (delta) report -> keep prior
+    PB_FILA_EMPTY,        // report explicitly has no active/loaded filament -> clear
+    PB_FILA_PRESENT,      // an active filament type was found -> use `out`
+} pb_fila_result_t;
+
+// Copy the string value of a JSON key ("key":"value") into out. `key` includes the
+// quotes. Returns true if a (possibly empty) string value was found.
+static inline bool pb_bambu_find_string(const char *s, const char *key, char *out, size_t outsz)
+{
+    const char *q = strstr(s, key);
+    if (!q) return false;
+    q = strchr(q, ':');
+    if (!q) return false;
+    q++;
+    while (*q == ' ' || *q == '\t' || *q == '\n' || *q == '\r') q++;
+    if (*q != '"') return false;
+    q++;
+    size_t i = 0;
+    while (*q && *q != '"' && i + 1 < outsz) out[i++] = *q++;
+    out[i] = '\0';
+    return true;
+}
+
+// Resolve the ACTIVE filament type from a Bambu report. Bambu lists loaded filaments
+// under print.ams (AMS units, tray[].tray_type) and print.vt_tray (external spool),
+// with print.ams.tray_now selecting the active global tray index (254 = external
+// spool, 255 = none loaded). Targeted scan — no full JSON parse over ~15 KB.
+static inline pb_fila_result_t pb_bambu_active_filament(const char *json, char *out, size_t outsz)
+{
+    out[0] = '\0';
+    const char *tn  = strstr(json, "\"tray_now\"");
+    const char *vt  = strstr(json, "\"vt_tray\"");
+    const char *ams = strstr(json, "\"ams\"");
+    if (!tn && !vt && !ams) return PB_FILA_ABSENT;   // delta with no filament state
+
+    char trayn[8] = {0};
+    long now = (tn && pb_bambu_find_string(json, "\"tray_now\"", trayn, sizeof trayn))
+                   ? strtol(trayn, NULL, 10) : -1;
+    char tt[16];
+
+    // An AMS slot is selected: report the active tray's type. An empty type there
+    // means that slot has nothing loaded -> EMPTY (do NOT fall back to vt_tray).
+    if (now >= 0 && now < 250) {
+        if (ams) {
+            const char *p = ams; long idx = -1;
+            while ((p = strstr(p, "\"tray_type\"")) != NULL) {
+                if (++idx == now) {
+                    if (pb_bambu_find_string(p, "\"tray_type\"", tt, sizeof tt) && tt[0]) {
+                        snprintf(out, outsz, "%s", tt); return PB_FILA_PRESENT;
+                    }
+                    break;
+                }
+                p += 11;
+            }
+        }
+        return PB_FILA_EMPTY;
+    }
+
+    // External spool (tray_now 254, or tray_now absent with a vt_tray present).
+    if (vt && pb_bambu_find_string(vt, "\"tray_type\"", tt, sizeof tt) && tt[0]) {
+        snprintf(out, outsz, "%s", tt); return PB_FILA_PRESENT;
+    }
+
+    // Filament state was present in the report, but nothing is loaded/active
+    // (tray_now 255, empty vt_tray, ...). Explicit empty -> clear.
+    return PB_FILA_EMPTY;
+}
+
+// Index of the first zone whose base name is a case-insensitive prefix of `filament`
+// (so "PETG-CF" / "PLA Basic" resolve to PETG / PLA), or -1 if none match.
+static inline int pb_bambu_zone_match(const char *filament, const char *const names[], int count)
+{
+    if (!filament || !filament[0]) return -1;
+    for (int i = 0; i < count; i++)
+        if (strncasecmp(filament, names[i], strlen(names[i])) == 0) return i;
+    return -1;
+}

--- a/components/pb_bambu/include/pb_bambu_parse.h
+++ b/components/pb_bambu/include/pb_bambu_parse.h
@@ -53,32 +53,35 @@ static inline pb_fila_result_t pb_bambu_active_filament(const char *json, char *
                    ? strtol(trayn, NULL, 10) : -1;
     char tt[16];
 
-    // An AMS slot is selected: report the active tray's type. An empty type there
-    // means that slot has nothing loaded -> EMPTY (do NOT fall back to vt_tray).
+    if (now == 255) return PB_FILA_EMPTY;   // tray_now explicitly says nothing is loaded
+
+    // AMS slot selected: resolve the active tray's type ONLY IF this report carries it.
+    // A delta may name the slot (tray_now) without including the tray payload — that is
+    // ABSENT (keep the last known filament), not empty. Only an active tray whose
+    // tray_type is explicitly present-and-empty counts as EMPTY.
     if (now >= 0 && now < 250) {
         if (ams) {
             const char *p = ams; long idx = -1;
             while ((p = strstr(p, "\"tray_type\"")) != NULL) {
-                if (++idx == now) {
-                    if (pb_bambu_find_string(p, "\"tray_type\"", tt, sizeof tt) && tt[0]) {
-                        snprintf(out, outsz, "%s", tt); return PB_FILA_PRESENT;
+                if (++idx == now) {                 // the active tray IS in this report
+                    if (pb_bambu_find_string(p, "\"tray_type\"", tt, sizeof tt)) {
+                        if (tt[0]) { snprintf(out, outsz, "%s", tt); return PB_FILA_PRESENT; }
+                        return PB_FILA_EMPTY;        // active tray present but empty
                     }
                     break;
                 }
                 p += 11;
             }
         }
-        return PB_FILA_EMPTY;
+        return PB_FILA_ABSENT;   // selected tray's payload not in this (delta) report
     }
 
     // External spool (tray_now 254, or tray_now absent with a vt_tray present).
-    if (vt && pb_bambu_find_string(vt, "\"tray_type\"", tt, sizeof tt) && tt[0]) {
-        snprintf(out, outsz, "%s", tt); return PB_FILA_PRESENT;
+    if (vt && pb_bambu_find_string(vt, "\"tray_type\"", tt, sizeof tt)) {
+        if (tt[0]) { snprintf(out, outsz, "%s", tt); return PB_FILA_PRESENT; }
+        return PB_FILA_EMPTY;    // external spool present but empty
     }
-
-    // Filament state was present in the report, but nothing is loaded/active
-    // (tray_now 255, empty vt_tray, ...). Explicit empty -> clear.
-    return PB_FILA_EMPTY;
+    return PB_FILA_ABSENT;       // couldn't resolve -> don't clobber the last value
 }
 
 // Index of the first zone whose base name is a case-insensitive prefix of `filament`

--- a/components/pb_bambu/include/pb_bambu_parse.h
+++ b/components/pb_bambu/include/pb_bambu_parse.h
@@ -93,3 +93,14 @@ static inline int pb_bambu_zone_match(const char *filament, const char *const na
         if (strncasecmp(filament, names[i], strlen(names[i])) == 0) return i;
     return -1;
 }
+
+// Is a Bambu gcode_state "active" for chamber-zone purposes? PREPARE (so the chamber
+// preheats before the print), RUNNING, and PAUSE (hold heat across a pause) are active;
+// IDLE / FINISH / FAILED / SLICING are not. Case-sensitive: Bambu emits upper-case.
+static inline bool pb_bambu_gcode_active(const char *state)
+{
+    if (!state || !state[0]) return false;
+    return strcmp(state, "RUNNING") == 0
+        || strcmp(state, "PREPARE") == 0
+        || strcmp(state, "PAUSE")   == 0;
+}

--- a/components/pb_bambu/include/pb_bambu_parse.h
+++ b/components/pb_bambu/include/pb_bambu_parse.h
@@ -84,14 +84,22 @@ static inline pb_fila_result_t pb_bambu_active_filament(const char *json, char *
     return PB_FILA_ABSENT;       // couldn't resolve -> don't clobber the last value
 }
 
-// Index of the first zone whose base name is a case-insensitive prefix of `filament`
-// (so "PETG-CF" / "PLA Basic" resolve to PETG / PLA), or -1 if none match.
+// Index of the zone whose base name is the LONGEST case-insensitive prefix of
+// `filament` (so "PETG-CF" resolves to a custom "PETG-CF" over "PETG", and
+// "PLA Basic" to "PLA"), or -1 if none match.
 static inline int pb_bambu_zone_match(const char *filament, const char *const names[], int count)
 {
     if (!filament || !filament[0]) return -1;
-    for (int i = 0; i < count; i++)
-        if (strncasecmp(filament, names[i], strlen(names[i])) == 0) return i;
-    return -1;
+    int best = -1;
+    size_t bestlen = 0;
+    for (int i = 0; i < count; i++) {
+        size_t n = strlen(names[i]);
+        if (n > 0 && n > bestlen && strncasecmp(filament, names[i], n) == 0) {
+            best = i;
+            bestlen = n;
+        }
+    }
+    return best;
 }
 
 // Is a Bambu gcode_state "active" for chamber-zone purposes? PREPARE (so the chamber

--- a/components/pb_bambu/pb_bambu.c
+++ b/components/pb_bambu/pb_bambu.c
@@ -9,6 +9,7 @@
 //   device/<serial>/report; publish one "pushall" on connect (P1/A1 send deltas).
 // See plans/control-source-bambu-ha.md.
 #include "pb_bambu.h"
+#include "pb_bambu_parse.h"
 
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
@@ -104,58 +105,8 @@ static bool find_float(const char *s, const char *key, float *out)
     return true;
 }
 
-// Copy the string value of a JSON key ("key":"value") into out. `key` includes the
-// quotes. Returns true if a (possibly empty) string value was found.
-static bool find_string(const char *s, const char *key, char *out, size_t outsz)
-{
-    const char *q = strstr(s, key);
-    if (!q) return false;
-    q = strchr(q, ':');
-    if (!q) return false;
-    q++;
-    while (*q == ' ' || *q == '\t' || *q == '\n' || *q == '\r') q++;
-    if (*q != '"') return false;
-    q++;
-    size_t i = 0;
-    while (*q && *q != '"' && i + 1 < outsz) out[i++] = *q++;
-    out[i] = '\0';
-    return true;
-}
-
-// Resolve the ACTIVE filament type from a report. Bambu lists loaded filaments in
-// print.ams (AMS units, tray[].tray_type) and print.vt_tray (external spool), with
-// print.ams.tray_now selecting the active global tray index (254 = external spool,
-// 255/absent = none loaded). Targeted scan — no full JSON parse over ~15 KB.
-static bool active_filament(const char *json, char *out, size_t outsz)
-{
-    out[0] = '\0';
-    char trayn[8] = {0};
-    long now = find_string(json, "\"tray_now\"", trayn, sizeof trayn) ? strtol(trayn, NULL, 10) : -1;
-    const char *vt = strstr(json, "\"vt_tray\"");
-    char tt[16];
-
-    // AMS slot active: take the (now)th tray_type inside the "ams" object.
-    if (now >= 0 && now < 250) {
-        const char *ams = strstr(json, "\"ams\"");
-        if (ams) {
-            const char *p = ams; long idx = -1;
-            while ((p = strstr(p, "\"tray_type\"")) != NULL) {
-                if (++idx == now) {
-                    if (find_string(p, "\"tray_type\"", tt, sizeof tt) && tt[0]) {
-                        snprintf(out, outsz, "%s", tt); return true;
-                    }
-                    break;
-                }
-                p += 11;
-            }
-        }
-    }
-    // External spool (tray_now 254, or as a fallback): vt_tray.tray_type.
-    if (vt && find_string(vt, "\"tray_type\"", tt, sizeof tt) && tt[0]) {
-        snprintf(out, outsz, "%s", tt); return true;
-    }
-    return false;
-}
+// find_string() + active_filament() (tri-state) live in pb_bambu_parse.h so they
+// can be host-unit-tested (tests/pb_bambu_host_test.c).
 
 static void parse_report(const char *json)
 {
@@ -170,7 +121,7 @@ static void parse_report(const char *json)
     // field; only the legacy flat chamber_temper is read here. Bed follow (the
     // goal) works on all models via bed_temper/bed_target_temper.
     char fila[16];
-    bool got_fila = active_filament(json, fila, sizeof fila);   // active AMS/spool filament
+    pb_fila_result_t fr = pb_bambu_active_filament(json, fila, sizeof fila);
 
     xSemaphoreTake(s_lock, portMAX_DELAY);
     if (got_bed) {
@@ -180,11 +131,20 @@ static void parse_report(const char *json)
     }
     if (got_tgt)  s_status.bed_target = bedtgt;
     if (got_cham) s_status.chamber_temp = cham;
-    bool fila_changed = got_fila && strcmp(fila, s_status.filament) != 0;
-    if (fila_changed) snprintf(s_status.filament, sizeof s_status.filament, "%s", fila);
+    // Tri-state: PRESENT updates the filament; EMPTY (unload / print end / no spool)
+    // CLEARS it so a stale zone is never applied; ABSENT (a delta that simply omits
+    // the AMS/tray block) leaves the last known value untouched.
+    bool fila_changed = false;
+    if (fr == PB_FILA_PRESENT && strcmp(fila, s_status.filament) != 0) {
+        snprintf(s_status.filament, sizeof s_status.filament, "%s", fila);
+        fila_changed = true;
+    } else if (fr == PB_FILA_EMPTY && s_status.filament[0]) {
+        s_status.filament[0] = '\0';
+        fila_changed = true;
+    }
     xSemaphoreGive(s_lock);
 
-    if (fila_changed) ESP_LOGI(TAG, "active filament: %s", fila);
+    if (fila_changed) ESP_LOGI(TAG, "active filament: %s", fila[0] ? fila : "(none)");
     if (got_bed) ESP_LOGD(TAG, "bed=%.1f chamber=%.1f", bed, got_cham ? cham : NAN);
 }
 
@@ -352,16 +312,11 @@ esp_err_t pb_bambu_clear_config(void)
 
 // Base filament type -> default chamber target (°C). 0 = no zone (off). Opinionated
 // but sane; all user-overridable via NVS. PLA/TPU default off (a hot chamber hurts
-// PLA); PETG/ABS/ASA/PC want warmth for layer adhesion / reduced warping.
-static const struct { const char *name; const char *key; uint8_t def_c; }
-ZONES[PB_BAMBU_ZONE_COUNT] = {
-    { "PLA",  "zone_pla",  0  },
-    { "PETG", "zone_petg", 40 },
-    { "ABS",  "zone_abs",  45 },
-    { "ASA",  "zone_asa",  45 },
-    { "PC",   "zone_pc",   50 },
-    { "TPU",  "zone_tpu",  0  },
-};
+// PLA); PETG/ABS/ASA/PC want warmth for layer adhesion / reduced warping. Parallel
+// arrays so the (host-tested) pb_bambu_zone_match() can take ZONE_NAMES directly.
+static const char *const ZONE_NAMES[PB_BAMBU_ZONE_COUNT] = { "PLA", "PETG", "ABS", "ASA", "PC", "TPU" };
+static const char *const ZONE_KEYS [PB_BAMBU_ZONE_COUNT] = { "zone_pla", "zone_petg", "zone_abs", "zone_asa", "zone_pc", "zone_tpu" };
+static const uint8_t     ZONE_DEF  [PB_BAMBU_ZONE_COUNT] = { 0, 40, 45, 45, 50, 0 };
 
 static uint8_t s_zone_c[PB_BAMBU_ZONE_COUNT];   // RAM cache of the resolved targets
 static bool    s_zones_loaded = false;
@@ -372,8 +327,8 @@ static void zones_load(void)
     nvs_handle_t h;
     bool have = (nvs_open(NVS_NS, NVS_READONLY, &h) == ESP_OK);
     for (int i = 0; i < PB_BAMBU_ZONE_COUNT; i++) {
-        uint8_t v = ZONES[i].def_c;
-        if (have) nvs_get_u8(h, ZONES[i].key, &v);   // leaves default if key absent
+        uint8_t v = ZONE_DEF[i];
+        if (have) nvs_get_u8(h, ZONE_KEYS[i], &v);   // leaves default if key absent
         s_zone_c[i] = v;
     }
     if (have) nvs_close(h);
@@ -382,13 +337,9 @@ static void zones_load(void)
 
 uint8_t pb_bambu_zone_target(const char *filament)
 {
-    if (!filament || !filament[0]) return 0;
     if (!s_zones_loaded) zones_load();
-    // Case-insensitive prefix match so "PETG-CF" / "PLA Basic" resolve to their base.
-    for (int i = 0; i < PB_BAMBU_ZONE_COUNT; i++)
-        if (strncasecmp(filament, ZONES[i].name, strlen(ZONES[i].name)) == 0)
-            return s_zone_c[i];
-    return 0;
+    int i = pb_bambu_zone_match(filament, ZONE_NAMES, PB_BAMBU_ZONE_COUNT);
+    return i < 0 ? 0 : s_zone_c[i];
 }
 
 int pb_bambu_zone_get_all(pb_bambu_zone_t *out, int max)
@@ -396,7 +347,7 @@ int pb_bambu_zone_get_all(pb_bambu_zone_t *out, int max)
     if (!s_zones_loaded) zones_load();
     int n = 0;
     for (int i = 0; i < PB_BAMBU_ZONE_COUNT && n < max; i++, n++) {
-        snprintf(out[n].name, sizeof out[n].name, "%s", ZONES[i].name);
+        snprintf(out[n].name, sizeof out[n].name, "%s", ZONE_NAMES[i]);
         out[n].target_c = s_zone_c[i];
     }
     return n;
@@ -407,13 +358,13 @@ esp_err_t pb_bambu_zone_set(const char *name, uint8_t target_c)
     if (!name) return ESP_ERR_INVALID_ARG;
     int idx = -1;
     for (int i = 0; i < PB_BAMBU_ZONE_COUNT; i++)
-        if (strcasecmp(name, ZONES[i].name) == 0) { idx = i; break; }
+        if (strcasecmp(name, ZONE_NAMES[i]) == 0) { idx = i; break; }
     if (idx < 0) return ESP_ERR_NOT_FOUND;
     if (target_c > 70) target_c = 70;   // settable ceiling; pb_policy enforces hard cutoffs
     nvs_handle_t h;
     esp_err_t err = nvs_open(NVS_NS, NVS_READWRITE, &h);
     if (err != ESP_OK) return err;
-    err = nvs_set_u8(h, ZONES[idx].key, target_c);
+    err = nvs_set_u8(h, ZONE_KEYS[idx], target_c);
     if (err == ESP_OK) err = nvs_commit(h);
     nvs_close(h);
     if (err == ESP_OK) { if (!s_zones_loaded) zones_load(); s_zone_c[idx] = target_c; }

--- a/components/pb_bambu/pb_bambu.c
+++ b/components/pb_bambu/pb_bambu.c
@@ -313,19 +313,23 @@ esp_err_t pb_bambu_clear_config(void)
 
 // ---------- filament chamber zones (issue #64, Bambu only) ----------
 
-// Base filament type -> default chamber target (°C). 0 = no zone (off). Opinionated
-// but sane; all user-overridable via NVS. PLA/TPU default off (a hot chamber hurts
-// PLA); PETG/ABS/ASA/PC want warmth for layer adhesion / reduced warping. Parallel
-// arrays so the (host-tested) pb_bambu_zone_match() can take ZONE_NAMES directly.
+// Built-in filament types: fixed names + per-key NVS target override + a default
+// (shown as the UI's "default N" hint). PLA/TPU off (a hot chamber hurts PLA);
+// PETG/ABS/ASA/PC want warmth for adhesion / reduced warping.
 static const char *const ZONE_NAMES[PB_BAMBU_ZONE_COUNT] = { "PLA", "PETG", "ABS", "ASA", "PC", "TPU" };
 static const char *const ZONE_KEYS [PB_BAMBU_ZONE_COUNT] = { "zone_pla", "zone_petg", "zone_abs", "zone_asa", "zone_pc", "zone_tpu" };
 //                                                            PLA PETG ABS ASA PC  TPU
 static const uint8_t     ZONE_DEF  [PB_BAMBU_ZONE_COUNT] = {  0,  40, 55, 55, 60,  0 };
 
-static uint8_t s_zone_c[PB_BAMBU_ZONE_COUNT];   // RAM cache of the resolved targets
-static bool    s_zones_loaded = false;
+// User custom profiles — persisted together as one NVS blob "zone_custom".
+typedef struct { char name[12]; uint8_t target_c; } custom_zone_t;
 
-// Load the zone targets (NVS override, else default) into the RAM cache.
+static uint8_t       s_zone_c[PB_BAMBU_ZONE_COUNT];   // built-in target cache
+static custom_zone_t s_custom[PB_BAMBU_CUSTOM_MAX];   // custom profile cache
+static int           s_custom_n = 0;
+static bool          s_zones_loaded = false;
+
+// Load built-in targets (NVS override, else default) + custom profiles into RAM.
 static void zones_load(void)
 {
     nvs_handle_t h;
@@ -335,15 +339,40 @@ static void zones_load(void)
         if (have) nvs_get_u8(h, ZONE_KEYS[i], &v);   // leaves default if key absent
         s_zone_c[i] = v;
     }
-    if (have) nvs_close(h);
+    s_custom_n = 0;
+    if (have) {
+        size_t len = sizeof s_custom;
+        if (nvs_get_blob(h, "zone_custom", s_custom, &len) == ESP_OK)
+            s_custom_n = (int)(len / sizeof(custom_zone_t));
+        nvs_close(h);
+    }
     s_zones_loaded = true;
+}
+
+static esp_err_t customs_persist(void)
+{
+    nvs_handle_t h;
+    esp_err_t err = nvs_open(NVS_NS, NVS_READWRITE, &h);
+    if (err != ESP_OK) return err;
+    if (s_custom_n > 0) err = nvs_set_blob(h, "zone_custom", s_custom, s_custom_n * sizeof(custom_zone_t));
+    else                nvs_erase_key(h, "zone_custom");
+    if (err == ESP_OK) err = nvs_commit(h);
+    nvs_close(h);
+    return err;
 }
 
 uint8_t pb_bambu_zone_target(const char *filament)
 {
     if (!s_zones_loaded) zones_load();
-    int i = pb_bambu_zone_match(filament, ZONE_NAMES, PB_BAMBU_ZONE_COUNT);
-    return i < 0 ? 0 : s_zone_c[i];
+    if (!filament || !filament[0]) return 0;
+    // Longest-prefix match over built-ins + customs (a custom "PETG-CF" beats "PETG").
+    const char *names[PB_BAMBU_ZONE_MAX];
+    uint8_t     temps[PB_BAMBU_ZONE_MAX];
+    int n = 0;
+    for (int i = 0; i < PB_BAMBU_ZONE_COUNT; i++) { names[n] = ZONE_NAMES[i];   temps[n] = s_zone_c[i];        n++; }
+    for (int i = 0; i < s_custom_n;          i++) { names[n] = s_custom[i].name; temps[n] = s_custom[i].target_c; n++; }
+    int idx = pb_bambu_zone_match(filament, names, n);
+    return idx < 0 ? 0 : temps[idx];
 }
 
 int pb_bambu_zone_get_all(pb_bambu_zone_t *out, int max)
@@ -352,25 +381,63 @@ int pb_bambu_zone_get_all(pb_bambu_zone_t *out, int max)
     int n = 0;
     for (int i = 0; i < PB_BAMBU_ZONE_COUNT && n < max; i++, n++) {
         snprintf(out[n].name, sizeof out[n].name, "%s", ZONE_NAMES[i]);
-        out[n].target_c = s_zone_c[i];
+        out[n].target_c  = s_zone_c[i];
+        out[n].default_c = ZONE_DEF[i];
+        out[n].custom    = false;
+    }
+    for (int i = 0; i < s_custom_n && n < max; i++, n++) {
+        snprintf(out[n].name, sizeof out[n].name, "%.11s", s_custom[i].name);
+        out[n].target_c  = s_custom[i].target_c;
+        out[n].default_c = 0;
+        out[n].custom    = true;
     }
     return n;
 }
 
 esp_err_t pb_bambu_zone_set(const char *name, uint8_t target_c)
 {
-    if (!name) return ESP_ERR_INVALID_ARG;
-    int idx = -1;
-    for (int i = 0; i < PB_BAMBU_ZONE_COUNT; i++)
-        if (strcasecmp(name, ZONE_NAMES[i]) == 0) { idx = i; break; }
-    if (idx < 0) return ESP_ERR_NOT_FOUND;
+    if (!name || !name[0]) return ESP_ERR_INVALID_ARG;
     if (target_c > 70) target_c = 70;   // settable ceiling; pb_policy enforces hard cutoffs
-    nvs_handle_t h;
-    esp_err_t err = nvs_open(NVS_NS, NVS_READWRITE, &h);
-    if (err != ESP_OK) return err;
-    err = nvs_set_u8(h, ZONE_KEYS[idx], target_c);
-    if (err == ESP_OK) err = nvs_commit(h);
-    nvs_close(h);
-    if (err == ESP_OK) { if (!s_zones_loaded) zones_load(); s_zone_c[idx] = target_c; }
-    return err;
+    if (!s_zones_loaded) zones_load();
+
+    // Built-in: update its NVS key + cache.
+    for (int i = 0; i < PB_BAMBU_ZONE_COUNT; i++) {
+        if (strcasecmp(name, ZONE_NAMES[i]) == 0) {
+            nvs_handle_t h;
+            esp_err_t err = nvs_open(NVS_NS, NVS_READWRITE, &h);
+            if (err != ESP_OK) return err;
+            err = nvs_set_u8(h, ZONE_KEYS[i], target_c);
+            if (err == ESP_OK) err = nvs_commit(h);
+            nvs_close(h);
+            if (err == ESP_OK) s_zone_c[i] = target_c;
+            return err;
+        }
+    }
+    // Existing custom profile: update in place.
+    for (int i = 0; i < s_custom_n; i++)
+        if (strcasecmp(name, s_custom[i].name) == 0) {
+            s_custom[i].target_c = target_c;
+            return customs_persist();
+        }
+    // New custom profile: append if there's room and the name fits.
+    if (s_custom_n >= PB_BAMBU_CUSTOM_MAX) return ESP_ERR_NO_MEM;
+    if (strlen(name) >= sizeof s_custom[0].name) return ESP_ERR_INVALID_SIZE;
+    memset(&s_custom[s_custom_n], 0, sizeof s_custom[0]);
+    snprintf(s_custom[s_custom_n].name, sizeof s_custom[s_custom_n].name, "%.11s", name);
+    s_custom[s_custom_n].target_c = target_c;
+    s_custom_n++;
+    return customs_persist();
+}
+
+esp_err_t pb_bambu_zone_remove(const char *name)
+{
+    if (!name || !name[0]) return ESP_ERR_INVALID_ARG;
+    if (!s_zones_loaded) zones_load();
+    for (int i = 0; i < s_custom_n; i++)
+        if (strcasecmp(name, s_custom[i].name) == 0) {
+            for (int j = i; j < s_custom_n - 1; j++) s_custom[j] = s_custom[j + 1];
+            s_custom_n--;
+            return customs_persist();
+        }
+    return ESP_ERR_NOT_FOUND;   // not a custom (built-ins can't be removed)
 }

--- a/components/pb_bambu/pb_bambu.c
+++ b/components/pb_bambu/pb_bambu.c
@@ -103,6 +103,59 @@ static bool find_float(const char *s, const char *key, float *out)
     return true;
 }
 
+// Copy the string value of a JSON key ("key":"value") into out. `key` includes the
+// quotes. Returns true if a (possibly empty) string value was found.
+static bool find_string(const char *s, const char *key, char *out, size_t outsz)
+{
+    const char *q = strstr(s, key);
+    if (!q) return false;
+    q = strchr(q, ':');
+    if (!q) return false;
+    q++;
+    while (*q == ' ' || *q == '\t' || *q == '\n' || *q == '\r') q++;
+    if (*q != '"') return false;
+    q++;
+    size_t i = 0;
+    while (*q && *q != '"' && i + 1 < outsz) out[i++] = *q++;
+    out[i] = '\0';
+    return true;
+}
+
+// Resolve the ACTIVE filament type from a report. Bambu lists loaded filaments in
+// print.ams (AMS units, tray[].tray_type) and print.vt_tray (external spool), with
+// print.ams.tray_now selecting the active global tray index (254 = external spool,
+// 255/absent = none loaded). Targeted scan — no full JSON parse over ~15 KB.
+static bool active_filament(const char *json, char *out, size_t outsz)
+{
+    out[0] = '\0';
+    char trayn[8] = {0};
+    long now = find_string(json, "\"tray_now\"", trayn, sizeof trayn) ? strtol(trayn, NULL, 10) : -1;
+    const char *vt = strstr(json, "\"vt_tray\"");
+    char tt[16];
+
+    // AMS slot active: take the (now)th tray_type inside the "ams" object.
+    if (now >= 0 && now < 250) {
+        const char *ams = strstr(json, "\"ams\"");
+        if (ams) {
+            const char *p = ams; long idx = -1;
+            while ((p = strstr(p, "\"tray_type\"")) != NULL) {
+                if (++idx == now) {
+                    if (find_string(p, "\"tray_type\"", tt, sizeof tt) && tt[0]) {
+                        snprintf(out, outsz, "%s", tt); return true;
+                    }
+                    break;
+                }
+                p += 11;
+            }
+        }
+    }
+    // External spool (tray_now 254, or as a fallback): vt_tray.tray_type.
+    if (vt && find_string(vt, "\"tray_type\"", tt, sizeof tt) && tt[0]) {
+        snprintf(out, outsz, "%s", tt); return true;
+    }
+    return false;
+}
+
 static void parse_report(const char *json)
 {
     float bed, bedtgt, cham;
@@ -115,6 +168,8 @@ static void parse_report(const char *json)
     // NOTE(phase 2b): H2/newer moved chamber temp to a packed device.ctc.info.temp
     // field; only the legacy flat chamber_temper is read here. Bed follow (the
     // goal) works on all models via bed_temper/bed_target_temper.
+    char fila[16];
+    bool got_fila = active_filament(json, fila, sizeof fila);   // active AMS/spool filament
 
     xSemaphoreTake(s_lock, portMAX_DELAY);
     if (got_bed) {
@@ -124,8 +179,11 @@ static void parse_report(const char *json)
     }
     if (got_tgt)  s_status.bed_target = bedtgt;
     if (got_cham) s_status.chamber_temp = cham;
+    bool fila_changed = got_fila && strcmp(fila, s_status.filament) != 0;
+    if (fila_changed) snprintf(s_status.filament, sizeof s_status.filament, "%s", fila);
     xSemaphoreGive(s_lock);
 
+    if (fila_changed) ESP_LOGI(TAG, "active filament: %s", fila);
     if (got_bed) ESP_LOGD(TAG, "bed=%.1f chamber=%.1f", bed, got_cham ? cham : NAN);
 }
 

--- a/components/pb_bambu/pb_bambu.c
+++ b/components/pb_bambu/pb_bambu.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>   // strncasecmp / strcasecmp for filament zone matching
 
 static const char *TAG = "pb_bambu";
 
@@ -345,4 +346,76 @@ esp_err_t pb_bambu_clear_config(void)
     nvs_commit(h);
     nvs_close(h);
     return ESP_OK;
+}
+
+// ---------- filament chamber zones (issue #64, Bambu only) ----------
+
+// Base filament type -> default chamber target (°C). 0 = no zone (off). Opinionated
+// but sane; all user-overridable via NVS. PLA/TPU default off (a hot chamber hurts
+// PLA); PETG/ABS/ASA/PC want warmth for layer adhesion / reduced warping.
+static const struct { const char *name; const char *key; uint8_t def_c; }
+ZONES[PB_BAMBU_ZONE_COUNT] = {
+    { "PLA",  "zone_pla",  0  },
+    { "PETG", "zone_petg", 40 },
+    { "ABS",  "zone_abs",  45 },
+    { "ASA",  "zone_asa",  45 },
+    { "PC",   "zone_pc",   50 },
+    { "TPU",  "zone_tpu",  0  },
+};
+
+static uint8_t s_zone_c[PB_BAMBU_ZONE_COUNT];   // RAM cache of the resolved targets
+static bool    s_zones_loaded = false;
+
+// Load the zone targets (NVS override, else default) into the RAM cache.
+static void zones_load(void)
+{
+    nvs_handle_t h;
+    bool have = (nvs_open(NVS_NS, NVS_READONLY, &h) == ESP_OK);
+    for (int i = 0; i < PB_BAMBU_ZONE_COUNT; i++) {
+        uint8_t v = ZONES[i].def_c;
+        if (have) nvs_get_u8(h, ZONES[i].key, &v);   // leaves default if key absent
+        s_zone_c[i] = v;
+    }
+    if (have) nvs_close(h);
+    s_zones_loaded = true;
+}
+
+uint8_t pb_bambu_zone_target(const char *filament)
+{
+    if (!filament || !filament[0]) return 0;
+    if (!s_zones_loaded) zones_load();
+    // Case-insensitive prefix match so "PETG-CF" / "PLA Basic" resolve to their base.
+    for (int i = 0; i < PB_BAMBU_ZONE_COUNT; i++)
+        if (strncasecmp(filament, ZONES[i].name, strlen(ZONES[i].name)) == 0)
+            return s_zone_c[i];
+    return 0;
+}
+
+int pb_bambu_zone_get_all(pb_bambu_zone_t *out, int max)
+{
+    if (!s_zones_loaded) zones_load();
+    int n = 0;
+    for (int i = 0; i < PB_BAMBU_ZONE_COUNT && n < max; i++, n++) {
+        snprintf(out[n].name, sizeof out[n].name, "%s", ZONES[i].name);
+        out[n].target_c = s_zone_c[i];
+    }
+    return n;
+}
+
+esp_err_t pb_bambu_zone_set(const char *name, uint8_t target_c)
+{
+    if (!name) return ESP_ERR_INVALID_ARG;
+    int idx = -1;
+    for (int i = 0; i < PB_BAMBU_ZONE_COUNT; i++)
+        if (strcasecmp(name, ZONES[i].name) == 0) { idx = i; break; }
+    if (idx < 0) return ESP_ERR_NOT_FOUND;
+    if (target_c > 70) target_c = 70;   // settable ceiling; pb_policy enforces hard cutoffs
+    nvs_handle_t h;
+    esp_err_t err = nvs_open(NVS_NS, NVS_READWRITE, &h);
+    if (err != ESP_OK) return err;
+    err = nvs_set_u8(h, ZONES[idx].key, target_c);
+    if (err == ESP_OK) err = nvs_commit(h);
+    nvs_close(h);
+    if (err == ESP_OK) { if (!s_zones_loaded) zones_load(); s_zone_c[idx] = target_c; }
+    return err;
 }

--- a/components/pb_bambu/pb_bambu.c
+++ b/components/pb_bambu/pb_bambu.c
@@ -122,6 +122,8 @@ static void parse_report(const char *json)
     // goal) works on all models via bed_temper/bed_target_temper.
     char fila[16];
     pb_fila_result_t fr = pb_bambu_active_filament(json, fila, sizeof fila);
+    char gs[16];
+    bool got_gs = pb_bambu_find_string(json, "\"gcode_state\"", gs, sizeof gs);  // print state
 
     xSemaphoreTake(s_lock, portMAX_DELAY);
     if (got_bed) {
@@ -131,6 +133,7 @@ static void parse_report(const char *json)
     }
     if (got_tgt)  s_status.bed_target = bedtgt;
     if (got_cham) s_status.chamber_temp = cham;
+    if (got_gs)   s_status.printing = pb_bambu_gcode_active(gs);   // keep prior if a delta omits it
     // Tri-state: PRESENT updates the filament; EMPTY (unload / print end / no spool)
     // CLEARS it so a stale zone is never applied; ABSENT (a delta that simply omits
     // the AMS/tray block) leaves the last known value untouched.
@@ -316,7 +319,8 @@ esp_err_t pb_bambu_clear_config(void)
 // arrays so the (host-tested) pb_bambu_zone_match() can take ZONE_NAMES directly.
 static const char *const ZONE_NAMES[PB_BAMBU_ZONE_COUNT] = { "PLA", "PETG", "ABS", "ASA", "PC", "TPU" };
 static const char *const ZONE_KEYS [PB_BAMBU_ZONE_COUNT] = { "zone_pla", "zone_petg", "zone_abs", "zone_asa", "zone_pc", "zone_tpu" };
-static const uint8_t     ZONE_DEF  [PB_BAMBU_ZONE_COUNT] = { 0, 40, 45, 45, 50, 0 };
+//                                                            PLA PETG ABS ASA PC  TPU
+static const uint8_t     ZONE_DEF  [PB_BAMBU_ZONE_COUNT] = {  0,  40, 55, 55, 60,  0 };
 
 static uint8_t s_zone_c[PB_BAMBU_ZONE_COUNT];   // RAM cache of the resolved targets
 static bool    s_zones_loaded = false;

--- a/components/pb_hil/pb_hil.c
+++ b/components/pb_hil/pb_hil.c
@@ -303,7 +303,11 @@ static void handle_request(const cJSON *request)
         // "measured == trigger" behavior is preserved for existing HIL scenarios).
         double bed_target_c = bed_c;
         json_number(request, "bed_target_c", &bed_target_c);
-        pb_policy_set_env((float)bed_c, (float)bed_target_c, cJSON_IsTrue(connected));
+        // src_target_c: optional source-requested chamber target (Bambu filament zone);
+        // absent -> 0 (normal bed-AUTO), so existing scenarios are unchanged.
+        double src_target_c = 0.0;
+        json_number(request, "src_target_c", &src_target_c);
+        pb_policy_set_env((float)bed_c, (float)bed_target_c, cJSON_IsTrue(connected), (float)src_target_c);
         cJSON_AddBoolToObject(response, "ok", true);
     } else if (strcmp(cmd->valuestring, "zero_cross") == 0) {
         double count = 1.0;

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -884,6 +884,64 @@ static esp_err_t calibration_post(httpd_req_t *req)
     return calibration_send(req);   // echo the clamped offsets
 }
 
+// --- Filament chamber zones (Bambu) GET/POST /api/v2/zones ------------------
+// The filament -> chamber-target map used by the Bambu heating-zones feature. GET is
+// read-only/open; POST is auth-gated and applies live (no reboot). Values 0..max C,
+// 0 = no zone. Klipper drives the chamber via M141/M191 instead, so this is Bambu-only.
+static esp_err_t zones_send(httpd_req_t *req)
+{
+    cJSON *o = cJSON_CreateObject();
+    if (!o) { httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "oom"); return ESP_FAIL; }
+    cJSON_AddNumberToObject(o, "api_version", API_VERSION);
+    cJSON_AddNumberToObject(o, "max", PB_HEATER_ABS_MAX_TARGET_C);
+    cJSON *arr = cJSON_AddArrayToObject(o, "zones");
+    pb_bambu_zone_t z[PB_BAMBU_ZONE_COUNT];
+    int n = pb_bambu_zone_get_all(z, PB_BAMBU_ZONE_COUNT);
+    for (int i = 0; i < n; i++) {
+        cJSON *e = cJSON_CreateObject();
+        cJSON_AddStringToObject(e, "name", z[i].name);
+        cJSON_AddNumberToObject(e, "target_c", z[i].target_c);
+        cJSON_AddItemToArray(arr, e);
+    }
+    return send_json(req, o);
+}
+
+static esp_err_t zones_get(httpd_req_t *req) { return zones_send(req); }
+
+// POST /api/v2/zones — {"name":"PETG","target_c":45} sets one, or
+// {"zones":[{"name":..,"target_c":..},...]} sets several. Auth-gated; applies live.
+static esp_err_t zones_post(httpd_req_t *req)
+{
+    if (auth_reject(req)) return ESP_OK;
+    cJSON *root = recv_json(req);
+    if (!root)
+        return api_error(req, "400 Bad Request", "invalid_command", "invalid JSON body", NULL);
+
+    bool applied = false;
+    cJSON *arr = cJSON_GetObjectItemCaseSensitive(root, "zones");
+    if (cJSON_IsArray(arr)) {
+        cJSON *e;
+        cJSON_ArrayForEach(e, arr) {
+            cJSON *nm = cJSON_GetObjectItemCaseSensitive(e, "name");
+            double t;
+            if (cJSON_IsString(nm) && json_number(e, "target_c", &t)
+                && pb_bambu_zone_set(nm->valuestring, (uint8_t)(t < 0 ? 0 : t)) == ESP_OK)
+                applied = true;
+        }
+    } else {
+        cJSON *nm = cJSON_GetObjectItemCaseSensitive(root, "name");
+        double t;
+        if (cJSON_IsString(nm) && json_number(root, "target_c", &t)
+            && pb_bambu_zone_set(nm->valuestring, (uint8_t)(t < 0 ? 0 : t)) == ESP_OK)
+            applied = true;
+    }
+    cJSON_Delete(root);
+    if (!applied)
+        return api_error(req, "400 Bad Request", "invalid_command",
+                         "name + target_c (or zones[]) with a known filament required", NULL);
+    return zones_send(req);
+}
+
 // POST /update — stream a new DragonBreath .bin into the inactive OTA slot, verify,
 // set it as boot, and reboot. Auth-gated. SAFETY: refused while the heater is
 // armed/on — a reboot mid-heat leaves the SSR state undefined until re-init, so
@@ -1215,7 +1273,7 @@ esp_err_t pb_httpd_start(void)
     httpd_config_t cfg = HTTPD_DEFAULT_CONFIG();
     cfg.lru_purge_enable = true;
     cfg.uri_match_fn = httpd_uri_match_wildcard;   // lets pb_portal add a "/*" captive catch-all
-    cfg.max_uri_handlers = 29;                     // + /diag, /console, /api/v2/console, /api/v2/boot-inactive, /unbind
+    cfg.max_uri_handlers = 31;                     // + /diag, /console, /api/v2/console, /api/v2/boot-inactive, /unbind, /api/v2/zones (GET+POST)
     // The OTA handler hashes the image (mbedtls) with a 1 KB read buffer + the
     // app descriptor on-stack, which overflows the 4 KB default httpd task stack
     // (stack-protection panic). Give it headroom.
@@ -1261,6 +1319,8 @@ esp_err_t pb_httpd_start(void)
     httpd_uri_t tok    = { .uri = "/api/v2/token",     .method = HTTP_POST, .handler = token_post };
     httpd_uri_t calg   = { .uri = "/api/v2/calibration", .method = HTTP_GET,  .handler = calibration_get };
     httpd_uri_t calp   = { .uri = "/api/v2/calibration", .method = HTTP_POST, .handler = calibration_post };
+    httpd_uri_t zong   = { .uri = "/api/v2/zones",       .method = HTTP_GET,  .handler = zones_get };
+    httpd_uri_t zonp   = { .uri = "/api/v2/zones",       .method = HTTP_POST, .handler = zones_post };
     httpd_register_uri_handler(s_server, &info);
     httpd_register_uri_handler(s_server, &state);
     httpd_register_uri_handler(s_server, &cmd);
@@ -1278,6 +1338,8 @@ esp_err_t pb_httpd_start(void)
     httpd_register_uri_handler(s_server, &tok);
     httpd_register_uri_handler(s_server, &calg);
     httpd_register_uri_handler(s_server, &calp);
+    httpd_register_uri_handler(s_server, &zong);
+    httpd_register_uri_handler(s_server, &zonp);
     ESP_LOGI(TAG, "HTTP API v2 up :80 (info/state/events/health/logs; command/heartbeat/restart/factory-reset/token/calibration; settings; OTA /update)");
     return ESP_OK;
 }

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -164,6 +164,15 @@ static cJSON *state_json(const pb_policy_snapshot_t *s)
         pb_bambu_config_t bc;
         if (pb_bambu_get_config(&bc) == ESP_OK && bc.serial[0])
             cJSON_AddStringToObject(environment, "bambu_serial", bc.serial);
+        // Surface the active print's filament so the dashboard status card can show
+        // "Filament: PETG" while a Bambu print runs (Bambu-only; Klipper drives the
+        // chamber via macros and reports no filament here).
+        pb_bambu_status_t bs;
+        if (pb_bambu_get_status(&bs) == ESP_OK) {
+            cJSON_AddBoolToObject(environment, "bambu_printing", bs.printing);
+            if (bs.printing && bs.filament[0])
+                cJSON_AddStringToObject(environment, "bambu_filament", bs.filament);
+        }
     }
     cJSON_AddBoolToObject(environment, "moonraker_connected", s->moonraker_connected);
     add_num1(environment, "bed_temperature_c", s->bed_c);
@@ -894,13 +903,16 @@ static esp_err_t zones_send(httpd_req_t *req)
     if (!o) { httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "oom"); return ESP_FAIL; }
     cJSON_AddNumberToObject(o, "api_version", API_VERSION);
     cJSON_AddNumberToObject(o, "max", PB_HEATER_ABS_MAX_TARGET_C);
+    cJSON_AddNumberToObject(o, "custom_max", PB_BAMBU_CUSTOM_MAX);
     cJSON *arr = cJSON_AddArrayToObject(o, "zones");
-    pb_bambu_zone_t z[PB_BAMBU_ZONE_COUNT];
-    int n = pb_bambu_zone_get_all(z, PB_BAMBU_ZONE_COUNT);
+    pb_bambu_zone_t z[PB_BAMBU_ZONE_MAX];
+    int n = pb_bambu_zone_get_all(z, PB_BAMBU_ZONE_MAX);
     for (int i = 0; i < n; i++) {
         cJSON *e = cJSON_CreateObject();
         cJSON_AddStringToObject(e, "name", z[i].name);
         cJSON_AddNumberToObject(e, "target_c", z[i].target_c);
+        cJSON_AddNumberToObject(e, "default_c", z[i].default_c);
+        cJSON_AddBoolToObject(e, "custom", z[i].custom);
         cJSON_AddItemToArray(arr, e);
     }
     return send_json(req, o);
@@ -909,13 +921,25 @@ static esp_err_t zones_send(httpd_req_t *req)
 static esp_err_t zones_get(httpd_req_t *req) { return zones_send(req); }
 
 // POST /api/v2/zones — {"name":"PETG","target_c":45} sets one, or
-// {"zones":[{"name":..,"target_c":..},...]} sets several. Auth-gated; applies live.
+// {"zones":[{"name":..,"target_c":..},...]} sets several, or {"remove":"PCTG"} deletes
+// a custom profile. Auth-gated; applies live.
 static esp_err_t zones_post(httpd_req_t *req)
 {
     if (auth_reject(req)) return ESP_OK;
     cJSON *root = recv_json(req);
     if (!root)
         return api_error(req, "400 Bad Request", "invalid_command", "invalid JSON body", NULL);
+
+    // Remove a custom profile.
+    cJSON *rm = cJSON_GetObjectItemCaseSensitive(root, "remove");
+    if (cJSON_IsString(rm)) {
+        esp_err_t err = pb_bambu_zone_remove(rm->valuestring);
+        cJSON_Delete(root);
+        if (err != ESP_OK)
+            return api_error(req, "404 Not Found", "invalid_command",
+                             "no such custom profile (built-ins cannot be removed)", NULL);
+        return zones_send(req);
+    }
 
     bool applied = false;
     cJSON *arr = cJSON_GetObjectItemCaseSensitive(root, "zones");

--- a/components/pb_policy/include/pb_policy.h
+++ b/components/pb_policy/include/pb_policy.h
@@ -179,7 +179,12 @@ bool  pb_policy_get_filter_auto_enable(void);
 // fan-only filtration band trigger on — heat/airflow engage as soon as the print
 // COMMANDS a bed >= threshold, not when the bed physically reaches it (stock
 // parity). Pass bed_target_c = 0 when unknown/disconnected.
-void pb_policy_set_env(float bed_c, float bed_target_c, bool moonraker_connected);
+//
+// src_target_c is an optional source-requested chamber target (e.g. a Bambu filament
+// zone while a print is active): when > 0 in AUTO mode it engages heat to that target
+// directly, overriding the configured AUTO target and bypassing the bed threshold
+// ("zone wins"). Pass 0 for the normal bed-threshold AUTO behaviour.
+void pb_policy_set_env(float bed_c, float bed_target_c, bool source_connected, float src_target_c);
 
 // Refresh exactly the active lease.  A stale/superseded lease cannot keep heat
 // alive.

--- a/components/pb_policy/pb_policy.c
+++ b/components/pb_policy/pb_policy.c
@@ -73,6 +73,9 @@ typedef struct {
     float auto_bed_threshold_c;
     bool auto_engaged;
     bool auto_filtering;         // AUTO fan-only band latch (blower on, no heat)
+    float src_target_c;          // source-requested chamber target (e.g. Bambu filament
+                                 // zone); 0 = none. When >0 in AUTO it engages heat to
+                                 // this target directly, bypassing the bed threshold.
 
     int64_t drying_deadline_us;
     int64_t local_power_deadline_us;
@@ -621,13 +624,18 @@ void pb_policy_stop_drying(pb_source_t source)
     pb_policy_set_mode_off(source);
 }
 
-void pb_policy_set_env(float bed_c, float bed_target_c, bool moonraker_connected)
+void pb_policy_set_env(float bed_c, float bed_target_c, bool source_connected, float src_target_c)
 {
     if (!s_lock) return;
+    // Clamp the source-requested target to the settable ceiling; the fixed heater
+    // cutoffs (chamber/element over-temp) still protect regardless.
+    if (!isfinite(src_target_c) || src_target_c < 0.0f) src_target_c = 0.0f;
+    if (src_target_c > PB_HEATER_ABS_MAX_TARGET_C) src_target_c = PB_HEATER_ABS_MAX_TARGET_C;
     xSemaphoreTake(s_lock, portMAX_DELAY);
     s.bed_c = isfinite(bed_c) ? bed_c : 0.0f;
     s.bed_target_c = isfinite(bed_target_c) ? bed_target_c : 0.0f;
-    s.mk_connected = moonraker_connected;
+    s.mk_connected = source_connected;
+    s.src_target_c = src_target_c;
     xSemaphoreGive(s_lock);
 }
 
@@ -881,6 +889,13 @@ void pb_policy_tick(void)
             bool was_engaged = s.auto_engaged;
             if (!s.mk_connected) {
                 s.auto_engaged = false;
+            } else if (s.src_target_c > 0.0f) {
+                // Source-requested chamber target (e.g. a Bambu filament zone while a
+                // print is active): engage heat directly, bypassing the bed-setpoint
+                // threshold ("zone wins"). Clears when the source drops it to 0 (print
+                // end / no zone), falling back to the bed-threshold logic below and
+                // then to disengage — i.e. revert to idle/AUTO.
+                s.auto_engaged = true;
             } else if (!s.auto_engaged && s.bed_target_c >= s.auto_bed_threshold_c) {
                 s.auto_engaged = true;
             } else if (s.auto_engaged
@@ -893,7 +908,9 @@ void pb_policy_tick(void)
             if (s.auto_engaged != was_engaged)
                 revision_advance_locked(s.source);
             if (s.auto_engaged) {
-                target = s.requested_target_c;
+                // The source-requested zone target overrides the configured AUTO
+                // target when present; otherwise the normal AUTO target applies.
+                target = (s.src_target_c > 0.0f) ? s.src_target_c : s.requested_target_c;
                 autonomous = true;
             }
             break;

--- a/components/pb_portal/pb_portal.c
+++ b/components/pb_portal/pb_portal.c
@@ -842,7 +842,7 @@ static esp_err_t save_post(httpd_req_t *req)
         int nz = pb_bambu_zone_get_all(zones, PB_BAMBU_ZONE_COUNT);
         for (int i = 0; i < nz; i++) {
             char field[12] = {0}, val[8] = {0};
-            snprintf(field, sizeof field, "z_%.7s", zones[i].name);   // name is char[8]
+            snprintf(field, sizeof field, "z_%.7s", zones[i].name);   // built-ins only; names ≤4 chars
             form_get(body, field, val, sizeof val);
             if (val[0]) {
                 int t = atoi(val);

--- a/components/pb_portal/pb_portal.c
+++ b/components/pb_portal/pb_portal.c
@@ -641,9 +641,29 @@ static esp_err_t config_page(httpd_req_t *req)
     snprintf(buf, sizeof buf,
         "<label>Serial</label><input name=bb_serial value=\"%s\" placeholder='e.g. 01P00A000000000'>"
         "<label>LAN access code</label><input name=bb_code type=password placeholder='(unchanged)' autocomplete=off>"
-        "<small style='color:var(--muted)'>Enable <b>LAN Only Mode</b> on the printer; use its Access Code.</small></div>",
+        "<small style='color:var(--muted)'>Enable <b>LAN Only Mode</b> on the printer; use its Access Code.</small>",
         esc);
     SEND(req, buf);
+    // Filament chamber zones (Bambu only) — lives inside the Bambu group so it's
+    // shown only when Bambu is the control source (Klipper uses M141/M191 instead).
+    SEND(req,
+        "<label style='margin-top:10px'>Chamber zones \xC2\xB7 \xC2\xB0""C (0 = off)</label>"
+        "<small style='color:var(--muted);display:block;margin:-4px 0 6px'>"
+        "When a Bambu print runs, the chamber follows the active filament's target "
+        "here (overrides bed-follow).</small>");
+    {
+        pb_bambu_zone_t zones[PB_BAMBU_ZONE_COUNT];
+        int nz = pb_bambu_zone_get_all(zones, PB_BAMBU_ZONE_COUNT);
+        for (int i = 0; i < nz; i++) {
+            snprintf(buf, sizeof buf,
+                "<div style='display:flex;align-items:center;gap:8px;margin-bottom:4px'>"
+                "<label style='flex:1;margin:0'>%s</label>"
+                "<input name=z_%s type=number min=0 max=70 value=%u style='width:5.5em'></div>",
+                zones[i].name, zones[i].name, (unsigned)zones[i].target_c);
+            SEND(req, buf);
+        }
+    }
+    SEND(req, "</div>");   // close the Bambu group
 
     // Home Assistant group.
     html_attr_escape(ha_host, esc, sizeof esc);
@@ -750,7 +770,7 @@ static esp_err_t save_post(httpd_req_t *req)
 
     // Larger than the Wi-Fi-only form: now also carries the control-source
     // selector + Klipper/Bambu/HA field groups (all groups submit, even hidden).
-    char body[1024];
+    char body[1536];   // fits all field groups incl. the 6 Bambu chamber-zone inputs
     int total = 0, r;
     while ((r = httpd_req_recv(req, body + total, sizeof body - 1 - total)) > 0) {
         total += r;
@@ -813,6 +833,23 @@ static esp_err_t save_post(httpd_req_t *req)
         if (ha_topic[0]) nvs_set_str(h, "ha_topic", ha_topic);
         nvs_commit(h);
         nvs_close(h);
+    }
+
+    // Filament chamber zones (z_<TYPE>). pb_bambu_zone_set() opens its own NVS
+    // handle, so do this after the block above closes. Only write on change.
+    {
+        pb_bambu_zone_t zones[PB_BAMBU_ZONE_COUNT];
+        int nz = pb_bambu_zone_get_all(zones, PB_BAMBU_ZONE_COUNT);
+        for (int i = 0; i < nz; i++) {
+            char field[12] = {0}, val[8] = {0};
+            snprintf(field, sizeof field, "z_%.7s", zones[i].name);   // name is char[8]
+            form_get(body, field, val, sizeof val);
+            if (val[0]) {
+                int t = atoi(val);
+                if (t >= 0 && t <= 70 && (uint8_t)t != zones[i].target_c)
+                    pb_bambu_zone_set(zones[i].name, (uint8_t)t);
+            }
+        }
     }
 
     httpd_resp_set_type(req, "text/html; charset=utf-8");

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -382,6 +382,8 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
   .app-version{ display: block; }
   .chamber-reading strong{ font-size: 32px; }
 }
+.zones-list .zone-row{ display: flex; align-items: center; justify-content: space-between; gap: 8px; margin: 4px 0; }
+.zones-list .zone-in{ width: 5.5em; }
 </style>
 </head>
 <body>
@@ -391,6 +393,7 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
   <symbol id="i-flame" viewBox="0 0 24 24"><path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.07-2.14-.22-4.05 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.15.43-2.29 1-3a2.5 2.5 0 0 0 2.5 2.5z"/></symbol>
   <symbol id="i-refresh" viewBox="0 0 24 24"><path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"/><path d="M21 21v-5h-5"/></symbol>
   <symbol id="i-wind" viewBox="0 0 24 24"><path d="M12.8 19.6A2 2 0 1 0 14 16H2"/><path d="M17.5 8A2.5 2.5 0 1 1 19.5 12H2"/><path d="M9.8 4.4A2 2 0 1 1 11 8H2"/></symbol>
+  <symbol id="i-spool" viewBox="0 0 24 24"><rect x="4" y="3" width="3" height="18" rx="1"/><rect x="17" y="3" width="3" height="18" rx="1"/><path d="M7 8h10M7 12h10M7 16h10"/></symbol>
   <symbol id="i-fan" viewBox="0 0 24 24"><path d="M10.827 16.379a6.082 6.082 0 0 1-8.618-7.002l5.412 1.45a6.082 6.082 0 0 1 7.002-8.618l-1.45 5.412a6.082 6.082 0 0 1 8.618 7.002l-5.412-1.45a6.082 6.082 0 0 1-7.002 8.618l1.45-5.412Z"/><path d="M12 12v.01"/></symbol>
   <symbol id="i-settings" viewBox="0 0 24 24"><path d="M20 7h-9"/><path d="M14 17H5"/><circle cx="17" cy="17" r="3"/><circle cx="7" cy="7" r="3"/></symbol>
   <symbol id="i-thermometer" viewBox="0 0 24 24"><path d="M14 4v10.54a4 4 0 1 1-4 0V4a2 2 0 0 1 4 0z"/></symbol>
@@ -477,6 +480,13 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
           <div class="quick-actions">
             <button class="btn" type="button" id="db-filter" aria-pressed="false"><svg class="icon"><use href="#i-fan"/></svg> <span id="db-filter-label">Filtration</span></button>
           </div>
+        </section>
+        <!-- Filament chamber zones (Bambu only): shown when the control source is
+             Bambu; edits apply live via /api/v2/zones (no reboot). -->
+        <section class="card zones-card" id="zones-card" hidden>
+          <h3><svg class="icon"><use href="#i-spool"/></svg> Filament zones</h3>
+          <p class="muted">Chamber target by filament while a Bambu print runs (°C, 0 = off).</p>
+          <div id="zones-list" class="zones-list"></div>
         </section>
       </div>
 
@@ -945,6 +955,32 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
     return s.mode==='off' ? '—' : sourceLabel(s.source);
   }
 
+  /* Filament chamber zones (Bambu only). Fetched once when the Bambu card first
+     shows; each input edit is applied live via POST /api/v2/zones (no reboot). */
+  var zonesLoaded = false;
+  function renderZones(zones){
+    var list = document.getElementById('zones-list');
+    if(!list) return;
+    list.innerHTML = zones.map(function(z){
+      return '<div class="zone-row"><label>'+z.name+'</label>'+
+        '<input class="zone-in" type="number" min="0" max="70" step="1" data-zone="'+z.name+'" value="'+z.target_c+'"></div>';
+    }).join('');
+    list.querySelectorAll('.zone-in').forEach(function(inp){
+      inp.addEventListener('change', function(){
+        var v = Math.max(0, Math.min(70, parseInt(inp.value||'0',10)||0));
+        inp.value = v;
+        fetch('/api/v2/zones',{method:'POST',headers:hdr(),body:JSON.stringify({name:inp.dataset.zone,target_c:v})}).catch(function(){});
+      });
+    });
+  }
+  function loadZones(){
+    if(zonesLoaded) return;
+    zonesLoaded = true;
+    fetch('/api/v2/zones').then(function(r){return r.json();})
+      .then(function(d){ renderZones(d.zones||[]); })
+      .catch(function(){ zonesLoaded = false; });
+  }
+
   function apply(s){
     if(!s || s.api_version!==2) return;
     if(last && s.boot_id===last.boot_id && s.state_revision<rev) return;
@@ -1005,6 +1041,8 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
        link + bed); Home Assistant has no printer to follow (HA is the controller),
        so relabel the row and show the source instead of a misleading "not connected". */
     var src = s.environment.control_source || 'klipper';
+    var zc = document.getElementById('zones-card');
+    if(zc){ zc.hidden = (src!=='bambu'); if(src==='bambu') loadZones(); }
     var plabel = $('db-printer-label');
     if(src==='ha'){
       if(plabel) plabel.textContent='Source';

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -383,11 +383,19 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
   .chamber-reading strong{ font-size: 32px; }
 }
 .zones-list{ display: grid; grid-template-columns: 1fr auto; gap: 7px 12px; align-items: center; margin-top: 10px; }
-.zones-list .zone-lbl{ color: var(--muted-foreground); font-size: 13px; }
+#zones-custom-list{ grid-template-columns: 1fr auto auto; }
+.zones-list .zone-lbl{ color: var(--foreground); font-size: 13px; display: flex; flex-direction: column; }
+.zones-list .zone-def{ color: var(--muted-foreground); font-size: 11px; }
 .zones-list .zone-in{ width: 4.2em; text-align: center; padding: 5px 6px; font: inherit;
   color: var(--foreground); background: var(--background);
   border: 1px solid var(--input); border-radius: var(--radius-lg); }
 .zones-list .zone-in:focus{ outline: none; border-color: var(--primary); }
+.zones-list .zone-rm{ background: none; border: none; color: var(--muted-foreground); cursor: pointer;
+  padding: 4px; display: inline-flex; border-radius: var(--radius-lg); }
+.zones-list .zone-rm:hover{ color: var(--destructive, #e5484d); background: var(--input); }
+.zones-add{ display: flex; gap: 8px; align-items: center; margin-top: 12px; }
+.zones-add .zone-in-name{ width: auto; flex: 1; text-align: left; }
+.zones-empty{ color: var(--muted-foreground); font-size: 13px; margin-top: 10px; }
 </style>
 </head>
 <body>
@@ -404,6 +412,7 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
   <symbol id="i-power" viewBox="0 0 24 24"><path d="M12 2v10"/><path d="M18.4 6.6a9 9 0 1 1-12.8 0"/></symbol>
   <symbol id="i-minus" viewBox="0 0 24 24"><path d="M5 12h14"/></symbol>
   <symbol id="i-plus" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></symbol>
+  <symbol id="i-trash" viewBox="0 0 24 24"><path d="M3 6h18M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2M19 6l-1 14a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1L5 6"/></symbol>
   <symbol id="i-play" viewBox="0 0 24 24"><path d="M6 3l14 9-14 9z"/></symbol>
   <symbol id="i-square" viewBox="0 0 24 24"><rect x="5" y="5" width="14" height="14" rx="2"/></symbol>
   <symbol id="i-clock" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></symbol>
@@ -463,6 +472,7 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
             <div id="db-auto-row" hidden><dt>Auto</dt><dd id="db-auto">--</dd></div>
             <div id="db-drying-row" hidden><dt>Drying</dt><dd id="db-drying">--</dd></div>
             <div><dt id="db-printer-label">Printer</dt><dd id="db-printer">--</dd></div>
+            <div id="db-filament-row" hidden><dt>Filament</dt><dd id="db-filament">--</dd></div>
             <div><dt>Fault</dt><dd id="db-fault">--</dd></div>
           </dl>
           <div class="actions">
@@ -486,11 +496,22 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
           </div>
         </section>
         <!-- Filament chamber zones (Bambu only): shown when the control source is
-             Bambu; edits apply live via /api/v2/zones (no reboot). -->
+             Bambu; edits apply live via /api/v2/zones (no reboot). Two cards: the
+             built-in filament types (left) and user-added custom profiles (right). -->
         <section class="card zones-card" id="zones-card" hidden>
           <h3><svg class="icon"><use href="#i-spool"/></svg> Filament zones</h3>
           <p class="muted">Chamber target by filament while a Bambu print runs (°C, 0 = off).</p>
           <div id="zones-list" class="zones-list"></div>
+        </section>
+        <section class="card zones-card" id="zones-custom-card" hidden>
+          <h3><svg class="icon"><use href="#i-spool"/></svg> Custom profiles</h3>
+          <p class="muted">Add profiles for filaments not in the built-in set (PA, PCTG, …).</p>
+          <div id="zones-custom-list" class="zones-list"></div>
+          <div class="zones-add">
+            <input id="zc-name" class="zone-in zone-in-name" type="text" placeholder="name" maxlength="11" autocomplete="off">
+            <input id="zc-temp" class="zone-in" type="number" min="0" max="70" step="1" placeholder="°C">
+            <button class="btn btn-sm" type="button" id="zc-add"><svg class="icon"><use href="#i-plus"/></svg> Add</button>
+          </div>
         </section>
       </div>
 
@@ -961,27 +982,65 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
 
   /* Filament chamber zones (Bambu only). Fetched once when the Bambu card first
      shows; each input edit is applied live via POST /api/v2/zones (no reboot). */
-  var zonesLoaded = false;
+  var zonesLoaded = false, zonesCustomMax = 8;
+  function esc(t){ return String(t).replace(/[<>&"]/g, function(ch){
+    return {'<':'&lt;','>':'&gt;','&':'&amp;','"':'&quot;'}[ch]; }); }
+  /* Push a single zone target (create/update) then re-render both lists. */
+  function zoneSet(name, v){
+    fetch('/api/v2/zones',{method:'POST',headers:hdr(),body:JSON.stringify({name:name,target_c:v})})
+      .then(function(r){return r.json();}).then(function(d){ if(d && d.zones) renderZones(d.zones); }).catch(function(){});
+  }
+  function zoneRemove(name){
+    fetch('/api/v2/zones',{method:'POST',headers:hdr(),body:JSON.stringify({remove:name})})
+      .then(function(r){return r.json();}).then(function(d){ if(d && d.zones) renderZones(d.zones); }).catch(function(){});
+  }
   function renderZones(zones){
-    var list = document.getElementById('zones-list');
-    if(!list) return;
-    list.innerHTML = zones.map(function(z){
-      return '<span class="zone-lbl">'+z.name+'</span>'+
-        '<input class="zone-in" type="number" min="0" max="70" step="1" data-zone="'+z.name+'" value="'+z.target_c+'">';
+    var builtins = document.getElementById('zones-list');
+    var customs  = document.getElementById('zones-custom-list');
+    if(!builtins || !customs) return;
+    var bi = zones.filter(function(z){ return !z.custom; });
+    var cu = zones.filter(function(z){ return z.custom; });
+    builtins.innerHTML = bi.map(function(z){
+      var def = z.default_c ? 'default '+z.default_c+' °C' : 'default off';
+      return '<span class="zone-lbl">'+esc(z.name)+'<span class="zone-def">'+def+'</span></span>'+
+        '<input class="zone-in" type="number" min="0" max="70" step="1" data-zone="'+esc(z.name)+'" value="'+z.target_c+'">';
     }).join('');
-    list.querySelectorAll('.zone-in').forEach(function(inp){
-      inp.addEventListener('change', function(){
-        var v = Math.max(0, Math.min(70, parseInt(inp.value||'0',10)||0));
-        inp.value = v;
-        fetch('/api/v2/zones',{method:'POST',headers:hdr(),body:JSON.stringify({name:inp.dataset.zone,target_c:v})}).catch(function(){});
+    customs.innerHTML = cu.length ? cu.map(function(z){
+      return '<span class="zone-lbl">'+esc(z.name)+'</span>'+
+        '<input class="zone-in" type="number" min="0" max="70" step="1" data-zone="'+esc(z.name)+'" value="'+z.target_c+'">'+
+        '<button class="zone-rm" type="button" title="Remove" data-rm="'+esc(z.name)+'"><svg class="icon"><use href="#i-trash"/></svg></button>';
+    }).join('') : '<span class="zones-empty">No custom profiles yet.</span>';
+    [builtins, customs].forEach(function(list){
+      list.querySelectorAll('.zone-in').forEach(function(inp){
+        inp.addEventListener('change', function(){
+          var v = Math.max(0, Math.min(70, parseInt(inp.value||'0',10)||0));
+          inp.value = v; zoneSet(inp.dataset.zone, v);
+        });
+      });
+      list.querySelectorAll('.zone-rm').forEach(function(btn){
+        btn.addEventListener('click', function(){ zoneRemove(btn.dataset.rm); });
       });
     });
+    // Disable the add button once the custom store is full.
+    var add = document.getElementById('zc-add');
+    if(add) add.disabled = (cu.length >= zonesCustomMax);
+  }
+  function zoneAdd(){
+    var ni = document.getElementById('zc-name'), ti = document.getElementById('zc-temp');
+    if(!ni || !ti) return;
+    var name = (ni.value||'').trim();
+    if(!name) { ni.focus(); return; }
+    var v = Math.max(0, Math.min(70, parseInt(ti.value||'0',10)||0));
+    zoneSet(name, v);
+    ni.value=''; ti.value=''; ni.focus();
   }
   function loadZones(){
     if(zonesLoaded) return;
     zonesLoaded = true;
+    var add = document.getElementById('zc-add');
+    if(add) add.addEventListener('click', zoneAdd);
     fetch('/api/v2/zones').then(function(r){return r.json();})
-      .then(function(d){ renderZones(d.zones||[]); })
+      .then(function(d){ if(d.custom_max) zonesCustomMax = d.custom_max; renderZones(d.zones||[]); })
       .catch(function(){ zonesLoaded = false; });
   }
 
@@ -1045,8 +1104,18 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
        link + bed); Home Assistant has no printer to follow (HA is the controller),
        so relabel the row and show the source instead of a misleading "not connected". */
     var src = s.environment.control_source || 'klipper';
+    var isBambu = (src==='bambu');
     var zc = document.getElementById('zones-card');
-    if(zc){ zc.hidden = (src!=='bambu'); if(src==='bambu') loadZones(); }
+    var zcc = document.getElementById('zones-custom-card');
+    if(zc){ zc.hidden = !isBambu; if(isBambu) loadZones(); }
+    if(zcc) zcc.hidden = !isBambu;
+    /* Bambu-only: show the active print's filament in the status card. */
+    var frow = $('db-filament-row');
+    if(frow){
+      var fila = isBambu && s.environment.bambu_printing ? s.environment.bambu_filament : null;
+      frow.hidden = !fila;
+      if(fila) u('db-filament', fila);
+    }
     var plabel = $('db-printer-label');
     if(src==='ha'){
       if(plabel) plabel.textContent='Source';

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -382,8 +382,12 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
   .app-version{ display: block; }
   .chamber-reading strong{ font-size: 32px; }
 }
-.zones-list .zone-row{ display: flex; align-items: center; justify-content: space-between; gap: 8px; margin: 4px 0; }
-.zones-list .zone-in{ width: 5.5em; }
+.zones-list{ display: grid; grid-template-columns: 1fr auto; gap: 7px 12px; align-items: center; margin-top: 10px; }
+.zones-list .zone-lbl{ color: var(--muted-foreground); font-size: 13px; }
+.zones-list .zone-in{ width: 4.2em; text-align: center; padding: 5px 6px; font: inherit;
+  color: var(--foreground); background: var(--background);
+  border: 1px solid var(--input); border-radius: var(--radius-lg); }
+.zones-list .zone-in:focus{ outline: none; border-color: var(--primary); }
 </style>
 </head>
 <body>
@@ -962,8 +966,8 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
     var list = document.getElementById('zones-list');
     if(!list) return;
     list.innerHTML = zones.map(function(z){
-      return '<div class="zone-row"><label>'+z.name+'</label>'+
-        '<input class="zone-in" type="number" min="0" max="70" step="1" data-zone="'+z.name+'" value="'+z.target_c+'"></div>';
+      return '<span class="zone-lbl">'+z.name+'</span>'+
+        '<input class="zone-in" type="number" min="0" max="70" step="1" data-zone="'+z.name+'" value="'+z.target_c+'">';
     }).join('');
     list.querySelectorAll('.zone-in').forEach(function(inp){
       inp.addEventListener('change', function(){

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -207,7 +207,7 @@ static void control_task(void *arg)
         // is source-agnostic and triggers AUTO on the bed SETPOINT (bed_target_c).
         // Not-connected feeds zeros/false (identical to the pre-selector behavior
         // when Moonraker was down).
-        float bed_c = 0.0f, bed_target_c = 0.0f;
+        float bed_c = 0.0f, bed_target_c = 0.0f, src_target_c = 0.0f;
         bool  src_connected = false;
         if (s_net_up) {
             switch (s_src) {
@@ -219,6 +219,9 @@ static void control_task(void *arg)
                     if (src_connected) {
                         if (isfinite(bs.bed_temp))   bed_c = bs.bed_temp;
                         if (isfinite(bs.bed_target)) bed_target_c = bs.bed_target;
+                        // Filament chamber zone: while a print is active, request the
+                        // active filament's zone target (0 = no zone -> normal bed-AUTO).
+                        if (bs.printing) src_target_c = (float)pb_bambu_zone_target(bs.filament);
                     }
                 }
                 break;
@@ -241,7 +244,7 @@ static void control_task(void *arg)
                 break;
             }
         }
-        pb_policy_set_env(bed_c, bed_target_c, src_connected);
+        pb_policy_set_env(bed_c, bed_target_c, src_connected, src_target_c);
 #endif
 
         // Safety/control loop: enforces every heater cutoff + fan-follows-heater.

--- a/tests/pb_bambu_host_test.c
+++ b/tests/pb_bambu_host_test.c
@@ -87,6 +87,28 @@ int main(void)
     expect_zone("PVA", -1);      // unknown -> no zone
     expect_zone("", -1);
 
+    // --- longest-prefix wins when a custom profile shadows a built-in ---
+    // Combined built-ins + customs, exactly as pb_bambu_zone_target builds the array.
+    {
+        static const char *const combo[] = { "PLA","PETG","ABS","ASA","PC","TPU","PETG-CF","PA" };
+        int n = 8;
+        struct { const char *fil; int want; } cases[] = {
+            { "PETG-CF Bambu", 6 },   // custom "PETG-CF" beats built-in "PETG"
+            { "PETG",          1 },   // plain PETG still the built-in
+            { "PAHT-CF",       7 },   // custom "PA" prefix matches
+            { "PA6-GF",        7 },
+            { "PC",            4 },
+            { "PVA",          -1 },
+        };
+        for (unsigned i = 0; i < sizeof cases / sizeof cases[0]; i++) {
+            int got = pb_bambu_zone_match(cases[i].fil, combo, n);
+            int ok = got == cases[i].want;
+            if (!ok) fails++;
+            printf("[%s] custom-zone %-14s want=%d got=%d\n", ok ? "PASS" : "FAIL",
+                   cases[i].fil, cases[i].want, got);
+        }
+    }
+
     // --- print-state classifier (preheat starts on PREPARE) ---
     expect_active("PREPARE", 1);
     expect_active("RUNNING", 1);

--- a/tests/pb_bambu_host_test.c
+++ b/tests/pb_bambu_host_test.c
@@ -54,8 +54,21 @@ int main(void)
     expect_fila("delta no filament",
         "{\"print\":{\"bed_temper\":60.0,\"chamber_temper\":40.0}}",
         PB_FILA_ABSENT, NULL);
-    // The reviewer's PETG -> no-spool transition: the second report is EMPTY, which
-    // is what tells parse_report to clear the stored PETG (see pb_bambu.c).
+    // ABSENT: partial-AMS delta — slot is named (tray_now) but the tray payload is
+    // absent. Must NOT clear a known filament (review round 2).
+    expect_fila("partial-ams delta",
+        "{\"print\":{\"ams\":{\"tray_now\":\"0\"}}}",
+        PB_FILA_ABSENT, NULL);
+    // ABSENT: external selected (254) but no vt_tray payload in this delta -> keep.
+    expect_fila("ext selected, no vt",
+        "{\"print\":{\"ams\":{\"tray_now\":\"254\"}}}",
+        PB_FILA_ABSENT, NULL);
+    // EMPTY: external spool present but explicitly empty -> clear.
+    expect_fila("ext spool empty",
+        "{\"print\":{\"vt_tray\":{\"id\":\"254\",\"tray_type\":\"\"}}}",
+        PB_FILA_EMPTY, NULL);
+    // The reviewer's PETG -> no-spool transition: an EMPTY report tells parse_report
+    // to clear the stored PETG (see pb_bambu.c); ABSENT deltas leave it untouched.
 
     // --- filament -> zone matching (case-insensitive prefix) ---
     expect_zone("PETG", 1);

--- a/tests/pb_bambu_host_test.c
+++ b/tests/pb_bambu_host_test.c
@@ -28,6 +28,14 @@ static void expect_zone(const char *filament, int want_idx)
     printf("[%s] zone %-12s want=%d got=%d\n", ok ? "PASS" : "FAIL", filament, want_idx, got);
 }
 
+static void expect_active(const char *state, int want)
+{
+    int got = pb_bambu_gcode_active(state);
+    int ok = got == want;
+    if (!ok) fails++;
+    printf("[%s] gcode %-9s want=%d got=%d\n", ok ? "PASS" : "FAIL", state, want, got);
+}
+
 int main(void)
 {
     // --- active-filament tri-state ---
@@ -78,6 +86,15 @@ int main(void)
     expect_zone("petg", 1);      // case-insensitive
     expect_zone("PVA", -1);      // unknown -> no zone
     expect_zone("", -1);
+
+    // --- print-state classifier (preheat starts on PREPARE) ---
+    expect_active("PREPARE", 1);
+    expect_active("RUNNING", 1);
+    expect_active("PAUSE",   1);
+    expect_active("IDLE",    0);
+    expect_active("FINISH",  0);
+    expect_active("FAILED",  0);
+    expect_active("",        0);
 
     printf(fails ? "\n%d FAILED\n" : "\nALL PASS\n", fails);
     return fails ? 1 : 0;

--- a/tests/pb_bambu_host_test.c
+++ b/tests/pb_bambu_host_test.c
@@ -1,0 +1,71 @@
+// Host unit test for the Bambu report parser (pb_bambu_parse.h): active-filament
+// tri-state resolution and filament->zone matching. Pure logic, no ESP deps.
+#include "pb_bambu_parse.h"
+#include <stdio.h>
+#include <string.h>
+
+static int fails = 0;
+
+static void expect_fila(const char *name, const char *json,
+                        pb_fila_result_t want_r, const char *want_s)
+{
+    char got[16];
+    pb_fila_result_t r = pb_bambu_active_filament(json, got, sizeof got);
+    int ok = (r == want_r) && (want_r != PB_FILA_PRESENT || strcmp(got, want_s) == 0);
+    if (!ok) fails++;
+    static const char *R[] = { "ABSENT", "EMPTY", "PRESENT" };
+    printf("[%s] %-22s want=%s/%-6s got=%s/%s\n", ok ? "PASS" : "FAIL", name,
+           R[want_r], want_r == PB_FILA_PRESENT ? want_s : "-",
+           R[r], r == PB_FILA_PRESENT ? got : "-");
+}
+
+static void expect_zone(const char *filament, int want_idx)
+{
+    static const char *const names[] = { "PLA", "PETG", "ABS", "ASA", "PC", "TPU" };
+    int got = pb_bambu_zone_match(filament, names, 6);
+    int ok = got == want_idx;
+    if (!ok) fails++;
+    printf("[%s] zone %-12s want=%d got=%d\n", ok ? "PASS" : "FAIL", filament, want_idx, got);
+}
+
+int main(void)
+{
+    // --- active-filament tri-state ---
+    // PRESENT: AMS active tray carries a type.
+    expect_fila("ams tray0 PETG",
+        "{\"print\":{\"ams\":{\"ams\":[{\"tray\":[{\"tray_type\":\"PETG\"},{\"tray_type\":\"PLA\"}]}],\"tray_now\":\"0\"},\"vt_tray\":{\"tray_type\":\"\"}}}",
+        PB_FILA_PRESENT, "PETG");
+    expect_fila("ams tray1 PLA",
+        "{\"print\":{\"ams\":{\"ams\":[{\"tray\":[{\"tray_type\":\"PETG\"},{\"tray_type\":\"PLA\"}]}],\"tray_now\":\"1\"}}}",
+        PB_FILA_PRESENT, "PLA");
+    // PRESENT: external spool.
+    expect_fila("ext spool ABS",
+        "{\"print\":{\"ams\":{\"tray_now\":\"254\"},\"vt_tray\":{\"id\":\"254\",\"tray_type\":\"ABS\"}}}",
+        PB_FILA_PRESENT, "ABS");
+    // EMPTY: explicit no-spool (tray_now 255) MUST clear a prior value.
+    expect_fila("none tray_now=255",
+        "{\"print\":{\"ams\":{\"tray_now\":\"255\"},\"vt_tray\":{\"tray_type\":\"\"}}}",
+        PB_FILA_EMPTY, NULL);
+    // EMPTY: active AMS slot with an empty type (unloaded) -> clear.
+    expect_fila("ams tray0 empty",
+        "{\"print\":{\"ams\":{\"ams\":[{\"tray\":[{\"tray_type\":\"\"}]}],\"tray_now\":\"0\"}}}",
+        PB_FILA_EMPTY, NULL);
+    // ABSENT: a delta report that omits filament state -> keep prior (no clobber).
+    expect_fila("delta no filament",
+        "{\"print\":{\"bed_temper\":60.0,\"chamber_temper\":40.0}}",
+        PB_FILA_ABSENT, NULL);
+    // The reviewer's PETG -> no-spool transition: the second report is EMPTY, which
+    // is what tells parse_report to clear the stored PETG (see pb_bambu.c).
+
+    // --- filament -> zone matching (case-insensitive prefix) ---
+    expect_zone("PETG", 1);
+    expect_zone("PETG-CF", 1);
+    expect_zone("PLA Basic", 0);
+    expect_zone("ASA-CF", 3);
+    expect_zone("petg", 1);      // case-insensitive
+    expect_zone("PVA", -1);      // unknown -> no zone
+    expect_zone("", -1);
+
+    printf(fails ? "\n%d FAILED\n" : "\nALL PASS\n", fails);
+    return fails ? 1 : 0;
+}

--- a/tests/pb_policy_host_test.c
+++ b/tests/pb_policy_host_test.c
@@ -336,27 +336,27 @@ static void test_auto_requires_live_moonraker_and_uses_hysteresis(void)
     CHECK(pb_policy_set_auto(
         60.0f, 100.0f, PB_SOURCE_WEB, 1) == PB_POLICY_OK);
 
-    pb_policy_set_env(99.0f, 99.0f, true);
+    pb_policy_set_env(99.0f, 99.0f, true, 0.0f);
     pb_policy_tick();
     CHECK(snapshot().effective_target_c == 0.0f);
 
-    pb_policy_set_env(100.0f, 100.0f, true);
+    pb_policy_set_env(100.0f, 100.0f, true, 0.0f);
     pb_policy_tick();
     pb_policy_snapshot_t snap = snapshot();
     CHECK(snap.auto_engaged);
     CHECK(snap.effective_target_c == 60.0f);
 
-    pb_policy_set_env(98.0f, 98.0f, true);
+    pb_policy_set_env(98.0f, 98.0f, true, 0.0f);
     pb_policy_tick();
     CHECK(snapshot().auto_engaged);
 
-    pb_policy_set_env(96.9f, 96.9f, true);
+    pb_policy_set_env(96.9f, 96.9f, true, 0.0f);
     pb_policy_tick();
     snap = snapshot();
     CHECK(!snap.auto_engaged);
     CHECK(snap.effective_target_c == 0.0f);
 
-    pb_policy_set_env(105.0f, 105.0f, false);
+    pb_policy_set_env(105.0f, 105.0f, false, 0.0f);
     pb_policy_tick();
     CHECK(!snapshot().auto_engaged);
 
@@ -365,11 +365,11 @@ static void test_auto_requires_live_moonraker_and_uses_hysteresis(void)
     // immediately; a hot bed whose setpoint has dropped disengages.
     CHECK(pb_policy_set_auto(
         60.0f, 100.0f, PB_SOURCE_WEB, PB_POLICY_REVISION_ANY) == PB_POLICY_OK);
-    pb_policy_set_env(20.0f /*measured cold*/, 100.0f /*setpoint*/, true);
+    pb_policy_set_env(20.0f /*measured cold*/, 100.0f /*setpoint*/, true, 0.0f);
     pb_policy_tick();
     CHECK(snapshot().auto_engaged);
     CHECK(snapshot().effective_target_c == 60.0f);
-    pb_policy_set_env(99.0f /*measured hot*/, 0.0f /*setpoint cleared*/, true);
+    pb_policy_set_env(99.0f /*measured hot*/, 0.0f /*setpoint cleared*/, true, 0.0f);
     pb_policy_tick();
     CHECK(!snapshot().auto_engaged);
     CHECK(snapshot().effective_target_c == 0.0f);
@@ -385,14 +385,14 @@ static void test_auto_filtration_band_fan_only_not_cooldown(void)
     CHECK(pb_policy_set_filter_config(30.0f, true) == PB_POLICY_OK);
 
     // Bed below filter_temp: no filtration, fan off.
-    pb_policy_set_env(25.0f, 25.0f, true);
+    pb_policy_set_env(25.0f, 25.0f, true, 0.0f);
     pb_policy_tick();
     pb_policy_snapshot_t snap = snapshot();
     CHECK(!snap.auto_filtering);
     CHECK(snap.effective_fan_percent == 0);
 
     // Bed >= filter_temp but below the heat threshold: fan-only filtration band.
-    pb_policy_set_env(40.0f, 40.0f, true);
+    pb_policy_set_env(40.0f, 40.0f, true, 0.0f);
     pb_policy_tick();
     snap = snapshot();
     CHECK(snap.auto_filtering);                 // filtering
@@ -402,20 +402,20 @@ static void test_auto_filtration_band_fan_only_not_cooldown(void)
     CHECK(!snap.thermal_purge);                 // P1: must NOT read as cooldown purge
 
     // Hysteresis: stays on within [filter_temp - 3, ...); releases only below it.
-    pb_policy_set_env(28.0f, 28.0f, true);
+    pb_policy_set_env(28.0f, 28.0f, true, 0.0f);
     pb_policy_tick();
     CHECK(snapshot().auto_filtering);
-    pb_policy_set_env(26.0f, 26.0f, true);
+    pb_policy_set_env(26.0f, 26.0f, true, 0.0f);
     pb_policy_tick();
     snap = snapshot();
     CHECK(!snap.auto_filtering);
     CHECK(snap.effective_fan_percent == 0);
 
     // Moonraker disconnect fails to no-airflow even with a hot bed.
-    pb_policy_set_env(40.0f, 40.0f, true);
+    pb_policy_set_env(40.0f, 40.0f, true, 0.0f);
     pb_policy_tick();
     CHECK(snapshot().auto_filtering);
-    pb_policy_set_env(40.0f, 40.0f, false);
+    pb_policy_set_env(40.0f, 40.0f, false, 0.0f);
     pb_policy_tick();
     snap = snapshot();
     CHECK(!snap.auto_filtering);
@@ -434,7 +434,7 @@ static void test_filtration_band_runs_outside_auto(void)
     CHECK(snap.mode == PB_MODE_OFF);
 
     // OFF BY DEFAULT (opt-in): a hot bed while idle does NOT filter until enabled.
-    pb_policy_set_env(40.0f, 40.0f, true);
+    pb_policy_set_env(40.0f, 40.0f, true, 0.0f);
     pb_policy_tick();
     snap = snapshot();
     CHECK(!snap.auto_filtering);
@@ -460,7 +460,7 @@ static void test_filtration_band_runs_outside_auto(void)
 
     // Re-enabled but bed setpoint back below filter_temp: no filtration.
     CHECK(pb_policy_set_filter_config(30.0f, true) == PB_POLICY_OK);
-    pb_policy_set_env(20.0f, 20.0f, true);
+    pb_policy_set_env(20.0f, 20.0f, true, 0.0f);
     pb_policy_tick();
     snap = snapshot();
     CHECK(!snap.auto_filtering);
@@ -493,7 +493,7 @@ static void test_runtime_limits_drive_auto_and_remote_lease(void)
     CHECK(pb_policy_set_auto(
         65.0f, 100.0f, PB_SOURCE_WEB, 1) == PB_POLICY_OK);
     CHECK(snapshot().requested_target_c == 52.0f);
-    pb_policy_set_env(100.0f, 100.0f, true);
+    pb_policy_set_env(100.0f, 100.0f, true, 0.0f);
     pb_policy_tick();
     CHECK(snapshot().effective_target_c == 52.0f);
 
@@ -752,12 +752,12 @@ static void test_panel_leds_track_mode(void)
     pb_policy_set_mode_off(PB_SOURCE_WEB);
     CHECK(pb_policy_set_auto(
         60.0f, 100.0f, PB_SOURCE_WEB, PB_POLICY_REVISION_ANY) == PB_POLICY_OK);
-    pb_policy_set_env(20.0f, 20.0f, false);
+    pb_policy_set_env(20.0f, 20.0f, false, 0.0f);
     pb_policy_tick();
     CHECK(led_pattern[PB_LED_AUTO] == PB_LED_BLINK_SLOW);
     CHECK(led_pattern[PB_LED_ON] == PB_LED_OFF);
 
-    pb_policy_set_env(105.0f, 105.0f, true);
+    pb_policy_set_env(105.0f, 105.0f, true, 0.0f);
     pb_policy_tick();
     CHECK(snapshot().auto_engaged);
     CHECK(led_pattern[PB_LED_AUTO] == PB_LED_SOLID);
@@ -1059,6 +1059,39 @@ static void test_purge_decide_session_and_hysteresis(void)
     CHECK(pb_purge_decide(false, &heated, true, 49.9f, true, 49.0f, true, hot) == false);
 }
 
+// A source-requested chamber target (e.g. a Bambu filament zone) engages AUTO heat
+// directly, overriding the configured AUTO target and bypassing the bed threshold
+// ("zone wins"); clearing it reverts to normal bed-AUTO / idle. Value is clamped.
+static void test_auto_source_zone_overrides_bed_threshold(void)
+{
+    reset_fixture();
+    CHECK(pb_policy_set_auto(60.0f, 100.0f, PB_SOURCE_WEB, 1) == PB_POLICY_OK);
+
+    // Cold bed, no bed setpoint (0 < 100) -> bed-AUTO alone does NOT engage.
+    pb_policy_set_env(20.0f, 0.0f, true, 0.0f);
+    pb_policy_tick();
+    CHECK(!snapshot().auto_engaged);
+
+    // A source zone target (55) engages heat and overrides the 60 AUTO target.
+    pb_policy_set_env(20.0f, 0.0f, true, 55.0f);
+    pb_policy_tick();
+    pb_policy_snapshot_t snap = snapshot();
+    CHECK(snap.auto_engaged);
+    CHECK(snap.effective_target_c == 55.0f);
+
+    // Zone clears (print end) with no bed setpoint -> disengage (revert to idle/AUTO).
+    pb_policy_set_env(20.0f, 0.0f, true, 0.0f);
+    pb_policy_tick();
+    snap = snapshot();
+    CHECK(!snap.auto_engaged);
+    CHECK(snap.effective_target_c == 0.0f);
+
+    // Out-of-range zone target is clamped to the settable ceiling (70 C).
+    pb_policy_set_env(20.0f, 0.0f, true, 999.0f);
+    pb_policy_tick();
+    CHECK(snapshot().effective_target_c == 70.0f);
+}
+
 int main(void)
 {
     test_boot_is_off();
@@ -1066,6 +1099,7 @@ int main(void)
     test_new_command_supersedes_old_lease_and_off_is_unconditional();
     test_lease_expiry_latches_watchdog_fault();
     test_auto_requires_live_moonraker_and_uses_hysteresis();
+    test_auto_source_zone_overrides_bed_threshold();
     test_auto_filtration_band_fan_only_not_cooldown();
     test_filtration_band_runs_outside_auto();
     test_drying_is_bounded_and_expires_off();

--- a/tests/run_bambu_host_test.sh
+++ b/tests/run_bambu_host_test.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eu
+
+root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+out="${TMPDIR:-/tmp}/dragonbreath-pb-bambu-test"
+
+# pb_bambu_parse.h is pure (only libc), so no ESP stubs are needed — just its
+# include dir for the header under test.
+cc -std=c11 -Wall -Wextra -Werror \
+  -I"$root/components/pb_bambu/include" \
+  "$root/tests/pb_bambu_host_test.c" \
+  -o "$out"
+
+"$out"


### PR DESCRIPTION
Addresses #64 (heating zones). **Bambu-only by design** — Klipper users already drive the chamber via `M141`/`M191` macros ("the way"), and DragonBreath sits *in* the Klipper gcode path so no auto-detection is needed there. Bambu never sends chamber intent to DragonBreath (it isn't in Bambu's toolchain and ignores `M191`), so the only way to give Bambu users filament-aware chamber temps is for DragonBreath to read the loaded filament off MQTT and apply a filament → temperature map.

## Plan (phased)
- [x] **A — Parse active filament** *(this commit)*. `pb_bambu` extracts the active filament from the report's AMS / external-spool data (`tray_now` → `ams.tray[N].tray_type`, else `vt_tray.tray_type`), exposed as `pb_bambu_status_t.filament`, logged on change.
- [ ] **B — Filament → temp map** — user-configurable, NVS-persisted, with sane defaults (e.g. PETG 40, ABS/ASA 45, PLA 0/off).
- [ ] **C — Apply via AUTO** — when a Bambu print is active with a known filament, drive the chamber target from the map; revert on print end.
- [ ] **UI** — edit the zone map on the setup page.

## Validation
- **Parser: host unit test, 7 cases** — AMS tray 0/1/2, external spool, none-loaded, idle (no AMS), vt fallback — **all pass**.
- Live on the bench bound to a **bambuddy** virtual X1C: connects + subscribes. bambuddy archive-mode emits no AMS block, and its broker won't relay client-injected `/report` messages, so **end-to-end filament→zone will be confirmed on the requester's real printer** (and the pure parser logic is covered by the unit test).

## Notes / open questions
- Bambu ignores `M191` and never emits a "chamber setpoint" — deriving it from filament at our layer is the correct approach (bambuddy does the same internally).
- The map is opinion ("PETG likes 40 °C") → user-configurable with defaults, not hardcoded.
- Multi-material: likely follow the active tray (`tray_now`); open to "highest-temp loaded filament" instead.

Draft while B/C/UI land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
