### PR TITLE
Design: MQTT-Klipper mode implementation (grounds RFC #66)

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Test heater safety-trip decision (over-temp / fail-closed / watchdog)
         run: sh tests/run_heater_safety_host_test.sh
 
+      - name: Test MQTT-Klipper arming state machine (retained-aware arm/heartbeat)
+        run: sh tests/run_db_klipper_mqtt_host_test.sh
+
       - name: Test HIL scenario runner
         run: python3 -m unittest tests/test_hil_runner.py
 

--- a/components/db_klipper_mqtt/CMakeLists.txt
+++ b/components/db_klipper_mqtt/CMakeLists.txt
@@ -1,0 +1,9 @@
+idf_component_register(
+    SRCS "db_klipper_mqtt.c"
+    INCLUDE_DIRS "include"
+    # esp-mqtt to the printer's Moonraker broker; esp_timer for pacing; pb_policy for
+    # the lease/command/snapshot API; esp-tls for optional mqtts. Telemetry/RPC JSON is
+    # built with snprintf (no cJSON). The pure arming core (db_klipper_mqtt_arm.h) is
+    # header-only and host-tested separately.
+    REQUIRES nvs_flash mqtt esp_timer pb_policy esp-tls
+)

--- a/components/db_klipper_mqtt/db_klipper_mqtt.c
+++ b/components/db_klipper_mqtt/db_klipper_mqtt.c
@@ -1,0 +1,453 @@
+// Klipper-over-MQTT control source. Subscribes to the Moonraker MQTT split-status
+// for the DRAGONBREATH (desired-state) and DB_LINK (heartbeat) macros, runs the
+// retained-aware arming machine (db_klipper_mqtt_arm.h), and holds a pb_policy lease
+// while armed — exactly like pb_ha, but commanded by Klipper macros over the printer's
+// own Moonraker broker. Publishes device telemetry for a Moonraker [sensor] and an
+// on/off state for a Moonraker [power] device. See
+// plans/mqtt-klipper-implementation-design.md.
+//
+// Threading: the esp-mqtt event handler (mqtt task) updates arm/connection state under
+// s_lock; db_klipper_mqtt_tick() (control task) evaluates the machine, calls pb_policy,
+// and publishes. esp_mqtt_client_publish() is thread-safe; shared state is guarded.
+#include "db_klipper_mqtt.h"
+#include "db_klipper_mqtt_arm.h"
+#include "pb_policy.h"
+
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "mqtt_client.h"
+#include "nvs.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *TAG = "db_km";
+
+#define NVS_NS    "app_nvs"
+#define KEY_HOST  "km_host"
+#define KEY_PORT  "km_port"
+#define KEY_USER  "km_user"
+#define KEY_PASS  "km_pass"
+#define KEY_INST  "km_inst"
+#define KEY_TOPIC "km_topic"
+#define KEY_TLS   "km_tls"
+#define KEY_WB    "km_wb"
+
+#define DEFAULT_PORT      1883
+#define DEFAULT_TLS_PORT  8883
+#define DEFAULT_PREFIX    "dragonbreath"
+#define STATE_PERIOD_US   (2 * 1000 * 1000)    // telemetry + power state ~2 s
+#define HB_PERIOD_US      (5 * 1000 * 1000)    // lease heartbeat ~5 s (<< watchdog min)
+#define LIVE_TIMEOUT_US   ((int64_t)15 * 1000 * 1000)  // 3 x 5 s missed heartbeats
+#define TARGET_MIN_C      20.0f
+#define TARGET_MAX_C      70.0f
+
+static SemaphoreHandle_t        s_lock   = NULL;
+static db_km_config_t           s_cfg    = {0};
+static db_km_status_t           s_status = { .conn = DB_KM_DISABLED };
+static esp_mqtt_client_handle_t s_client = NULL;
+
+// Shared control state (guarded by s_lock).
+static db_km_arm_t        s_arm         = {0};
+static bool               s_have_lease  = false;
+static pb_policy_lease_t  s_lease       = {0};
+static bool               s_power_on    = true;   // Moonraker [power] master enable
+static bool               s_mrk_online  = true;   // Moonraker availability
+
+// Pacing / writeback (control task only).
+static int64_t  s_last_state_us = 0;
+static int64_t  s_last_hb_us    = 0;
+static uint32_t s_rpc_id        = 0;
+static bool     s_last_power_pub = true;
+
+// Topics built once at start (must outlive esp_mqtt_client_init for the LWT).
+static char s_avail_topic[80]  = {0};   // <base>/status  (device availability, LWT)
+
+static const char *base(void) { return s_cfg.topic[0] ? s_cfg.topic : DEFAULT_PREFIX; }
+
+// ---------- NVS ----------
+
+static esp_err_t nvs_load(db_km_config_t *out)
+{
+    memset(out, 0, sizeof(*out));
+    nvs_handle_t h;
+    esp_err_t err = nvs_open(NVS_NS, NVS_READONLY, &h);
+    if (err != ESP_OK) return err;
+
+    size_t sz = sizeof(out->host);
+    err = nvs_get_str(h, KEY_HOST, out->host, &sz);
+    if (err != ESP_OK) { nvs_close(h); return err; }   // no host = unconfigured
+
+    uint16_t p = 0;
+    uint8_t tls = 0, wb = 0;
+    nvs_get_u8(h, KEY_TLS, &tls);
+    out->tls = tls != 0;
+    if (nvs_get_u16(h, KEY_PORT, &p) == ESP_OK && p > 0) out->port = p;
+    else out->port = out->tls ? DEFAULT_TLS_PORT : DEFAULT_PORT;
+    nvs_get_u8(h, KEY_WB, &wb);
+    out->writeback = wb != 0;
+
+    sz = sizeof(out->user);  nvs_get_str(h, KEY_USER, out->user, &sz);
+    sz = sizeof(out->pass);  nvs_get_str(h, KEY_PASS, out->pass, &sz);
+    sz = sizeof(out->inst);  nvs_get_str(h, KEY_INST, out->inst, &sz);
+    sz = sizeof(out->topic); nvs_get_str(h, KEY_TOPIC, out->topic, &sz);
+    nvs_close(h);
+    return ESP_OK;
+}
+
+static esp_err_t nvs_save(const db_km_config_t *cfg)
+{
+    nvs_handle_t h;
+    esp_err_t err = nvs_open(NVS_NS, NVS_READWRITE, &h);
+    if (err != ESP_OK) return err;
+    err = nvs_set_str(h, KEY_HOST, cfg->host);
+    if (err == ESP_OK) err = nvs_set_u16(h, KEY_PORT, cfg->port);
+    if (err == ESP_OK) err = nvs_set_str(h, KEY_USER, cfg->user);
+    if (err == ESP_OK) err = nvs_set_str(h, KEY_PASS, cfg->pass);
+    if (err == ESP_OK) err = nvs_set_str(h, KEY_INST, cfg->inst);
+    if (err == ESP_OK) err = nvs_set_str(h, KEY_TOPIC, cfg->topic);
+    if (err == ESP_OK) err = nvs_set_u8(h, KEY_TLS, cfg->tls ? 1 : 0);
+    if (err == ESP_OK) err = nvs_set_u8(h, KEY_WB, cfg->writeback ? 1 : 0);
+    if (err == ESP_OK) err = nvs_commit(h);
+    nvs_close(h);
+    return err;
+}
+
+// ---------- policy mapping (mirrors pb_ha) ----------
+
+static void start_heat(float target_c)
+{
+    if (target_c < TARGET_MIN_C) target_c = TARGET_MIN_C;
+    if (target_c > TARGET_MAX_C) target_c = TARGET_MAX_C;
+    pb_policy_lease_t lease = {0};
+    pb_policy_result_t r = pb_policy_set_power_on(
+        target_c, DB_SOURCE_WEB, "klipper-mqtt", PB_POLICY_REVISION_ANY, &lease);
+    if (r == PB_POLICY_OK) {
+        xSemaphoreTake(s_lock, portMAX_DELAY);
+        s_lease = lease;
+        s_have_lease = true;
+        s_last_hb_us = esp_timer_get_time();
+        s_status.engaged = true;
+        s_status.comms_lost = false;
+        xSemaphoreGive(s_lock);
+        ESP_LOGI(TAG, "klipper-mqtt -> heat %.0f C", (double)target_c);
+    } else {
+        ESP_LOGW(TAG, "heat rejected (policy result %d)", (int)r);
+    }
+}
+
+static void stop_heat(bool comms_lost)
+{
+    pb_policy_set_mode_off(DB_SOURCE_WEB);
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    s_have_lease = false;
+    s_status.engaged = false;
+    if (comms_lost) s_status.comms_lost = true;
+    xSemaphoreGive(s_lock);
+    ESP_LOGI(TAG, "klipper-mqtt -> off%s", comms_lost ? " (comms lost)" : "");
+}
+
+// Force the arming machine back to disarmed (master-power off / Moonraker offline).
+static void force_disarm(void)
+{
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    s_arm.engaged = false;
+    xSemaphoreGive(s_lock);
+    stop_heat(false);
+}
+
+// ---------- inbound classification ----------
+
+static void handle_field(const char *topic, const char *payload)
+{
+    db_km_field_t f = db_km_field_of(topic);
+    if (f == DB_KM_F_NONE) return;
+    char val[24];
+    if (!db_km_value(payload, val, sizeof val)) return;
+
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    switch (f) {
+    case DB_KM_F_SEQ:       db_km_arm_seq(&s_arm, strtol(val, NULL, 10)); break;
+    case DB_KM_F_TARGET:    db_km_arm_target(&s_arm, strtof(val, NULL)); break;
+    case DB_KM_F_MODE:      db_km_arm_mode(&s_arm, val); break;
+    case DB_KM_F_FAN:       db_km_arm_fan(&s_arm, (int)strtol(val, NULL, 10)); break;
+    case DB_KM_F_ARMED:     db_km_arm_armed(&s_arm, (strcmp(val, "true") == 0) ? 1 : (int)strtol(val, NULL, 10)); break;
+    case DB_KM_F_PURGE:     (void)db_km_arm_purge(&s_arm, strtol(val, NULL, 10)); break;
+    case DB_KM_F_HEARTBEAT: db_km_arm_hb(&s_arm, strtol(val, NULL, 10), esp_timer_get_time()); break;
+    default: break;
+    }
+    xSemaphoreGive(s_lock);
+}
+
+static void handle_data(const char *topic, int tlen, const char *data, int dlen)
+{
+    char t[128], d[64];
+    int n = tlen < (int)sizeof(t) - 1 ? tlen : (int)sizeof(t) - 1;
+    memcpy(t, topic, n); t[n] = '\0';
+    n = dlen < (int)sizeof(d) - 1 ? dlen : (int)sizeof(d) - 1;
+    memcpy(d, data, n); d[n] = '\0';
+
+    // Moonraker availability: {"server":"online"|"offline"}
+    if (strstr(t, "/moonraker/status")) {
+        if (strstr(d, "offline")) { s_mrk_online = false; force_disarm(); }
+        else if (strstr(d, "online")) s_mrk_online = true;
+        return;
+    }
+    // Master power command from Moonraker [power]: payload "on"/"off".
+    char pset[80];
+    snprintf(pset, sizeof pset, "%s/power/set", base());
+    if (strcmp(t, pset) == 0) {
+        bool on = (strstr(d, "on") != NULL) && (strstr(d, "off") == NULL);
+        s_power_on = on;
+        if (!on) force_disarm();
+        s_last_state_us = 0;   // force a prompt power/state echo
+        return;
+    }
+    // Desired-state / heartbeat split-status.
+    handle_field(t, d);
+}
+
+// ---------- publish ----------
+
+static void publish_power_state(bool on)
+{
+    char topic[80];
+    snprintf(topic, sizeof topic, "%s/power/state", base());
+    esp_mqtt_client_publish(s_client, topic, on ? "on" : "off", 0, 0, 1);  // qos0, retain
+    s_last_power_pub = on;
+}
+
+static void publish_telemetry(void)
+{
+    pb_policy_snapshot_t snap;
+    pb_policy_get_snapshot(&snap);
+
+    char cb[16], pb[16];
+    if (isfinite(snap.chamber_c)) snprintf(cb, sizeof cb, "%.1f", snap.chamber_c); else strcpy(cb, "null");
+    if (isfinite(snap.ptc_c))     snprintf(pb, sizeof pb, "%.1f", snap.ptc_c);     else strcpy(pb, "null");
+    const char *mode = (snap.mode == PB_MODE_OFF) ? "off" : "heat";
+
+    long seq_ack; bool armed; bool comms;
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    seq_ack = s_arm.acted_seq;
+    armed   = s_status.engaged;
+    comms   = s_status.comms_lost;
+    xSemaphoreGive(s_lock);
+
+    char buf[200];
+    snprintf(buf, sizeof buf,
+        "{\"v\":1,\"chamber_temperature\":%s,\"element_temperature\":%s,"
+        "\"mode\":\"%s\",\"target\":%.0f,\"armed\":%s,\"seq_ack\":%ld,\"fault\":\"%s\"}",
+        cb, pb, mode, (double)snap.effective_target_c,
+        armed ? "true" : "false", seq_ack, comms ? "comms_lost" : "");
+
+    char topic[80];
+    snprintf(topic, sizeof topic, "%s/telemetry", base());
+    esp_mqtt_client_publish(s_client, topic, buf, 0, 0, 0);   // qos0, non-retained
+
+    // Optional device->Klipper writeback of live chamber temp into a macro variable,
+    // so macro logic can read it (Moonraker [sensor] values are invisible to macros).
+    // QoS 0 (no mqtt_timestamp needed); rate = telemetry cadence (~2 s).
+    if (s_cfg.writeback && isfinite(snap.chamber_c)) {
+        char rpc[220], areq[96];
+        snprintf(rpc, sizeof rpc,
+            "{\"jsonrpc\":\"2.0\",\"method\":\"printer.gcode.script\",\"id\":%u,"
+            "\"params\":{\"script\":\"SET_GCODE_VARIABLE MACRO=DRAGONBREATH "
+            "VARIABLE=temperature VALUE=%.1f\"}}",
+            (unsigned)(++s_rpc_id), snap.chamber_c);
+        snprintf(areq, sizeof areq, "%s/moonraker/api/request", s_cfg.inst);
+        esp_mqtt_client_publish(s_client, areq, rpc, 0, 0, 0);
+    }
+}
+
+// ---------- mqtt events ----------
+
+static void subscribe_all(void)
+{
+    char sub[128];
+    snprintf(sub, sizeof sub, "%s/klipper/state/gcode_macro DRAGONBREATH/#", s_cfg.inst);
+    esp_mqtt_client_subscribe(s_client, sub, 0);
+    snprintf(sub, sizeof sub, "%s/klipper/state/gcode_macro DB_LINK/#", s_cfg.inst);
+    esp_mqtt_client_subscribe(s_client, sub, 0);
+    snprintf(sub, sizeof sub, "%s/moonraker/status", s_cfg.inst);
+    esp_mqtt_client_subscribe(s_client, sub, 0);
+    snprintf(sub, sizeof sub, "%s/power/set", base());
+    esp_mqtt_client_subscribe(s_client, sub, 0);
+}
+
+static void mqtt_event_handler(void *args, esp_event_base_t evbase, int32_t id, void *data)
+{
+    (void)args; (void)evbase;
+    esp_mqtt_event_handle_t e = (esp_mqtt_event_handle_t)data;
+    switch ((esp_mqtt_event_id_t)id) {
+    case MQTT_EVENT_CONNECTED:
+        ESP_LOGI(TAG, "connected to broker");
+        xSemaphoreTake(s_lock, portMAX_DELAY);
+        s_status.conn = DB_KM_CONNECTED;
+        s_status.connected = true;
+        db_km_arm_reset(&s_arm);      // retained state must NOT arm — start disarmed
+        s_mrk_online = true;
+        xSemaphoreGive(s_lock);
+        esp_mqtt_client_publish(s_client, s_avail_topic, "online", 0, 1, 1);
+        publish_power_state(s_power_on);
+        subscribe_all();
+        s_last_state_us = 0;          // prompt first telemetry
+        break;
+    case MQTT_EVENT_DISCONNECTED:
+        xSemaphoreTake(s_lock, portMAX_DELAY);
+        s_status.conn = DB_KM_DISCONNECTED;
+        s_status.connected = false;
+        xSemaphoreGive(s_lock);
+        force_disarm();               // no broker -> can't heartbeat -> fail safe off
+        break;
+    case MQTT_EVENT_DATA:
+        if (e->topic_len > 0 && e->data_len >= 0)
+            handle_data(e->topic, e->topic_len, e->data, e->data_len);
+        break;
+    default:
+        break;
+    }
+}
+
+// ---------- lifecycle ----------
+
+esp_err_t db_klipper_mqtt_start(void)
+{
+    if (s_lock != NULL) return ESP_ERR_INVALID_STATE;
+    s_lock = xSemaphoreCreateMutex();
+    if (s_lock == NULL) return ESP_ERR_NO_MEM;
+
+    if (nvs_load(&s_cfg) != ESP_OK || s_cfg.host[0] == '\0') {
+        ESP_LOGI(TAG, "no Klipper-MQTT config saved; idle");
+        s_status.conn = DB_KM_DISABLED;
+        return ESP_OK;
+    }
+
+    snprintf(s_avail_topic, sizeof s_avail_topic, "%s/status", base());
+
+    char uri[128];
+    snprintf(uri, sizeof uri, "%s://%s:%u", s_cfg.tls ? "mqtts" : "mqtt",
+             s_cfg.host, (unsigned)s_cfg.port);
+    esp_mqtt_client_config_t mc = {
+        .broker.address.uri = uri,
+        .session.last_will = {
+            .topic = s_avail_topic, .msg = "offline", .msg_len = 7, .qos = 1, .retain = 1,
+        },
+    };
+    if (s_cfg.tls) mc.broker.verification.skip_cert_common_name_check = true;
+    if (s_cfg.user[0]) mc.credentials.username = s_cfg.user;
+    if (s_cfg.pass[0]) mc.credentials.authentication.password = s_cfg.pass;
+
+    s_client = esp_mqtt_client_init(&mc);
+    if (s_client == NULL) {
+        ESP_LOGE(TAG, "esp_mqtt_client_init failed");
+        s_status.conn = DB_KM_DISCONNECTED;
+        return ESP_FAIL;
+    }
+    esp_mqtt_client_register_event(s_client, ESP_EVENT_ANY_ID, mqtt_event_handler, NULL);
+    esp_err_t err = esp_mqtt_client_start(s_client);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_mqtt_client_start: %s", esp_err_to_name(err));
+        s_status.conn = DB_KM_DISCONNECTED;
+        return err;
+    }
+    s_status.conn = DB_KM_CONNECTING;
+    ESP_LOGI(TAG, "connecting to %s (instance '%s', base '%s')", uri, s_cfg.inst, base());
+    return ESP_OK;
+}
+
+void db_klipper_mqtt_tick(void)
+{
+    if (s_client == NULL) return;
+    bool connected;
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    connected = s_status.connected;
+    xSemaphoreGive(s_lock);
+    if (!connected) return;
+
+    int64_t now = esp_timer_get_time();
+
+    // Evaluate the arming machine under lock (it mutates arm state).
+    float target = 0.0f;
+    db_km_action_t action;
+    bool allow, hb_due = false;
+    pb_policy_lease_t lease = {0};
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    allow = s_power_on && s_mrk_online;
+    action = db_km_arm_eval(&s_arm, now, LIVE_TIMEOUT_US, &target);
+    if (action == DB_KM_ENGAGE && !allow) {   // master-off / Moonraker-offline gate
+        s_arm.engaged = false;
+        action = DB_KM_DISENGAGE;
+    }
+    if (action == DB_KM_HOLD && s_arm.engaged && s_have_lease && now - s_last_hb_us >= HB_PERIOD_US) {
+        lease = s_lease; s_last_hb_us = now; hb_due = true;
+    }
+    xSemaphoreGive(s_lock);
+
+    switch (action) {
+    case DB_KM_ENGAGE:    start_heat(target); break;
+    case DB_KM_DISENGAGE: stop_heat(false);   break;
+    case DB_KM_COMMS_LOST: stop_heat(true);   break;
+    case DB_KM_HOLD:
+        if (hb_due && pb_policy_heartbeat(&lease) != PB_POLICY_OK) {
+            xSemaphoreTake(s_lock, portMAX_DELAY);
+            s_have_lease = false;
+            xSemaphoreGive(s_lock);
+        }
+        break;
+    }
+
+    if (now - s_last_state_us >= STATE_PERIOD_US) {
+        s_last_state_us = now;
+        if (s_power_on != s_last_power_pub) publish_power_state(s_power_on);
+        publish_telemetry();
+    }
+}
+
+esp_err_t db_klipper_mqtt_set_config(const db_km_config_t *cfg)
+{
+    if (cfg == NULL) return ESP_ERR_INVALID_ARG;
+    esp_err_t err = nvs_save(cfg);
+    if (err != ESP_OK) return err;
+    if (s_lock) {
+        xSemaphoreTake(s_lock, portMAX_DELAY);
+        s_cfg = *cfg;
+        xSemaphoreGive(s_lock);
+    }
+    return ESP_OK;   // takes effect on next boot (matches pb_ha / pb_moonraker)
+}
+
+esp_err_t db_klipper_mqtt_get_config(db_km_config_t *out)
+{
+    if (out == NULL) return ESP_ERR_INVALID_ARG;
+    if (s_lock) xSemaphoreTake(s_lock, portMAX_DELAY);
+    *out = s_cfg;
+    if (s_lock) xSemaphoreGive(s_lock);
+    return ESP_OK;
+}
+
+esp_err_t db_klipper_mqtt_get_status(db_km_status_t *out)
+{
+    if (out == NULL) return ESP_ERR_INVALID_ARG;
+    if (s_lock) xSemaphoreTake(s_lock, portMAX_DELAY);
+    *out = s_status;
+    if (s_lock) xSemaphoreGive(s_lock);
+    return ESP_OK;
+}
+
+esp_err_t db_klipper_mqtt_clear_config(void)
+{
+    nvs_handle_t h;
+    esp_err_t err = nvs_open(NVS_NS, NVS_READWRITE, &h);
+    if (err != ESP_OK) return err;
+    nvs_erase_key(h, KEY_HOST); nvs_erase_key(h, KEY_PORT); nvs_erase_key(h, KEY_USER);
+    nvs_erase_key(h, KEY_PASS); nvs_erase_key(h, KEY_INST); nvs_erase_key(h, KEY_TOPIC);
+    nvs_erase_key(h, KEY_TLS);  nvs_erase_key(h, KEY_WB);
+    nvs_commit(h);
+    nvs_close(h);
+    return ESP_OK;
+}

