### PR TITLE
Read-only HA telemetry alongside a Bambu/Klipper source

### DIFF
--- a/components/pb_ha/include/pb_ha.h
+++ b/components/pb_ha/include/pb_ha.h
@@ -33,6 +33,12 @@ typedef struct {
 
 esp_err_t pb_ha_start(void);
 
+// Start HA in READ-ONLY mode: publishes MQTT-Discovery sensors + a retained state
+// topic (chamber/element temp, target, mode) but never subscribes command topics and
+// never takes a pb_policy lease. Used when HA runs ALONGSIDE another control source
+// (Bambu/Klipper) purely as a monitor. Mutually exclusive with pb_ha_start().
+esp_err_t pb_ha_start_readonly(void);
+
 // Periodic pump: publishes retained state (~2 s) and heartbeats the heat lease
 // (~5 s, well under the comms-watchdog minimum). Call from the control loop when
 // HA is the active source. No-op if the client isn't running.

--- a/components/pb_ha/pb_ha.c
+++ b/components/pb_ha/pb_ha.c
@@ -44,14 +44,23 @@ static pb_ha_config_t           s_cfg    = {0};
 static pb_ha_status_t           s_status = { .state = PB_HA_DISABLED };
 static esp_mqtt_client_handle_t s_client = NULL;
 
+// Read-only mode: publish telemetry (sensors + state) but never subscribe to command
+// topics and never take a pb_policy lease — used when HA runs ALONGSIDE another
+// control source (Bambu/Klipper) purely as a monitor. Set once at start, before the
+// client connects, so it's effectively immutable while the client runs.
+static bool s_readonly = false;
+
 // Shared control state (guarded by s_lock).
 static bool               s_have_lease = false;
 static pb_policy_lease_t  s_lease      = {0};
 static float              s_desired_target = 45.0f;
 
-// Pacing (control task only).
+// Pacing (control task only). s_pub_pending is a lock-guarded request from the MQTT
+// callback (on connect) asking tick() to publish promptly — avoids the MQTT task
+// writing the control-task pacing clock directly (cross-task data race).
 static int64_t s_last_state_us = 0;
 static int64_t s_last_hb_us    = 0;
+static bool    s_pub_pending   = false;   // guarded by s_lock
 
 // Availability (LWT) topic — must outlive esp_mqtt_client_init(), so it's static.
 static char s_avail_topic[80] = {0};
@@ -166,28 +175,35 @@ static void publish_discovery(void)
 {
     const char *p = prefix();
     char buf[1024];
+    char topic[96];
 
-    // Climate entity (HA MQTT discovery, abbreviated keys). State fields are read
-    // from the single retained <p>/state JSON via templates.
-    int cfg = snprintf(buf, sizeof buf,
-        "{\"name\":\"DragonBreath\",\"uniq_id\":\"%s_climate\","
-        "\"avty_t\":\"%s/availability\","
-        "\"curr_temp_t\":\"%s/state\",\"curr_temp_tpl\":\"{{value_json.chamber}}\","
-        "\"temp_stat_t\":\"%s/state\",\"temp_stat_tpl\":\"{{value_json.target}}\","
-        "\"temp_cmd_t\":\"%s/temp/set\","
-        "\"mode_stat_t\":\"%s/state\",\"mode_stat_tpl\":\"{{value_json.mode}}\","
-        "\"mode_cmd_t\":\"%s/mode/set\","
-        // temp_unit "C": our target/current values on the state + command topics are
-        // Celsius. HA converts for display and converts a user's setpoint (e.g. °F on
-        // an imperial system) back to °C before publishing to temp_cmd_t.
-        "\"temp_unit\":\"C\","
-        "\"modes\":[\"off\",\"heat\"],\"min_temp\":20,\"max_temp\":70,\"temp_step\":1,"
-        "\"dev\":{\"ids\":[\"%s\"],\"name\":\"DragonBreath\",\"mdl\":\"Panda Breath\",\"mf\":\"DragonBreath\"}}",
-        p, p, p, p, p, p, p, p);
-    if (cfg > 0 && cfg < (int)sizeof buf) {
-        char topic[96];
-        snprintf(topic, sizeof topic, "homeassistant/climate/%s/config", p);
-        esp_mqtt_client_publish(s_client, topic, buf, 0, 1, 1);   // qos1, retain
+    // Climate entity (controllable thermostat) — only in full-control mode. In
+    // read-only mode we publish an EMPTY retained payload to the same config topic so
+    // HA removes any thermostat left over from a previous full-control session (no
+    // dead buttons); the device just reports via sensors below.
+    snprintf(topic, sizeof topic, "homeassistant/climate/%s/config", p);
+    if (s_readonly) {
+        esp_mqtt_client_publish(s_client, topic, "", 0, 1, 1);   // clear retained config
+    } else {
+        // Climate entity (HA MQTT discovery, abbreviated keys). State fields are read
+        // from the single retained <p>/state JSON via templates.
+        int cfg = snprintf(buf, sizeof buf,
+            "{\"name\":\"DragonBreath\",\"uniq_id\":\"%s_climate\","
+            "\"avty_t\":\"%s/availability\","
+            "\"curr_temp_t\":\"%s/state\",\"curr_temp_tpl\":\"{{value_json.chamber}}\","
+            "\"temp_stat_t\":\"%s/state\",\"temp_stat_tpl\":\"{{value_json.target}}\","
+            "\"temp_cmd_t\":\"%s/temp/set\","
+            "\"mode_stat_t\":\"%s/state\",\"mode_stat_tpl\":\"{{value_json.mode}}\","
+            "\"mode_cmd_t\":\"%s/mode/set\","
+            // temp_unit "C": our target/current values on the state + command topics are
+            // Celsius. HA converts for display and converts a user's setpoint (e.g. °F on
+            // an imperial system) back to °C before publishing to temp_cmd_t.
+            "\"temp_unit\":\"C\","
+            "\"modes\":[\"off\",\"heat\"],\"min_temp\":20,\"max_temp\":70,\"temp_step\":1,"
+            "\"dev\":{\"ids\":[\"%s\"],\"name\":\"DragonBreath\",\"mdl\":\"Panda Breath\",\"mf\":\"DragonBreath\"}}",
+            p, p, p, p, p, p, p, p);
+        if (cfg > 0 && cfg < (int)sizeof buf)
+            esp_mqtt_client_publish(s_client, topic, buf, 0, 1, 1);   // qos1, retain
     }
 
     // Chamber temperature sensor.
@@ -197,11 +213,8 @@ static void publish_discovery(void)
         "\"val_tpl\":\"{{value_json.chamber}}\",\"unit_of_meas\":\"\xC2\xB0""C\","
         "\"dev_cla\":\"temperature\",\"dev\":{\"ids\":[\"%s\"]}}",
         p, p, p, p);
-    {
-        char topic[96];
-        snprintf(topic, sizeof topic, "homeassistant/sensor/%s_chamber/config", p);
-        esp_mqtt_client_publish(s_client, topic, buf, 0, 1, 1);
-    }
+    snprintf(topic, sizeof topic, "homeassistant/sensor/%s_chamber/config", p);
+    esp_mqtt_client_publish(s_client, topic, buf, 0, 1, 1);
 
     // Element (PTC) temperature sensor.
     snprintf(buf, sizeof buf,
@@ -210,9 +223,27 @@ static void publish_discovery(void)
         "\"val_tpl\":\"{{value_json.ptc}}\",\"unit_of_meas\":\"\xC2\xB0""C\","
         "\"dev_cla\":\"temperature\",\"dev\":{\"ids\":[\"%s\"]}}",
         p, p, p, p);
-    {
-        char topic[96];
-        snprintf(topic, sizeof topic, "homeassistant/sensor/%s_ptc/config", p);
+    snprintf(topic, sizeof topic, "homeassistant/sensor/%s_ptc/config", p);
+    esp_mqtt_client_publish(s_client, topic, buf, 0, 1, 1);
+
+    // Read-only mode has no controllable thermostat, so surface target + mode as
+    // plain sensors too (so HA still sees the setpoint the active source is driving).
+    if (s_readonly) {
+        snprintf(buf, sizeof buf,
+            "{\"name\":\"DragonBreath Target\",\"uniq_id\":\"%s_target\","
+            "\"avty_t\":\"%s/availability\",\"stat_t\":\"%s/state\","
+            "\"val_tpl\":\"{{value_json.target}}\",\"unit_of_meas\":\"\xC2\xB0""C\","
+            "\"dev_cla\":\"temperature\",\"dev\":{\"ids\":[\"%s\"]}}",
+            p, p, p, p);
+        snprintf(topic, sizeof topic, "homeassistant/sensor/%s_target/config", p);
+        esp_mqtt_client_publish(s_client, topic, buf, 0, 1, 1);
+
+        snprintf(buf, sizeof buf,
+            "{\"name\":\"DragonBreath Mode\",\"uniq_id\":\"%s_mode\","
+            "\"avty_t\":\"%s/availability\",\"stat_t\":\"%s/state\","
+            "\"val_tpl\":\"{{value_json.mode}}\",\"dev\":{\"ids\":[\"%s\"]}}",
+            p, p, p, p);
+        snprintf(topic, sizeof topic, "homeassistant/sensor/%s_mode/config", p);
         esp_mqtt_client_publish(s_client, topic, buf, 0, 1, 1);
     }
 }
@@ -249,16 +280,19 @@ static void mqtt_event_handler(void *args, esp_event_base_t base, int32_t id, vo
         xSemaphoreTake(s_lock, portMAX_DELAY);
         s_status.state = PB_HA_CONNECTED;
         s_status.connected = true;
+        s_pub_pending = true;   // ask tick() to publish state promptly (no cross-task write)
         xSemaphoreGive(s_lock);
-        // Availability online (retained), discovery, then subscribe commands.
+        // Availability online (retained) + discovery. In full-control mode also
+        // subscribe the command topics; read-only mode never accepts commands.
         esp_mqtt_client_publish(s_client, s_avail_topic, "online", 0, 1, 1);
         publish_discovery();
-        char sub[80];
-        snprintf(sub, sizeof sub, "%s/mode/set", prefix());
-        esp_mqtt_client_subscribe(s_client, sub, 1);
-        snprintf(sub, sizeof sub, "%s/temp/set", prefix());
-        esp_mqtt_client_subscribe(s_client, sub, 1);
-        s_last_state_us = 0;   // force an immediate state publish on next tick
+        if (!s_readonly) {
+            char sub[80];
+            snprintf(sub, sizeof sub, "%s/mode/set", prefix());
+            esp_mqtt_client_subscribe(s_client, sub, 1);
+            snprintf(sub, sizeof sub, "%s/temp/set", prefix());
+            esp_mqtt_client_subscribe(s_client, sub, 1);
+        }
         break;
     }
     case MQTT_EVENT_DISCONNECTED:
@@ -278,7 +312,7 @@ static void mqtt_event_handler(void *args, esp_event_base_t base, int32_t id, vo
 
 // ---------- lifecycle ----------
 
-esp_err_t pb_ha_start(void)
+static esp_err_t ha_start_common(void)
 {
     if (s_lock != NULL) return ESP_ERR_INVALID_STATE;
     s_lock = xSemaphoreCreateMutex();
@@ -326,9 +360,17 @@ esp_err_t pb_ha_start(void)
         return err;
     }
     s_status.state = PB_HA_CONNECTING;
-    ESP_LOGI(TAG, "connecting to broker %s (prefix '%s')", uri, prefix());
+    ESP_LOGI(TAG, "connecting to broker %s (prefix '%s'%s)", uri, prefix(),
+             s_readonly ? ", read-only" : "");
     return ESP_OK;
 }
+
+// Full-control: HA is the selected control source (subscribes commands, holds a lease).
+esp_err_t pb_ha_start(void) { s_readonly = false; return ha_start_common(); }
+
+// Read-only: HA runs ALONGSIDE another control source as a monitor — publishes
+// sensors + state, never subscribes commands, never takes a pb_policy lease.
+esp_err_t pb_ha_start_readonly(void) { s_readonly = true; return ha_start_common(); }
 
 void pb_ha_tick(void)
 {
@@ -336,11 +378,13 @@ void pb_ha_tick(void)
     bool connected;
     xSemaphoreTake(s_lock, portMAX_DELAY);
     connected = s_status.connected;
+    bool pub_now = s_pub_pending;
+    s_pub_pending = false;
     xSemaphoreGive(s_lock);
     if (!connected) return;
 
     int64_t now = esp_timer_get_time();
-    if (now - s_last_state_us >= STATE_PERIOD_US) {
+    if (pub_now || now - s_last_state_us >= STATE_PERIOD_US) {
         s_last_state_us = now;
         publish_state();
     }
@@ -350,7 +394,7 @@ void pb_ha_tick(void)
     bool do_hb = false;
     pb_policy_lease_t lease = {0};
     xSemaphoreTake(s_lock, portMAX_DELAY);
-    if (s_have_lease && now - s_last_hb_us >= HB_PERIOD_US) {
+    if (!s_readonly && s_have_lease && now - s_last_hb_us >= HB_PERIOD_US) {
         lease = s_lease;
         s_last_hb_us = now;
         do_hb = true;

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -214,10 +214,9 @@ static void control_task(void *arg)
                 }
                 break;
             case DC_SRC_HA:
-                // HA is a controller, not a bed source — no AUTO follow. Pump the
-                // HA client (retained state publish + heat-lease heartbeat); it
-                // drives target/mode through pb_policy directly.
-                if (s_ha_up) pb_ha_tick();
+                // HA is a controller, not a bed source — no AUTO follow. It drives
+                // target/mode through pb_policy directly. Pumped below (s_ha_up),
+                // which also covers HA running read-only alongside another source.
                 break;
             case DC_SRC_KLIPPER_MQTT:
                 // Klipper-over-MQTT is also a controller (not a bed source): Klipper
@@ -239,6 +238,10 @@ static void control_task(void *arg)
             }
         }
         pb_policy_set_env(bed_c, bed_target_c, src_connected, src_target_c);
+        // Home Assistant: pump the client whenever it's up — full-control when HA is
+        // the selected source, or read-only when it runs alongside another source
+        // (Bambu/Klipper) as a monitor. pb_ha_tick() no-ops until connected.
+        if (s_ha_up) pb_ha_tick();
 #endif
 
         // Safety/control loop: enforces every heater cutoff + fan-follows-heater.
@@ -427,6 +430,27 @@ void app_main(void)
         break;
     }
     ESP_LOGI(TAG, "control source: %s", dc_source_str(s_src));
+    // Home Assistant read-only telemetry alongside a non-HA control source: if an HA
+    // broker is configured but HA is NOT the selected source, start pb_ha in read-only
+    // monitor mode (publishes sensors + state, never controls). When HA *is* the
+    // source it already started above in full-control mode.
+    if (s_src != DC_SRC_HA) {
+        size_t sz = 0;
+        bool ha_cfg = false;
+        nvs_handle_t hh;
+        if (nvs_open("app_nvs", NVS_READONLY, &hh) == ESP_OK) {
+            ha_cfg = (nvs_get_str(hh, "ha_host", NULL, &sz) == ESP_OK && sz > 1);
+            nvs_close(hh);
+        }
+        if (ha_cfg) {
+            if ((e = pb_ha_start_readonly()) != ESP_OK)
+                ESP_LOGE(TAG, "pb_ha_start_readonly: %s (continuing; no HA telemetry)", esp_err_to_name(e));
+            else {
+                s_ha_up = true;
+                ESP_LOGI(TAG, "Home Assistant read-only telemetry enabled alongside %s", dc_source_str(s_src));
+            }
+        }
+    }
     if ((e = pb_httpd_start()) != ESP_OK)
         ESP_LOGE(TAG, "pb_httpd_start: %s (continuing)", esp_err_to_name(e));
     else if ((e = pb_portal_start()) != ESP_OK)   // portal needs the httpd handle


### PR DESCRIPTION
## Summary

Enables **read-only Home Assistant telemetry alongside** a Bambu/Klipper control source — HA is no longer mutually exclusive with the other sources when used purely for monitoring.

- New `pb_ha_start_readonly()`: publishes MQTT-Discovery **sensors** (chamber/element temp + target + mode) and the retained `state` topic, but **never subscribes command topics and never takes a `pb_policy` lease** — it cannot control, only report.
- `app_main` auto-starts it when an HA broker is configured (NVS `ha_host`) but HA is **not** the selected control source. When HA *is* the source, it starts in full-control mode as before.
- The stale controllable **climate** entity is cleared (empty retained config) in read-only mode, so HA shows no dead buttons — just sensors.
- `pb_ha_tick()` is now pumped whenever the client is up (full or read-only).

Enablement + entity style were the owner's call: **auto-when-configured** and **sensors-only**.

## Why

Fixes @Egosumumbravir's report on #64 — "HA reporting dies after connecting to a Bambu machine." That was the single-source design (selecting Bambu stopped the HA client entirely); now HA keeps reporting read-only while Bambu/Klipper drives control.

## Also (opportunistic, same file)

Fixes a **pre-existing cross-task data race** in `pb_ha` — the same class you flagged in `db_klipper_mqtt` #67: the MQTT connect handler wrote the control-task pacing clock `s_last_state_us` directly. Replaced with a lock-guarded `s_pub_pending` request flag that `tick()` reads+clears. This matters more now that `pb_ha` can run concurrently with another MQTT client.

## Scope / validation

- **App-side only — no dragon-core changes.**
- Clean ESP-IDF v5.3 build, cppcheck clean, policy + arming host tests green.
- Not yet validated on hardware against a live HA broker + Bambu concurrently (would appreciate a sanity check there before/with merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