--- a/components/db_klipper_mqtt/include/db_klipper_mqtt.h
+++ b/components/db_klipper_mqtt/include/db_klipper_mqtt.h
@@ -1,0 +1,48 @@
+#pragma once
+// Klipper-over-MQTT control source. For locked/managed Klipper installs that permit
+// moonraker.conf + printer.cfg edits + a broker, but no klippy/extras plugin. Unlike
+// PB_SRC_KLIPPER (Moonraker WebSocket bed-follow), this is a CONTROLLER: Klipper
+// macros publish desired-state (target/mode/armed/seq) which Moonraker relays as MQTT
+// split-status; the device holds a pb_policy lease and heartbeats it. Heat arming is
+// governed by the retained-aware state machine in db_klipper_mqtt_arm.h (never arms
+// from retained values — only on a fresh seq + a live heartbeat).
+// See plans/mqtt-klipper-implementation-design.md.
+#include <stdbool.h>
+#include <stdint.h>
+#include "esp_err.h"
+
+typedef enum {
+    DB_KM_DISABLED,      // no config saved / source not selected
+    DB_KM_DISCONNECTED,  // config present, not currently connected
+    DB_KM_CONNECTING,
+    DB_KM_CONNECTED,     // broker session up (subscribed)
+} db_km_conn_t;
+
+typedef struct {
+    char     host[64];   // broker (Moonraker's) IP/hostname; empty = unconfigured
+    uint16_t port;       // defaults to 1883 (8883 with TLS) if 0
+    char     user[32];   // broker username (required by the validator)
+    char     pass[64];   // broker password
+    char     inst[48];   // Moonraker instance_name (required — derives all topics)
+    char     topic[48];  // device topic base (defaults to "dragonbreath")
+    bool     tls;        // mqtts (skip-verify LAN, like pb_bambu)
+    bool     writeback;  // push live temp/fault into macro vars (off by default)
+} db_km_config_t;
+
+typedef struct {
+    db_km_conn_t conn;
+    bool connected;      // conn == DB_KM_CONNECTED
+    bool engaged;        // heat currently armed+driven by this source
+    bool comms_lost;     // last disengage was a heartbeat-timeout
+} db_km_status_t;
+
+esp_err_t db_klipper_mqtt_start(void);
+
+// Periodic pump (control task): evaluate the arming machine, apply/stop heat, publish
+// telemetry + power state, heartbeat the lease. No-op if the client isn't running.
+void db_klipper_mqtt_tick(void);
+
+esp_err_t db_klipper_mqtt_set_config(const db_km_config_t *cfg);
+esp_err_t db_klipper_mqtt_get_config(db_km_config_t *out);
+esp_err_t db_klipper_mqtt_get_status(db_km_status_t *out);
+esp_err_t db_klipper_mqtt_clear_config(void);

--- a/components/db_klipper_mqtt/include/db_klipper_mqtt_arm.h
+++ b/components/db_klipper_mqtt/include/db_klipper_mqtt_arm.h
@@ -1,0 +1,180 @@
+#pragma once
+// Pure, host-testable core of the MQTT-Klipper control source: split-status value
+// extraction + the retained-aware arming state machine. No ESP deps, so it can be
+// unit-tested on the host (mirrors pb_bambu_parse.h / pb_ntc / pb_heater).
+//
+// Safety model (see plans/mqtt-klipper-implementation-design.md §5): Moonraker
+// publishes Klipper split-status RETAINED, so a reconnecting device is handed stale
+// desired-state (armed=1/target/seq) and the last heartbeat value immediately. Heat
+// must therefore NEVER engage from received values alone — it engages only on a NEW
+// coherent `seq` (the macro writes `seq` LAST, so all fields are consistent when it
+// changes) AND while liveness is fresh (the DB_LINK heartbeat has been observed to
+// change since connect and did so within the timeout). A retained snapshot is the
+// baseline `seq`, which is not a change, so it can never arm on its own.
+//
+// The state machine is deliberately quick to DISARM (armed->0, mode->off, or lost
+// liveness disengage immediately, no seq needed) and careful to ARM (full seq
+// coherence + liveness). Failing to engage is fail-safe; falsely engaging is not.
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// ---- split-status payload value extraction --------------------------------
+// Moonraker split-status payload is JSON: {"eventtime":<ts>,"value":<v>} where <v>
+// is a JSON literal (number, "string", or true/false). Copy the raw <v> token
+// (quotes stripped for strings) into `out`. Returns false if no "value" key.
+static inline bool db_km_value(const char *payload, char *out, size_t outsz)
+{
+    if (!payload || !out || outsz == 0) return false;
+    const char *q = strstr(payload, "\"value\"");
+    if (!q) return false;
+    q = strchr(q, ':');
+    if (!q) return false;
+    q++;
+    while (*q == ' ' || *q == '\t' || *q == '\n' || *q == '\r') q++;
+    size_t i = 0;
+    if (*q == '"') {                         // string value
+        q++;
+        while (*q && *q != '"' && i + 1 < outsz) out[i++] = *q++;
+    } else {                                 // number / bool / literal
+        while (*q && *q != ',' && *q != '}' && *q != ' ' &&
+               *q != '\r' && *q != '\n' && *q != '\t' && i + 1 < outsz)
+            out[i++] = *q++;
+    }
+    out[i] = '\0';
+    return true;
+}
+
+// ---- topic → field classification -----------------------------------------
+// The desired-state lives on gcode_macro DRAGONBREATH; the heartbeat on
+// gcode_macro DB_LINK. Split-status topic is:
+//   <INST>/klipper/state/gcode_macro DRAGONBREATH/<statename>
+// (the macro object name keeps its literal space). Classify by the trailing
+// <statename> plus which macro object it belongs to.
+typedef enum {
+    DB_KM_F_NONE = 0,
+    DB_KM_F_SEQ,
+    DB_KM_F_TARGET,
+    DB_KM_F_MODE,
+    DB_KM_F_FAN,
+    DB_KM_F_ARMED,
+    DB_KM_F_PURGE,
+    DB_KM_F_HEARTBEAT,
+} db_km_field_t;
+
+static inline db_km_field_t db_km_field_of(const char *topic)
+{
+    if (!topic) return DB_KM_F_NONE;
+    bool is_db   = strstr(topic, "gcode_macro DRAGONBREATH/") != NULL;
+    bool is_link = strstr(topic, "gcode_macro DB_LINK/") != NULL;
+    if (!is_db && !is_link) return DB_KM_F_NONE;
+    const char *slash = strrchr(topic, '/');
+    const char *name = slash ? slash + 1 : topic;
+    if (is_link) return (strcmp(name, "heartbeat") == 0) ? DB_KM_F_HEARTBEAT : DB_KM_F_NONE;
+    if (strcmp(name, "seq")         == 0) return DB_KM_F_SEQ;
+    if (strcmp(name, "target")      == 0) return DB_KM_F_TARGET;
+    if (strcmp(name, "mode")        == 0) return DB_KM_F_MODE;
+    if (strcmp(name, "fan")         == 0) return DB_KM_F_FAN;
+    if (strcmp(name, "armed")       == 0) return DB_KM_F_ARMED;
+    if (strcmp(name, "purge_nonce") == 0) return DB_KM_F_PURGE;
+    return DB_KM_F_NONE;
+}
+
+// ---- arming state machine --------------------------------------------------
+typedef struct {
+    // latest desired-state fields
+    long   seq;          bool seq_known;
+    long   acted_seq;    // last seq we engaged/disengaged on (baseline on connect)
+    float  target;
+    bool   mode_heat;    // mode == "heat"
+    int    armed;        // 0 | 1
+    uint8_t fan;         // 0..100
+    long   purge_nonce;  bool purge_known;
+    // heartbeat liveness
+    long    hb;          bool hb_known;
+    int64_t hb_change_us;
+    bool    hb_live;     // observed >=1 heartbeat change since connect
+    // engagement
+    bool   engaged;
+} db_km_arm_t;
+
+// Result of an eval step — the transition the caller must apply.
+typedef enum {
+    DB_KM_HOLD = 0,   // no change
+    DB_KM_ENGAGE,     // (re)apply heat at out_target — take/refresh the lease
+    DB_KM_DISENGAGE,  // normal off (armed->0, mode->off, or a coherent off update)
+    DB_KM_COMMS_LOST, // liveness lost while engaged — force off + latch comms_lost
+} db_km_action_t;
+
+// Call on every (re)connect: clears all liveness/arming state to DISARMED so that
+// retained desired-state cannot arm without a fresh, live re-arm.
+static inline void db_km_arm_reset(db_km_arm_t *st)
+{
+    memset(st, 0, sizeof(*st));
+}
+
+static inline void db_km_arm_seq(db_km_arm_t *st, long v)
+{
+    if (!st->seq_known) { st->seq_known = true; st->acted_seq = v; }  // baseline
+    st->seq = v;
+}
+static inline void db_km_arm_target(db_km_arm_t *st, float v) { st->target = v; }
+static inline void db_km_arm_mode(db_km_arm_t *st, const char *m)
+{
+    st->mode_heat = (m && strcmp(m, "heat") == 0);
+}
+static inline void db_km_arm_armed(db_km_arm_t *st, int v) { st->armed = (v != 0); }
+static inline void db_km_arm_fan(db_km_arm_t *st, int v)
+{
+    st->fan = (uint8_t)(v < 0 ? 0 : (v > 100 ? 100 : v));
+}
+// Returns true if the purge nonce advanced (a fresh one-shot request), false on the
+// connect-baseline value (a retained nonce must not re-fire).
+static inline bool db_km_arm_purge(db_km_arm_t *st, long v)
+{
+    if (!st->purge_known) { st->purge_known = true; st->purge_nonce = v; return false; }
+    if (v != st->purge_nonce) { st->purge_nonce = v; return true; }
+    return false;
+}
+static inline void db_km_arm_hb(db_km_arm_t *st, long v, int64_t now_us)
+{
+    if (!st->hb_known) { st->hb_known = true; st->hb = v; st->hb_change_us = now_us; return; }
+    if (v != st->hb) { st->hb = v; st->hb_change_us = now_us; st->hb_live = true; }
+}
+
+// True when the heartbeat has been observed to change since connect AND the last
+// change was within the timeout window.
+static inline bool db_km_arm_live(const db_km_arm_t *st, int64_t now_us, int64_t timeout_us)
+{
+    return st->hb_live && (now_us - st->hb_change_us) < timeout_us;
+}
+
+// Evaluate the current state. Quick to disarm, careful to arm (see file header).
+// On DB_KM_ENGAGE, *out_target holds the target to drive.
+static inline db_km_action_t db_km_arm_eval(db_km_arm_t *st, int64_t now_us,
+                                            int64_t timeout_us, float *out_target)
+{
+    bool live = db_km_arm_live(st, now_us, timeout_us);
+    if (out_target) *out_target = st->target;
+
+    // 1) Safety: drop engagement immediately on lost liveness / disarm / mode-off —
+    //    no seq change required.
+    if (st->engaged) {
+        if (!live)                          { st->engaged = false; return DB_KM_COMMS_LOST; }
+        if (st->armed == 0 || !st->mode_heat) { st->engaged = false; return DB_KM_DISENGAGE; }
+    }
+
+    // 2) Act only on a NEW coherent seq (the macro writes seq LAST).
+    if (st->seq_known && st->seq != st->acted_seq) {
+        st->acted_seq = st->seq;
+        if (st->armed == 1 && st->mode_heat && live) {
+            st->engaged = true;
+            if (out_target) *out_target = st->target;
+            return DB_KM_ENGAGE;            // engage or refresh target
+        }
+        if (st->engaged) { st->engaged = false; return DB_KM_DISENGAGE; }
+    }
+    return DB_KM_HOLD;
+}

--- a/components/pb_portal/CMakeLists.txt
+++ b/components/pb_portal/CMakeLists.txt
@@ -1,7 +1,7 @@
 idf_component_register(
     SRCS "pb_portal.c" "pb_dns.c"
     INCLUDE_DIRS "include"
-    REQUIRES esp_http_server dc_wifi pb_httpd dc_source dc_moonraker dc_bambu pb_ha nvs_flash esp_wifi lwip json
+    REQUIRES esp_http_server dc_wifi pb_httpd dc_source dc_moonraker dc_bambu pb_ha db_klipper_mqtt nvs_flash esp_wifi lwip json
 )
 
 # The STA-mode dashboard is a real source file (www/app.html) that we gzip at

--- a/components/pb_portal/pb_portal.c
+++ b/components/pb_portal/pb_portal.c
@@ -7,6 +7,7 @@
 #include "dc_moonraker.h"
 #include "dc_bambu.h"
 #include "pb_ha.h"
+#include "db_klipper_mqtt.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
@@ -553,6 +554,9 @@ static esp_err_t config_page(httpd_req_t *req)
     char bb_host[64] = {0},   bb_serial[32] = {0};
     char ha_host[64] = {0};   uint16_t ha_port = 1883;
     char ha_user[32] = {0},   ha_topic[48] = {0};
+    char km_host[64] = {0};   uint16_t km_port = 1883;
+    char km_user[32] = {0},   km_inst[48] = {0},  km_topic[48] = {0};
+    uint8_t km_tls = 0,       km_wb = 0;
     nvs_handle_t h;
     if (nvs_open(NVS_NS, NVS_READONLY, &h) == ESP_OK) {
         size_t sz;
@@ -564,6 +568,13 @@ static esp_err_t config_page(httpd_req_t *req)
         nvs_get_u16(h, "ha_port", &ha_port);
         sz = sizeof ha_user;   nvs_get_str(h, "ha_user", ha_user, &sz);
         sz = sizeof ha_topic;  nvs_get_str(h, "ha_topic", ha_topic, &sz);
+        sz = sizeof km_host;   nvs_get_str(h, "km_host", km_host, &sz);
+        nvs_get_u16(h, "km_port", &km_port);
+        sz = sizeof km_user;   nvs_get_str(h, "km_user", km_user, &sz);
+        sz = sizeof km_inst;   nvs_get_str(h, "km_inst", km_inst, &sz);
+        sz = sizeof km_topic;  nvs_get_str(h, "km_topic", km_topic, &sz);
+        nvs_get_u8(h, "km_tls", &km_tls);
+        nvs_get_u8(h, "km_wb", &km_wb);
         nvs_close(h);
     }
     dc_ctl_source_t src = dc_source_get();
@@ -611,14 +622,16 @@ static esp_err_t config_page(httpd_req_t *req)
     snprintf(buf, sizeof buf,
         "<select id=ctlsrc name=ctl_src onchange='srcshow()'>"
         "<option value=0%s>Klipper (Moonraker)</option>"
+        "<option value=4%s>Klipper (MQTT)</option>"
         "<option value=1%s>Bambu (LAN)</option>"
         "<option value=2%s>Home Assistant</option>"
         "<option value=3%s>None (unbound)</option></select>"
         "<button type=button class=sec onclick='unbind()' style='margin-top:8px'>Unbind current source</button>",
-        src == DC_SRC_KLIPPER ? " selected" : "",
-        src == DC_SRC_BAMBU   ? " selected" : "",
-        src == DC_SRC_HA      ? " selected" : "",
-        src == DC_SRC_NONE    ? " selected" : "");
+        src == DC_SRC_KLIPPER      ? " selected" : "",
+        src == DC_SRC_KLIPPER_MQTT ? " selected" : "",
+        src == DC_SRC_BAMBU        ? " selected" : "",
+        src == DC_SRC_HA           ? " selected" : "",
+        src == DC_SRC_NONE         ? " selected" : "");
     SEND(req, buf);
 
     // Klipper group.
@@ -690,7 +703,51 @@ static esp_err_t config_page(httpd_req_t *req)
         "Home Assistant controls the heater only while it is the selected control source above. When "
         "Klipper or Bambu is bound, HA is not connected \xE2\x80\x94 Unbind that source first to hand control to HA. "
         "<a href='https://github.com/plastikman/DragonBreath/blob/main/docs/control-source.md' target=_blank rel=noopener>Details &rarr;</a>"
-        "</small></div></div>");
+        "</small></div>");   // close HA group
+
+    // Klipper (MQTT) group — for locked/managed Klipper installs (no klippy extra).
+    // Controller over the printer's own Moonraker broker; see the generated config.
+    html_attr_escape(km_host, esc, sizeof esc);
+    snprintf(buf, sizeof buf,
+        "<div class=grp data-src=4 style='display:%s'>"
+        "<label>MQTT broker (Moonraker's)</label><input name=km_host value=\"%s\" placeholder='e.g. mosquitto.lan'>"
+        "<label>Port</label><input name=km_port value=\"%u\">",
+        src == DC_SRC_KLIPPER_MQTT ? "block" : "none", esc, (unsigned)km_port);
+    SEND(req, buf);
+    html_attr_escape(km_user, esc, sizeof esc);
+    snprintf(buf, sizeof buf,
+        "<label>Username</label><input name=km_user value=\"%s\" autocomplete=off>"
+        "<label>Password</label><input name=km_pass type=password placeholder='(unchanged)' autocomplete=off>",
+        esc);
+    SEND(req, buf);
+    html_attr_escape(km_inst, esc, sizeof esc);
+    snprintf(buf, sizeof buf,
+        "<label>Moonraker instance_name</label>"
+        "<input name=km_inst value=\"%s\" placeholder='e.g. myprinter'>"
+        "<small style='color:var(--muted);display:block;margin:-4px 0 6px'>"
+        "Must match <code>instance_name</code> in <code>[mqtt]</code> \xE2\x80\x94 it derives every topic.</small>",
+        esc);
+    SEND(req, buf);
+    snprintf(buf, sizeof buf,
+        "<label><input type=checkbox name=km_tls value=1 %s> Use TLS (mqtts)</label>"
+        "<label><input type=checkbox name=km_wb value=1 %s> Write live temp back to macros (advanced)</label>",
+        km_tls ? "checked" : "", km_wb ? "checked" : "");
+    SEND(req, buf);
+    html_attr_escape(km_topic, esc, sizeof esc);
+    snprintf(buf, sizeof buf,
+        "<details style='margin-top:6px'><summary style='cursor:pointer;color:var(--muted)'>Advanced</summary>"
+        "<label>Device topic base</label><input name=km_topic value=\"%s\" placeholder='dragonbreath'>"
+        "</details>", esc);
+    SEND(req, buf);
+    // Generated-config link + the mutual-exclusion note (static).
+    SEND(req,
+        "<small style='color:var(--muted);display:block;margin-top:8px'>"
+        "Save first, then <a href='/km-config' target=_blank rel=noopener>generate your Klipper config</a> "
+        "(moonraker.conf + printer.cfg + Mosquitto ACL) filled in from these settings. "
+        "<b>Do not also run the native <code>dragonbreath-klipper</code> extra</b> \xE2\x80\x94 pick one Klipper integration."
+        "</small></div>");   // close MQTT group
+
+    SEND(req, "</div>");   // close the control-source card
     // Reveal-only-the-selected-group script (static — kept out of the snprintf
     // above so it isn't subject to format-truncation on a long topic value).
     SEND(req,
@@ -770,7 +827,7 @@ static esp_err_t save_post(httpd_req_t *req)
 
     // Larger than the Wi-Fi-only form: now also carries the control-source
     // selector + Klipper/Bambu/HA field groups (all groups submit, even hidden).
-    char body[1536];   // fits all field groups incl. the 6 Bambu chamber-zone inputs
+    char body[2048];   // fits all field groups (Bambu zones + the Klipper-MQTT group)
     int total = 0, r;
     while ((r = httpd_req_recv(req, body + total, sizeof body - 1 - total)) > 0) {
         total += r;
@@ -797,6 +854,35 @@ static esp_err_t save_post(httpd_req_t *req)
     form_get(body, "ha_user", ha_user, sizeof ha_user);
     form_get(body, "ha_pass", ha_pass, sizeof ha_pass);
     form_get(body, "ha_topic", ha_topic, sizeof ha_topic);
+    char km_host[64] = {0}, km_port_s[8] = {0}, km_user[32] = {0}, km_pass[64] = {0};
+    char km_inst[48] = {0}, km_topic[48] = {0}, km_tls_s[4] = {0}, km_wb_s[4] = {0};
+    form_get(body, "km_host", km_host, sizeof km_host);
+    form_get(body, "km_port", km_port_s, sizeof km_port_s);
+    form_get(body, "km_user", km_user, sizeof km_user);
+    form_get(body, "km_pass", km_pass, sizeof km_pass);
+    form_get(body, "km_inst", km_inst, sizeof km_inst);
+    form_get(body, "km_topic", km_topic, sizeof km_topic);
+    form_get(body, "km_tls", km_tls_s, sizeof km_tls_s);   // checkbox: present iff checked
+    form_get(body, "km_wb", km_wb_s, sizeof km_wb_s);
+
+    // Validator: the Klipper-MQTT mode must never be enabled without a broker AND
+    // credentials — an open/anonymous broker exposing printer.gcode.script is unsafe
+    // (design §8). A password already saved (secret left blank) counts.
+    if (src_s[0] && atoi(src_s) == DC_SRC_KLIPPER_MQTT) {
+        bool pass_ok = km_pass[0] != '\0';
+        if (!pass_ok) {
+            nvs_handle_t hv; char saved[8]; size_t ss = sizeof saved;
+            if (nvs_open(NVS_NS, NVS_READONLY, &hv) == ESP_OK) {
+                pass_ok = (nvs_get_str(hv, "km_pass", saved, &ss) == ESP_OK && saved[0]);
+                nvs_close(hv);
+            }
+        }
+        if (!km_host[0] || !km_user[0] || !km_inst[0] || !pass_ok) {
+            httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST,
+                "Klipper (MQTT) needs a broker host, username, password, and instance_name");
+            return ESP_FAIL;
+        }
+    }
 
     const char *chosen = ssid_manual[0] ? ssid_manual : ssid;
     // In AP/provisioning mode there are no saved creds yet, so a Wi-Fi network is
@@ -811,10 +897,12 @@ static esp_err_t save_post(httpd_req_t *req)
 
     nvs_handle_t h;
     if (nvs_open(NVS_NS, NVS_READWRITE, &h) == ESP_OK) {
-        // Control source (0=klipper/1=bambu/2=ha); ignore out-of-range.
+        // Control source (0=klipper/1=bambu/2=ha/3=none/4=klipper-mqtt); ignore
+        // out-of-range. DC_SRC_MAX is an exclusive sentinel, so the range is
+        // [DC_SRC_KLIPPER, DC_SRC_MAX).
         if (src_s[0]) {
             int s = atoi(src_s);
-            if (s >= DC_SRC_KLIPPER && s <= DC_SRC_NONE) nvs_set_u8(h, "ctl_src", (uint8_t)s);
+            if (s >= DC_SRC_KLIPPER && s < DC_SRC_MAX) nvs_set_u8(h, "ctl_src", (uint8_t)s);
         }
         // Klipper.
         if (mk_host[0]) nvs_set_str(h, "mk_host", mk_host);
@@ -831,6 +919,20 @@ static esp_err_t save_post(httpd_req_t *req)
         if (ha_user[0])  nvs_set_str(h, "ha_user", ha_user);
         if (ha_pass[0])  nvs_set_str(h, "ha_pass", ha_pass);
         if (ha_topic[0]) nvs_set_str(h, "ha_topic", ha_topic);
+        // Klipper (MQTT) — secret km_pass only written when re-entered. The TLS /
+        // writeback checkboxes are persisted from their submitted state (present =
+        // checked) whenever the MQTT group carries a host, so toggling either sticks.
+        if (km_host[0])  nvs_set_str(h, "km_host", km_host);
+        int kp = atoi(km_port_s);
+        if (kp > 0 && kp < 65536) nvs_set_u16(h, "km_port", (uint16_t)kp);
+        if (km_user[0])  nvs_set_str(h, "km_user", km_user);
+        if (km_pass[0])  nvs_set_str(h, "km_pass", km_pass);
+        if (km_inst[0])  nvs_set_str(h, "km_inst", km_inst);
+        if (km_topic[0]) nvs_set_str(h, "km_topic", km_topic);
+        if (km_host[0]) {
+            nvs_set_u8(h, "km_tls", km_tls_s[0] ? 1 : 0);
+            nvs_set_u8(h, "km_wb",  km_wb_s[0]  ? 1 : 0);
+        }
         nvs_commit(h);
         nvs_close(h);
     }
@@ -882,9 +984,10 @@ static esp_err_t unbind_post(httpd_req_t *req)
     }
     dc_ctl_source_t src = dc_source_get();
     switch (src) {
-    case DC_SRC_KLIPPER: dc_moonraker_clear_config(); break;
-    case DC_SRC_BAMBU:   dc_bambu_clear_config();     break;
-    case DC_SRC_HA:      pb_ha_clear_config();        break;
+    case DC_SRC_KLIPPER:      dc_moonraker_clear_config();    break;
+    case DC_SRC_BAMBU:        dc_bambu_clear_config();        break;
+    case DC_SRC_HA:           pb_ha_clear_config();           break;
+    case DC_SRC_KLIPPER_MQTT: db_klipper_mqtt_clear_config(); break;
     default: break;   // already None — nothing to clear
     }
     dc_source_set(DC_SRC_NONE);
@@ -895,6 +998,130 @@ static esp_err_t unbind_post(httpd_req_t *req)
     vTaskDelay(pdMS_TO_TICKS(250));   // let the response flush before we reboot
     esp_restart();
     return ESP_OK;                     // unreachable
+}
+
+// GET /km-config — render the Klipper-side config (moonraker.conf + printer.cfg +
+// Mosquitto ACL) as text/plain, filled in from the saved Klipper-MQTT settings so
+// the two ends can't drift (design §8). Braces in the Jinja templates are literal
+// here — only the substituted lines go through snprintf; brace-heavy blocks are
+// static. The broker password is never echoed (placeholder only).
+static esp_err_t km_config_page(httpd_req_t *req)
+{
+    char host[64] = {0}, user[32] = {0}, inst[48] = {0}, base[48] = {0};
+    uint16_t port = 1883;
+    nvs_handle_t h;
+    if (nvs_open(NVS_NS, NVS_READONLY, &h) == ESP_OK) {
+        size_t sz;
+        sz = sizeof host;  nvs_get_str(h, "km_host", host, &sz);
+        sz = sizeof user;  nvs_get_str(h, "km_user", user, &sz);
+        sz = sizeof inst;  nvs_get_str(h, "km_inst", inst, &sz);
+        sz = sizeof base;  nvs_get_str(h, "km_topic", base, &sz);
+        nvs_get_u16(h, "km_port", &port);
+        nvs_close(h);
+    }
+    if (!host[0]) strcpy(host, "mosquitto.lan");
+    if (!user[0]) strcpy(user, "dragonbreath");
+    if (!inst[0]) strcpy(inst, "myprinter");
+    if (!base[0]) strcpy(base, "dragonbreath");
+
+    httpd_resp_set_type(req, "text/plain; charset=utf-8");
+    char b[640];
+
+    SEND(req,
+        "# ===== DragonBreath - Klipper (MQTT) config =====\n"
+        "# Generated from your /setup values. Paste each block into the named file,\n"
+        "# restart Moonraker + Klipper, then set the control source to 'Klipper (MQTT)'.\n"
+        "# Do NOT also run the native dragonbreath-klipper extra - pick one integration.\n\n");
+
+    // ---- moonraker.conf ----
+    snprintf(b, sizeof b,
+        "########## moonraker.conf ##########\n"
+        "[mqtt]\n"
+        "address: %s\n"
+        "port: %u\n"
+        "username: %s\n"
+        "password: <your broker password>\n"
+        "instance_name: %s\n"
+        "enable_moonraker_api: True\n"
+        "publish_split_status: True\n"
+        "status_objects:\n"
+        "  gcode_macro DRAGONBREATH\n"
+        "  gcode_macro DB_LINK\n\n",
+        host, (unsigned)port, user, inst);
+    SEND(req, b);
+
+    snprintf(b, sizeof b, "[sensor %s]\ntype: mqtt\nname: DragonBreath\nstate_topic: %s/telemetry\n",
+             base, base);
+    SEND(req, b);
+    SEND(req,
+        "state_response_template:\n"
+        "  {% set s = payload|fromjson %}\n"
+        "  {set_result(\"chamber_temperature\", s[\"chamber_temperature\"]|float)}\n"
+        "  {set_result(\"element_temperature\", s[\"element_temperature\"]|float)}\n"
+        "parameter_chamber_temperature:\n  units=\xC2\xB0""C\n"
+        "parameter_element_temperature:\n  units=\xC2\xB0""C\n\n");
+
+    snprintf(b, sizeof b, "[power %s]\ntype: mqtt\ncommand_topic: %s/power/set\n", base, base);
+    SEND(req, b);
+    snprintf(b, sizeof b,
+        "command_payload:\n  {command}\nstate_topic: %s/power/state\n"
+        "state_response_template:\n  {payload}\noff_when_shutdown: True\n\n", base);
+    SEND(req, b);
+
+    // ---- printer.cfg (all static: brace-heavy, no substitution) ----
+    SEND(req,
+        "########## printer.cfg ##########\n"
+        "[gcode_macro DRAGONBREATH]\n"
+        "variable_seq: 0\nvariable_target: 0.0\nvariable_mode: \"off\"\n"
+        "variable_fan: 0\nvariable_armed: 0\nvariable_purge_nonce: 0\n"
+        "variable_temperature: -1.0\nvariable_humidity: -1.0\nvariable_fault: \"\"\ngcode:\n\n"
+        "[gcode_macro DB_LINK]\nvariable_heartbeat: 0\ngcode:\n\n"
+        "[delayed_gcode DB_HEARTBEAT]\ninitial_duration: 5\ngcode:\n"
+        "  {% set hb = printer[\"gcode_macro DB_LINK\"].heartbeat|int %}\n"
+        "  SET_GCODE_VARIABLE MACRO=DB_LINK VARIABLE=heartbeat VALUE={hb + 1}\n"
+        "  UPDATE_DELAYED_GCODE ID=DB_HEARTBEAT DURATION=5\n\n");
+    SEND(req,
+        "# Arm + set chamber target. Writes all fields, then bumps seq LAST so the\n"
+        "# device applies a coherent update. Call M141 in your filament/print START.\n"
+        "[gcode_macro M141]\ngcode:\n"
+        "  {% set s = params.S|default(0)|float %}\n"
+        "  {% set m = \"heat\" if s > 0 else \"off\" %}\n"
+        "  SET_GCODE_VARIABLE MACRO=DRAGONBREATH VARIABLE=target VALUE={s}\n"
+        "  SET_GCODE_VARIABLE MACRO=DRAGONBREATH VARIABLE=mode VALUE='\"{m}\"'\n"
+        "  SET_GCODE_VARIABLE MACRO=DRAGONBREATH VARIABLE=armed VALUE={1 if s > 0 else 0}\n"
+        "  SET_GCODE_VARIABLE MACRO=DRAGONBREATH VARIABLE=seq VALUE={printer[\"gcode_macro DRAGONBREATH\"].seq|int + 1}\n\n");
+    SEND(req,
+        "# M191 in MQTT mode sets the target but does NOT block (a true wait needs a\n"
+        "# real Klipper sensor). To refuse printing without a chamber wait, comment out\n"
+        "# this alias and uncomment the strict variant below.\n"
+        "[gcode_macro M191]\ngcode:\n"
+        "  {action_respond_info(\"M191: MQTT mode sets chamber target but does NOT wait.\")}\n"
+        "  M141 S{params.S|default(0)}\n"
+        "# [gcode_macro M191]\n# gcode:\n"
+        "#   { action_raise_error(\"M191 unsupported in MQTT mode - use M141\") }\n\n");
+
+    // ---- mosquitto ACL ----
+    snprintf(b, sizeof b,
+        "########## mosquitto ACL (least privilege) ##########\n"
+        "# Create the user + password:  mosquitto_passwd -c /etc/mosquitto/passwd %s\n"
+        "user %s\n"
+        "topic write %s/telemetry\n"
+        "topic write %s/power/state\n"
+        "topic write %s/status\n"
+        "topic read  %s/power/set\n",
+        user, user, base, base, base, base);
+    SEND(req, b);
+    snprintf(b, sizeof b,
+        "topic read  %s/moonraker/status\n"
+        "topic read  %s/klipper/state/gcode_macro DRAGONBREATH/#\n"
+        "topic read  %s/klipper/state/gcode_macro DB_LINK/#\n"
+        "# writeback (only if you enabled it):\n"
+        "topic write %s/moonraker/api/request\n"
+        "topic read  %s/moonraker/api/response\n",
+        inst, inst, inst, inst, inst);
+    SEND(req, b);
+
+    return httpd_resp_send_chunk(req, NULL, 0);
 }
 
 esp_err_t pb_portal_start(void)
@@ -909,6 +1136,7 @@ esp_err_t pb_portal_start(void)
     httpd_uri_t setup  = { .uri = "/setup",     .method = HTTP_GET,  .handler = config_page };
     httpd_uri_t fw     = { .uri = "/fw",        .method = HTTP_GET,  .handler = fw_page };
     httpd_uri_t diag   = { .uri = "/diag",      .method = HTTP_GET,  .handler = diag_page };
+    httpd_uri_t kmcfg  = { .uri = "/km-config", .method = HTTP_GET,  .handler = km_config_page };
     httpd_uri_t cons   = { .uri = "/console",   .method = HTTP_GET,  .handler = console_page };
     httpd_uri_t favic  = { .uri = "/favicon.ico", .method = HTTP_GET, .handler = favicon_ico };
     httpd_uri_t root   = { .uri = "/*",          .method = HTTP_GET,  .handler = root_page };
@@ -919,6 +1147,7 @@ esp_err_t pb_portal_start(void)
     httpd_register_uri_handler(s, &setup);
     httpd_register_uri_handler(s, &fw);
     httpd_register_uri_handler(s, &diag);
+    httpd_register_uri_handler(s, &kmcfg);
     httpd_register_uri_handler(s, &cons);
     httpd_register_uri_handler(s, &favic);  // before the catch-all so /favicon.ico != SPA
     httpd_register_uri_handler(s, &root);   // catch-all LAST (captive-portal probes)

--- a/components/pb_portal/www/app.html
+++ b/components/pb_portal/www/app.html
@@ -973,9 +973,11 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
   }
   function controllerLabel(s){
     var l=(s.control||{}).lease||{};
-    /* In Home Assistant mode HA is the controller — show "Home Assistant" rather
-       than the internal transport/owner (which is Web/"ha"). */
-    if((s.environment||{}).control_source==='ha') return 'Home Assistant';
+    /* HA and Klipper-MQTT are external controllers — show the controller name rather
+       than the internal transport/owner (which is Web/"ha"/"klipper-mqtt"). */
+    var cs=(s.environment||{}).control_source;
+    if(cs==='ha') return 'Home Assistant';
+    if(cs==='klipper-mqtt') return 'Klipper (MQTT)';
     if(l.active) return sourceLabel(s.source)+(l.owner? ' ('+l.owner+')':'');
     return s.mode==='off' ? '—' : sourceLabel(s.source);
   }
@@ -1117,9 +1119,10 @@ svg.icon{ width: 20px; height: 20px; fill: none; stroke: currentColor;
       if(fila) u('db-filament', fila);
     }
     var plabel = $('db-printer-label');
-    if(src==='ha'){
+    if(src==='ha' || src==='klipper-mqtt'){
+      /* Controllers with no printer bed to follow — label the row as the source. */
       if(plabel) plabel.textContent='Source';
-      u('db-printer','Home Assistant');
+      u('db-printer', src==='ha' ? 'Home Assistant' : 'Klipper (MQTT)');
     } else {
       var plabelText = 'Printer';
       if(src==='bambu') plabelText = 'Bambu'+(s.environment.bambu_serial ? ' ('+s.environment.bambu_serial+')' : '');

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -2,5 +2,5 @@ idf_component_register(
     SRCS "app_main.c"
     INCLUDE_DIRS "."
     REQUIRES pb_board pb_ntc pb_heater pb_fan pb_policy pb_leds pb_buttons pb_hil pb_httpd pb_portal
-             dc_wifi dc_moonraker dc_source dc_bambu pb_ha dc_evlog nvs_flash esp_wifi app_update
+             dc_wifi dc_moonraker dc_source dc_bambu pb_ha db_klipper_mqtt dc_evlog nvs_flash esp_wifi app_update
 )

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -37,6 +37,7 @@
 #include "dc_source.h"
 #include "dc_bambu.h"
 #include "pb_ha.h"
+#include "db_klipper_mqtt.h"
 #include <math.h>
 
 #include "pb_httpd.h"
@@ -64,6 +65,7 @@ static volatile bool s_net_up = false;
 static volatile bool s_mk_up    = false;   // Klipper (Moonraker)
 static volatile bool s_bambu_up = false;   // Bambu LAN MQTT
 static volatile bool s_ha_up    = false;   // Home Assistant MQTT
+static volatile bool s_km_up    = false;   // Klipper (MQTT)
 // The persisted control source, read once at boot. Default Klipper.
 static dc_ctl_source_t s_src = DC_SRC_KLIPPER;
 
@@ -216,6 +218,12 @@ static void control_task(void *arg)
                 // HA client (retained state publish + heat-lease heartbeat); it
                 // drives target/mode through pb_policy directly.
                 if (s_ha_up) pb_ha_tick();
+                break;
+            case DC_SRC_KLIPPER_MQTT:
+                // Klipper-over-MQTT is also a controller (not a bed source): Klipper
+                // macros publish desired-state, the client runs the retained-aware
+                // arming machine and drives target/mode through pb_policy directly.
+                if (s_km_up) db_klipper_mqtt_tick();
                 break;
             case DC_SRC_NONE:
                 break;   // unbound: no bed source, feeds zeros/not-connected
@@ -400,6 +408,12 @@ void app_main(void)
             ESP_LOGE(TAG, "pb_ha_start: %s (continuing; no HA control)", esp_err_to_name(e));
         else
             s_ha_up = true;
+        break;
+    case DC_SRC_KLIPPER_MQTT:
+        if ((e = db_klipper_mqtt_start()) != ESP_OK)
+            ESP_LOGE(TAG, "db_klipper_mqtt_start: %s (continuing; no MQTT control)", esp_err_to_name(e));
+        else
+            s_km_up = true;
         break;
     case DC_SRC_NONE:
         ESP_LOGI(TAG, "control source: none (unbound) — no external controller");

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -2,20 +2,20 @@ dependencies:
   dc_evlog:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_evlog
-    version: ec44eb4e0d897b58de14ed34500590019e3726c3
+    version: 431983c38c0fe37c2bea9c7afe393207b97e9004
   dc_source:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_source
-    version: ec44eb4e0d897b58de14ed34500590019e3726c3
+    version: 431983c38c0fe37c2bea9c7afe393207b97e9004
   dc_bambu:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_bambu
-    version: ec44eb4e0d897b58de14ed34500590019e3726c3
+    version: 431983c38c0fe37c2bea9c7afe393207b97e9004
   dc_wifi:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_wifi
-    version: ec44eb4e0d897b58de14ed34500590019e3726c3
+    version: 431983c38c0fe37c2bea9c7afe393207b97e9004
   dc_moonraker:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_moonraker
-    version: ec44eb4e0d897b58de14ed34500590019e3726c3
+    version: 431983c38c0fe37c2bea9c7afe393207b97e9004

--- a/plans/mqtt-klipper-implementation-design.md
+++ b/plans/mqtt-klipper-implementation-design.md
@@ -1,0 +1,315 @@
+# MQTT-Klipper mode — implementation design (targets v1.0.5)
+
+Status: **Design, pre-implementation.** Grounds [RFC #66](https://github.com/plastikman/DragonBreath/pull/66)
+(`plans/mqtt-klipper-integration-mode.md`) in the *verified* Moonraker/Klipper wire
+contract and this firmware's existing control-source architecture. No code yet — this
+is the doc to review before Phase 2.
+
+This is the portable, plugin-free Klipper integration for **locked/managed** setups
+(user can edit `moonraker.conf` + `printer.cfg` + broker, but cannot install a
+`klippy/extras/` module). The native `dragonbreath-klipper` extra remains the
+preferred path everywhere it can be installed.
+
+---
+
+## 0. What the documentation research changed
+
+Four doc sweeps (Moonraker MQTT core, `[sensor]`/`[power]`, Klipper macros + printer
+API, reference integrations) corrected several RFC assumptions. The design below
+uses the **verified** facts. The corrections that matter:
+
+| # | RFC assumed | Verified reality | Impact |
+|---|---|---|---|
+| 1 | availability at `{instance}/mqtt/...` | **`{instance}/moonraker/status`**, retained `{"server":"online"\|"offline"}` (also the LWT) | our clean "Klipper stack up?" signal |
+| 2 | split-status payload = raw scalar | **`{"eventtime":…,"value":…}` JSON, retained** | parser reads `.value`; retained ⇒ arming must ignore it (see §6) |
+| 3 | (unstated) | combined `.../klipper/status` topic is **non-retained**; split topics **are** | we require `publish_split_status: True` |
+| 4 | object name sanitized | **literal space** kept: `.../gcode_macro DRAGONBREATH/…` | topic filters/parser handle the space |
+| 5 | (unstated) | API correlation by **globally-unique `id`** on a shared response topic; add **`mqtt_timestamp`** (or QoS 0/2) to avoid double-exec | writeback correlation + dedup |
+| 6 | M191 "normally blocking" | **M141/M191 don't exist natively in Klipper**; a macro cannot block on an external value; `TEMPERATURE_WAIT` needs a *hardware* Klipper sensor; **no MQTT-fed Klipper sensor exists** | M141 shim only; blocking M191 impossible by construction |
+| 7 | (unstated) | `SET_GCODE_VARIABLE` is **in-memory only** (resets on FIRMWARE_RESTART) | device re-publishes desired-state + re-asserts `seq` on reconnect |
+| 8 | (unstated) | Moonraker `[sensor]` is **invisible to Klipper macros** | dashboard temp and macro-visible temp are **two paths** (sensor + writeback) |
+| 9 | (unstated) | keepalive fixed at 60 s; `state_timeout` (power) default 2 s | our own dead-man timer is the real safety clock, not MQTT keepalive |
+
+Moonraker Jinja uses **single-brace expressions** `{ }` and `{% %}` statements (not
+Klipper's `{{ }}`); `set_result()` takes exactly `(name, number)`; power
+`state_response_template` must resolve to `on`/`off`/`discard`.
+
+---
+
+## 1. Core invariant: exactly one control source, ever
+
+The firmware already enforces this structurally, and we keep it that way:
+
+- A single NVS enum `ctl_src` (`pb_source`) is read once at boot. `app_main` runs one
+  `switch(ctl_src)` that starts **exactly one** client; the per-tick loop polls that
+  same single branch. `/setup` is one `<select>`. There is no path that runs two MQTT
+  clients or two policy writers.
+- MQTT-Klipper is a **new 5th value** in that same exclusive selector, so choosing it
+  deselects Bambu/HA/native-Klipper automatically.
+- Care-points (mechanical): add `PB_SRC_KLIPPER_MQTT`, renumber `PB_SRC_NONE`, keep
+  every `<= PB_SRC_NONE` range clamp correct (`pb_source.c`, portal save).
+
+### The two "Klipper" sources — disambiguation
+
+There are now two Klipper integrations, and they are **mutually exclusive**:
+
+- **Klipper (Moonraker)** — `PB_SRC_KLIPPER`, today's default. Device follows the bed
+  setpoint over the Moonraker WebSocket and engages AUTO. Pairs with the native
+  `dragonbreath-klipper` extra when installed.
+- **Klipper (MQTT)** — `PB_SRC_KLIPPER_MQTT`, new. Device is *commanded* over MQTT
+  (target/mode/arm) with the RFC's arming+heartbeat safety contract.
+
+`/setup` labels them distinctly and the generated config bundle carries a "do **not**
+also run the native extra" note, so the deployment-level duplicate (two things driving
+the chamber) is prevented by documentation + the single-selector.
+
+---
+
+## 2. Firmware shape: `pb_klipper_mqtt` is a **controller** (HA-shaped)
+
+Unlike Bambu (read-only bed-follow), MQTT-Klipper *receives a desired target and
+arms heat*, so it mirrors **`pb_ha`**: it holds a `pb_policy` lease and heartbeats it,
+rather than feeding the AUTO seam via `pb_policy_set_env`.
+
+New component `components/pb_klipper_mqtt/` (CMake REQUIRES `nvs_flash mqtt esp_timer
+pb_policy`, `+esp-tls` for mqtts):
+
+```
+pb_klipper_mqtt_start(void)                 // boot: connect, subscribe
+pb_klipper_mqtt_tick(void)                  // per-tick: apply desired-state / lease
+pb_klipper_mqtt_get_status(status_t *out)   // for /state JSON + dashboard
+pb_klipper_mqtt_set_config / get_config / clear_config
+```
+
+Policy integration reuses existing seams — **no `pb_policy` signature change**:
+`pb_policy_set_power_on(target, PB_SOURCE_WEB, "klipper-mqtt", …, &lease)` when armed
+and fresh; `pb_policy_heartbeat(&lease)` on each fresh heartbeat; `pb_policy_set_mode_off`
+when disarmed/timed-out. The **`pb_heater` comms dead-man** (`notify_link_alive`, tied
+to lease TTL) is the hardware backstop that forces heat off if we stop heartbeating.
+
+---
+
+## 3. Topic map
+
+`INST` = user-set `instance_name` (required; the hostname default is non-deterministic).
+`DB` = device topic base (default `dragonbreath`; advanced-configurable).
+
+**Device subscribes:**
+
+| Topic | Source | Purpose |
+|---|---|---|
+| `INST/klipper/state/gcode_macro DRAGONBREATH/#` | Moonraker split-status (retained) | desired-state fields |
+| `INST/klipper/state/gcode_macro DB_LINK/#` | Moonraker split-status (retained) | heartbeat counter |
+| `INST/moonraker/status` | Moonraker (retained/LWT) | Klipper-stack availability |
+| `INST/moonraker/api/response` | Moonraker (non-retained) | JSON-RPC writeback responses |
+| `DB/power/set` | Moonraker `[power]` command | master enable on/off |
+
+**Device publishes:**
+
+| Topic | Retain | Payload |
+|---|---|---|
+| `DB/telemetry` | no | versioned JSON telemetry (§4) |
+| `DB/power/state` | **yes** | `on`/`off` (Moonraker inits w/o query; 2 s `state_timeout`) |
+| `DB/status` | **yes** (LWT) | `online` / `offline` (device availability) |
+| `INST/moonraker/api/request` | no | JSON-RPC `printer.gcode.script` writeback (§5) |
+
+**All device-published *application* messages are non-retained** except `power/state`
+and `status` (which are device-availability/init, never arming inputs).
+
+---
+
+## 4. Payload schemas (versioned)
+
+Every device JSON payload carries `"v": 1` (schema version; bump on breaking change).
+
+**`DB/telemetry`** (non-retained, ~2 s or on-change):
+```json
+{"v":1,"chamber_temperature":42.3,"element_temperature":80.1,"humidity":35.0,
+ "mode":"heat","target":55.0,"armed":true,"seq_ack":7,"fault":""}
+```
+Consumed by Moonraker `[sensor type: mqtt]` for the dashboard (parses the temp fields
+via `set_result`) and available to any observer; `seq_ack` closes the desired-state
+loop (device echoes the `seq` it last applied).
+
+**Desired-state** lives on **`gcode_macro DRAGONBREATH`** (lower-case variable names,
+Klipper rule):
+```
+variable_seq: 0            # monotonic; bumped LAST after all fields written
+variable_target: 0.0       # chamber °C
+variable_mode: "off"       # "off" | "heat"
+variable_fan: 0            # 0..100
+variable_armed: 0          # 0 | 1  (explicit arm)
+variable_purge_nonce: 0    # one-shot actions (increment, not bool)
+# device-written back (for macro logic):
+variable_temperature: -1.0
+variable_humidity: -1.0
+variable_fault: ""
+```
+Delivered as retained split-status: topic `.../gcode_macro DRAGONBREATH/seq` etc.,
+payload `{"eventtime":…,"value":7}`. Device reads `.value`.
+
+**Heartbeat** on **`gcode_macro DB_LINK`**: `variable_heartbeat` incremented every 5 s
+by a self-rescheduling `[delayed_gcode]` (doc-idiomatic; body stays motion-free).
+
+---
+
+## 5. Desired-state → arming state machine (the safety core)
+
+> **Invariant:** DragonBreath never energizes heat merely because it received desired
+> state. It requires an explicit **arm edge observed live** *and* a **fresh heartbeat**.
+
+Because split-status is **retained**, a reconnecting device is handed `armed=1`,
+`target=55`, `seq=7`, and the last `heartbeat` value **immediately** — all potentially
+stale. So arming gates on *liveness observed after connect*, not on received values:
+
+State per (re)connect starts **DISARMED**, and:
+
+1. **Connect snapshot** — the first value received for each field (target/mode/seq/
+   armed/heartbeat) is recorded as the initial snapshot. An `armed=1` *in the snapshot*
+   is **not** an arm edge; the snapshot `heartbeat` is **not** proof of liveness.
+2. **Liveness** — becomes true only after we observe the `heartbeat` value **change**
+   at least once post-connect, and stays true while the last change was `< 15 s` ago
+   (3 × 5 s cadence). Loss of liveness ⇒ force heat off, latch `comms_lost`.
+3. **Arm** — heat is driven only when **all** hold:
+   - `seq` advanced beyond last-applied (a coherent new desired-state — `seq` is
+     written last, so all other fields are consistent when it changes);
+   - `mode == "heat"` and `armed == 1`;
+   - the `0→1` **arm edge was observed live** (not the connect snapshot);
+   - liveness is currently true.
+4. **Apply** — on a qualifying update: `pb_policy_set_power_on(target, …, &lease)`;
+   publish `seq_ack = seq`. While armed+live, `pb_policy_heartbeat(&lease)` on each
+   fresh heartbeat (period `< pb_heater` comms timeout).
+5. **Disarm / recover** — `armed→0`, `mode→off`, liveness lost, Moonraker `offline`,
+   or master-power off ⇒ `pb_policy_set_mode_off`. Recovery re-enters at DISARMED and
+   requires a **new** live arm edge (a retained `armed=1` after reconnect never
+   re-arms on its own).
+
+Fan (`variable_fan`) and one-shots (`purge_nonce` edge) apply independently of the heat
+arm. Thermal cutoffs, max-temp, the `pb_heater` watchdog and fail-off all remain inside
+firmware and are unchanged — this mode cannot weaken them.
+
+---
+
+## 6. Device→Klipper writeback (macro-visible temp/fault)
+
+Moonraker `[sensor]` values are invisible to macros (§0 #8), so for macro logic the
+device writes temp/humidity/fault back into `DRAGONBREATH` vars via the API bridge:
+```json
+{"jsonrpc":"2.0","method":"printer.gcode.script","id":<uniq>,
+ "params":{"script":"SET_GCODE_VARIABLE MACRO=DRAGONBREATH VARIABLE=temperature VALUE=42.3",
+           "mqtt_timestamp":<us>}}
+```
+Rules from the docs: `id` **globally unique** (shared response topic); include
+`mqtt_timestamp` (or QoS 0/2) to prevent duplicate execution; **rate-limit to ~2 s,
+on-change only** — `printer.gcode.script` enters the G-code queue and must not compete
+with print moves. String values need doubled quoting (`VALUE='"latched"'`); numbers
+bare. This path is **optional** (telemetry-out via `[sensor]` covers the dashboard);
+enable it only when a customer's macros need live device state.
+
+---
+
+## 7. M141 shim; M191 policy
+
+- **`M141`** (set chamber temp, non-blocking) — shim macro writes `target` + bumps
+  `seq`; that's the whole control input during a print (filament start-gcode). Klipper
+  has no native M141, so we *provide* it (no `rename_existing`).
+- **`M191`** (set + wait) — a correct blocking wait is **impossible** in this mode
+  (§0 #6). **DECIDED:** default to a **non-blocking alias** — `M191` sets the target
+  (like `M141`) and prints a one-line `action_respond_info` warning that it does *not*
+  wait. Rationale: M191 behavior cannot affect safety (arming/heartbeat/watchdog govern
+  heat regardless); a hard error would *abort* any print whose start-gcode emits M191,
+  whereas the alias degrades gracefully (worst case: cooler first layers). The strict
+  hard-error variant ships **commented-out directly below** in the generated
+  `printer.cfg`, so a user who wants "refuse to print without a chamber wait" flips it
+  by uncommenting — no firmware toggle, since this is Klipper-side config the user owns.
+  The iHeater "`start_offset` early-release" trick does **not** save us — it still needs
+  a real Klipper `temperature_sensor`, which MQTT mode doesn't provide.
+
+  ```
+  [gcode_macro M191]
+  gcode:
+    {action_respond_info("M191: MQTT mode sets target but does NOT block.")}
+    M141 S{params.S|default(0)}
+  # --- Strict alternative: refuse to print without a real chamber wait ---
+  # [gcode_macro M191]
+  # gcode:
+  #   { action_raise_error("M191 unsupported in MQTT mode — use M141") }
+  ```
+- **Optional `printer.emergency_stop`** on a latching critical enclosure fault: keep
+  **disabled by default** until its trigger policy is specified and tested.
+
+---
+
+## 8. `/setup` UX — single source of truth → generated config
+
+Design principle: collect the *minimum* free-form inputs; **derive** every topic;
+**emit** the exact Klipper-side config so the two ends can't drift.
+
+**Fields (new `data-src` group, mirrors the Bambu/HA groups):**
+- Broker `address`, `port` (1883/8883), `username`, `password`, `TLS` toggle.
+- `instance_name` (**required** — topics are non-deterministic otherwise).
+- `device topic base` (default `dragonbreath`; advanced/collapsible).
+- (advanced) QoS.
+
+**Setup validator** (RFC phase 3, made *generative*): refuses to enable the mode
+without broker address **and** credentials; warns if `instance_name` is blank.
+
+**Generated bundle** (rendered from the fields above, shown on `/setup` for copy-paste
+and downloadable): `moonraker.conf` (`[mqtt]` with `publish_split_status: True` +
+`status_objects` for both macros, `[sensor type: mqtt]` for the dashboard temp,
+`[power type: mqtt]` for the master enable), `printer.cfg` (the `DRAGONBREATH` +
+`DB_LINK` macros, the `DB_HEARTBEAT` delayed_gcode, `M141`/`M191` shims), and the
+`mosquitto` ACL (least-privilege, per RFC — *not* presented as optional). The bundle
+header states native-extra mutual exclusion.
+
+---
+
+## 9. Reference patterns adopted (from the integration survey)
+
+- **`off_when_shutdown: True`** on the `[power]` device — the one free Klipper-side
+  kill (heater off if Klippy dies), complementing our dead-man timer.
+- **Relaxed `verify_heater`** guidance in docs (chamber heats slowly; hotend defaults
+  false-trip) — though in MQTT mode the element is *ours*, not a Klipper heater, so
+  this is advisory for any user who also mirrors a Klipper heater.
+- **Non-motion heartbeat body** (`SET_GCODE_VARIABLE`/`action_respond_info` only).
+- **`seq`-written-last** coherent-update discipline; **`purge_nonce`** for repeatable
+  one-shots.
+- **`discard` via `last_request`/`response_count`** in the power `state_response_template`
+  only if we ever echo command+state (we publish state once per real change, so likely
+  unneeded — noted to avoid toggle flap).
+
+---
+
+## 10. Decisions (locked — schema frozen)
+
+1. **M191 behavior:** **non-blocking alias + warning** (default), strict hard-error
+   variant shipped commented-out in the generated `printer.cfg` (§7). ✔ locked
+2. **Device topic base:** **fixed `dragonbreath`, advanced-editable** in `/setup` (§8). ✔ locked
+3. **Writeback (§6) on by default:** **off** — dashboard via `[sensor]` suffices;
+   opt-in toggle for macro-driven setups. ✔ locked
+4. **`emergency_stop` escalation:** **disabled by default** for 1.0.5, pending a
+   specified+tested trigger policy. ✔ locked
+5. **Expose DragonBreath as a Klipper `[heater_generic]`/`[temperature_sensor]`?**
+   Out of scope for MQTT-only (needs a plugin/MCU); it's the only route to a real
+   blocking M191 — noted as a future "native+" path, **not 1.0.5**.
+
+---
+
+## 11. Implementation phases (1.0.5 = phases 1–3; phase 4 gates the final tag)
+
+1. **Schema freeze** — ✅ done (this doc; decisions locked §10).
+2. **Firmware** — ✅ done. `pb_klipper_mqtt` (controller, HA-shaped) reusing the
+   lease/policy + `pb_heater` watchdog seams; NVS-safe enum; `/setup` group +
+   validator; `pb_source`/dashboard surface. Arming core host-tested (26 cases:
+   retained-snapshot-doesn't-arm, arm-needs-new-seq+live-heartbeat, seq coherence,
+   heartbeat-timeout → comms-lost, re-arm-after-recovery, prompt disarm, purge nonce).
+   Builds clean; on-device smoke test of `/setup` + `/km-config` passed.
+3. **Config artifacts** — ✅ generative: `GET /km-config` renders `moonraker.conf` +
+   `printer.cfg` + Mosquitto ACL filled in from the saved settings (single source of
+   truth), incl. the M141 shim + non-blocking-M191 alias. TODO: a short `docs/`
+   page framing MQTT mode as the compatibility path (polish).
+4. **Hardware validation on a real locked Klipper install** (Mainsail + Fluidd):
+   dashboard readings, control, queue behavior mid-print, loss/recovery, and the proof
+   that heat stays off until an explicit live re-arm. **PENDING — gates the `v1.0.5`
+   tag.** (Bench has no locked-Klipper broker; needs a real setup.)
+5. Docs polish; retain native module as recommended path.

--- a/tests/db_klipper_mqtt_host_test.c
+++ b/tests/db_klipper_mqtt_host_test.c
@@ -1,0 +1,165 @@
+// Host unit test for the MQTT-Klipper arming core (db_klipper_mqtt_arm.h): the
+// retained-aware arm/heartbeat state machine + split-status value extraction +
+// topic field classification. Pure logic, no ESP deps.
+//
+// The arming tests encode the safety contract from
+// plans/mqtt-klipper-implementation-design.md §5.
+#include "db_klipper_mqtt_arm.h"
+#include <stdio.h>
+#include <string.h>
+
+static int fails = 0;
+#define CHECK(cond, msg) do { \
+    int ok_ = (cond); if (!ok_) fails++; \
+    printf("[%s] %s\n", ok_ ? "PASS" : "FAIL", msg); } while (0)
+
+// 15 s liveness window (3 x 5 s heartbeat), in microseconds.
+#define TIMEOUT_US ((int64_t)15 * 1000 * 1000)
+#define SEC_US(s)  ((int64_t)(s) * 1000 * 1000)
+
+int main(void)
+{
+    // ---------- split-status value extraction ----------
+    char v[32];
+    CHECK(db_km_value("{\"eventtime\":123.4,\"value\":55.0}", v, sizeof v) && strcmp(v, "55.0") == 0,
+          "value: number");
+    CHECK(db_km_value("{\"value\":\"heat\",\"eventtime\":1}", v, sizeof v) && strcmp(v, "heat") == 0,
+          "value: string (quotes stripped)");
+    CHECK(db_km_value("{\"eventtime\":1,\"value\":true}", v, sizeof v) && strcmp(v, "true") == 0,
+          "value: bool");
+    CHECK(db_km_value("{\"eventtime\": 9, \"value\" : 7 }", v, sizeof v) && strcmp(v, "7") == 0,
+          "value: whitespace tolerant");
+    CHECK(!db_km_value("{\"eventtime\":1}", v, sizeof v), "value: absent -> false");
+
+    // ---------- topic field classification (literal space in object name) ----------
+    CHECK(db_km_field_of("p/klipper/state/gcode_macro DRAGONBREATH/seq")    == DB_KM_F_SEQ,    "field: seq");
+    CHECK(db_km_field_of("p/klipper/state/gcode_macro DRAGONBREATH/target") == DB_KM_F_TARGET, "field: target");
+    CHECK(db_km_field_of("p/klipper/state/gcode_macro DRAGONBREATH/armed")  == DB_KM_F_ARMED,  "field: armed");
+    CHECK(db_km_field_of("p/klipper/state/gcode_macro DB_LINK/heartbeat")   == DB_KM_F_HEARTBEAT, "field: heartbeat");
+    CHECK(db_km_field_of("p/klipper/state/gcode_macro OTHER/seq")           == DB_KM_F_NONE,   "field: other macro -> none");
+    CHECK(db_km_field_of("p/moonraker/status")                             == DB_KM_F_NONE,   "field: non-state -> none");
+
+    float tgt;
+    db_km_action_t a;
+
+    // ---------- retained snapshot must NOT arm ----------
+    // On connect, retained desired-state (armed=1, mode heat, seq=7, target=55) and a
+    // retained heartbeat=100 all arrive as the baseline snapshot. No live heartbeat
+    // change yet -> must stay disarmed.
+    {
+        db_km_arm_t st; db_km_arm_reset(&st);
+        db_km_arm_seq(&st, 7);
+        db_km_arm_target(&st, 55.0f);
+        db_km_arm_mode(&st, "heat");
+        db_km_arm_armed(&st, 1);
+        db_km_arm_hb(&st, 100, SEC_US(0));         // snapshot heartbeat (not live)
+        a = db_km_arm_eval(&st, SEC_US(1), TIMEOUT_US, &tgt);
+        CHECK(a == DB_KM_HOLD && !st.engaged, "retained snapshot does not arm");
+    }
+
+    // ---------- arm only after a fresh seq + live heartbeat ----------
+    {
+        db_km_arm_t st; db_km_arm_reset(&st);
+        db_km_arm_seq(&st, 7);                     // baseline
+        db_km_arm_target(&st, 55.0f);
+        db_km_arm_mode(&st, "heat");
+        db_km_arm_armed(&st, 1);
+        db_km_arm_hb(&st, 100, SEC_US(0));         // baseline hb
+        // heartbeat increments (liveness) but seq unchanged -> still no engage
+        db_km_arm_hb(&st, 101, SEC_US(5));
+        a = db_km_arm_eval(&st, SEC_US(5), TIMEOUT_US, &tgt);
+        CHECK(a == DB_KM_HOLD && !st.engaged, "live heartbeat alone (no new seq) does not arm");
+        // now a fresh coherent desired-state (macro re-arm bumps seq)
+        db_km_arm_seq(&st, 8);
+        a = db_km_arm_eval(&st, SEC_US(6), TIMEOUT_US, &tgt);
+        CHECK(a == DB_KM_ENGAGE && st.engaged && tgt == 55.0f, "new seq + armed + live -> ENGAGE");
+    }
+
+    // ---------- heartbeat timeout while engaged -> comms lost ----------
+    {
+        db_km_arm_t st; db_km_arm_reset(&st);
+        db_km_arm_seq(&st, 1); db_km_arm_target(&st, 50.0f);
+        db_km_arm_mode(&st, "heat"); db_km_arm_armed(&st, 1);
+        db_km_arm_hb(&st, 0, SEC_US(0));
+        db_km_arm_hb(&st, 1, SEC_US(5));           // live at t=5
+        db_km_arm_seq(&st, 2);
+        a = db_km_arm_eval(&st, SEC_US(6), TIMEOUT_US, &tgt);
+        CHECK(a == DB_KM_ENGAGE && st.engaged, "engaged for timeout test");
+        // no more heartbeats; at t=5+16s (>15s since last change) liveness is gone
+        a = db_km_arm_eval(&st, SEC_US(21), TIMEOUT_US, &tgt);
+        CHECK(a == DB_KM_COMMS_LOST && !st.engaged, "heartbeat timeout -> COMMS_LOST + off");
+    }
+
+    // ---------- re-arm after recovery requires a NEW seq ----------
+    {
+        db_km_arm_t st; db_km_arm_reset(&st);
+        db_km_arm_seq(&st, 1); db_km_arm_target(&st, 50.0f);
+        db_km_arm_mode(&st, "heat"); db_km_arm_armed(&st, 1);
+        db_km_arm_hb(&st, 0, SEC_US(0)); db_km_arm_hb(&st, 1, SEC_US(5));
+        db_km_arm_seq(&st, 2);
+        db_km_arm_eval(&st, SEC_US(6), TIMEOUT_US, &tgt);                 // engaged
+        db_km_arm_eval(&st, SEC_US(30), TIMEOUT_US, &tgt);               // comms lost -> off
+        // heartbeat resumes, armed still 1, but seq unchanged -> must NOT re-engage
+        db_km_arm_hb(&st, 2, SEC_US(31));
+        a = db_km_arm_eval(&st, SEC_US(32), TIMEOUT_US, &tgt);
+        CHECK(a == DB_KM_HOLD && !st.engaged, "recovery without new seq stays off");
+        // explicit re-arm (macro bumps seq) -> engages
+        db_km_arm_seq(&st, 3);
+        a = db_km_arm_eval(&st, SEC_US(33), TIMEOUT_US, &tgt);
+        CHECK(a == DB_KM_ENGAGE && st.engaged, "explicit re-arm after recovery -> ENGAGE");
+    }
+
+    // ---------- armed=0 disengages promptly (no seq needed) ----------
+    {
+        db_km_arm_t st; db_km_arm_reset(&st);
+        db_km_arm_seq(&st, 1); db_km_arm_target(&st, 50.0f);
+        db_km_arm_mode(&st, "heat"); db_km_arm_armed(&st, 1);
+        db_km_arm_hb(&st, 0, SEC_US(0)); db_km_arm_hb(&st, 1, SEC_US(5));
+        db_km_arm_seq(&st, 2);
+        db_km_arm_eval(&st, SEC_US(6), TIMEOUT_US, &tgt);                 // engaged
+        db_km_arm_armed(&st, 0);                                          // disarm field
+        a = db_km_arm_eval(&st, SEC_US(7), TIMEOUT_US, &tgt);
+        CHECK(a == DB_KM_DISENGAGE && !st.engaged, "armed=0 disengages promptly");
+    }
+
+    // ---------- mode=off disengages promptly ----------
+    {
+        db_km_arm_t st; db_km_arm_reset(&st);
+        db_km_arm_seq(&st, 1); db_km_arm_target(&st, 50.0f);
+        db_km_arm_mode(&st, "heat"); db_km_arm_armed(&st, 1);
+        db_km_arm_hb(&st, 0, SEC_US(0)); db_km_arm_hb(&st, 1, SEC_US(5));
+        db_km_arm_seq(&st, 2);
+        db_km_arm_eval(&st, SEC_US(6), TIMEOUT_US, &tgt);
+        db_km_arm_mode(&st, "off");
+        a = db_km_arm_eval(&st, SEC_US(7), TIMEOUT_US, &tgt);
+        CHECK(a == DB_KM_DISENGAGE && !st.engaged, "mode=off disengages promptly");
+    }
+
+    // ---------- target update takes effect only on a new seq ----------
+    {
+        db_km_arm_t st; db_km_arm_reset(&st);
+        db_km_arm_seq(&st, 1); db_km_arm_target(&st, 50.0f);
+        db_km_arm_mode(&st, "heat"); db_km_arm_armed(&st, 1);
+        db_km_arm_hb(&st, 0, SEC_US(0)); db_km_arm_hb(&st, 1, SEC_US(5));
+        db_km_arm_seq(&st, 2);
+        db_km_arm_eval(&st, SEC_US(6), TIMEOUT_US, &tgt);
+        CHECK(tgt == 50.0f, "engaged at 50");
+        db_km_arm_target(&st, 60.0f);                                     // new target field, no seq bump
+        a = db_km_arm_eval(&st, SEC_US(7), TIMEOUT_US, &tgt);
+        CHECK(a == DB_KM_HOLD, "target change without seq bump does not re-apply");
+        db_km_arm_seq(&st, 3);                                            // coherent update
+        a = db_km_arm_eval(&st, SEC_US(8), TIMEOUT_US, &tgt);
+        CHECK(a == DB_KM_ENGAGE && tgt == 60.0f, "target applied on new seq");
+    }
+
+    // ---------- purge nonce: baseline does not fire, advance fires ----------
+    {
+        db_km_arm_t st; db_km_arm_reset(&st);
+        CHECK(db_km_arm_purge(&st, 5) == false, "retained purge nonce (baseline) does not fire");
+        CHECK(db_km_arm_purge(&st, 5) == false, "same nonce does not fire");
+        CHECK(db_km_arm_purge(&st, 6) == true,  "advanced nonce fires");
+    }
+
+    printf(fails ? "\n%d FAILED\n" : "\nALL PASS\n", fails);
+    return fails ? 1 : 0;
+}

--- a/tests/run_db_klipper_mqtt_host_test.sh
+++ b/tests/run_db_klipper_mqtt_host_test.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eu
+
+root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+out="${TMPDIR:-/tmp}/dragonbreath-pb-klipper-mqtt-test"
+
+# db_klipper_mqtt_arm.h is pure (only libc), so no ESP stubs are needed — just its
+# include dir for the header under test.
+cc -std=c11 -Wall -Wextra -Werror \
+  -I"$root/components/db_klipper_mqtt/include" \
+  "$root/tests/db_klipper_mqtt_host_test.c" \
+  -o "$out"
+
+"$out"


### PR DESCRIPTION
## What this is

A **grounded implementation design** for the MQTT-only Klipper integration mode, building directly on @justinh-rahb's RFC in #66. Doc-only (`plans/mqtt-klipper-implementation-design.md`) — **for review before any firmware is written.** Targets **v1.0.5**.

Before designing, I ran four documentation sweeps against the *official* Moonraker/Klipper docs (MQTT core, `[sensor]`/`[power]`, macros + printer API, and reference integrations like iHeater / Panda Sense). Several RFC assumptions needed correcting — captured in §0 of the doc.

## Verified corrections to the RFC (the ones that change the contract)

- **Availability topic is `{instance}/moonraker/status`** (retained `{"server":online|offline}`, also the LWT) — not `{instance}/mqtt/...`.
- **Split-status payload is `{"eventtime":…,"value":…}` JSON and is *retained*** (not a raw scalar); the combined `.../klipper/status` topic is *non-retained* → we require `publish_split_status: True`.
- **Object names keep their literal space**: `.../gcode_macro DRAGONBREATH/…`.
- **API is correlated by a globally-unique JSON-RPC `id`** on a shared response topic; add **`mqtt_timestamp`** (or QoS 0/2) to avoid double-executing `printer.gcode.script`. Keepalive is a fixed 60 s.
- **Blocking `M191` is impossible by construction** — Klipper expands a macro fully before executing (no await), `TEMPERATURE_WAIT` needs a *hardware* Klipper sensor, and no MQTT-fed Klipper sensor exists. Bonus: `M141`/`M191` aren't native Klipper commands, so we *provide* M141 (no `rename_existing`).
- **`SET_GCODE_VARIABLE` is in-memory only** → device re-publishes desired-state + re-asserts `seq` on reconnect.
- **Moonraker `[sensor]` is invisible to Klipper macros** → dashboard temp and macro-visible temp are two separate paths.

## Design highlights

- **`pb_klipper_mqtt` is a *controller*** (mirrors `pb_ha`: holds a `pb_policy` lease + heartbeats it), reusing the existing lease/policy and `pb_heater` comms-watchdog seams — **no `pb_policy` signature change**, hardware fail-off unchanged.
- **Exactly-one-source stays structural**: a 5th value in the single `/setup` selector, labeled "Klipper (MQTT)" vs "Klipper (Moonraker)", mutually exclusive with the native extra.
- **Retained-aware arming** (the safety core): because split-status is retained, a reconnecting device is handed stale `armed=1`/`target`/`seq` instantly — so heat arms **only** on a live arm-edge *after* connect **plus** a fresh heartbeat (3×5 s = 15 s timeout → force off + latch `comms_lost`). A retained `armed=1` never re-arms.
- **`/setup` = single source of truth → generated config**: collect broker + `instance_name`, derive all topics, emit exact `moonraker.conf` / `printer.cfg` / `mosquitto` ACL; validator refuses to enable without broker + creds.

## Locked decisions (§10)

- **M191** → non-blocking alias + warning (strict hard-error variant shipped commented-out).
- **Writeback** → off by default (opt-in).
- **Topic base** → fixed `dragonbreath`, advanced-editable.
- **`emergency_stop`** escalation → disabled by default.

## Feedback wanted

1. The **retained-aware arming state machine** (§5) — is the "live arm-edge + fresh heartbeat, never trust retained" model airtight?
2. The **controller-vs-bed-follow** choice (§2) and the lease/heartbeat mapping onto `pb_policy`/`pb_heater`.
3. Anything in the **OpenVent shared-core boundary** you'd want handled differently, given 1.1.0 will target the shared base.
4. The **M191 non-blocking default** (§7) — agree it degrades more gracefully than a hard error?

Closes nothing yet — RFC #66 stays open as the spec; this is the implementation plan derived from it.
