### PR TITLE
Share and harden MQTT clients

### DIFF
--- a/components/db_klipper_mqtt/CMakeLists.txt
+++ b/components/db_klipper_mqtt/CMakeLists.txt
@@ -1,9 +1,7 @@
 idf_component_register(
     SRCS "db_klipper_mqtt.c"
     INCLUDE_DIRS "include"
-    # esp-mqtt to the printer's Moonraker broker; esp_timer for pacing; pb_policy for
-    # the lease/command/snapshot API; esp-tls for optional mqtts. Telemetry/RPC JSON is
-    # built with snprintf (no cJSON). The pure arming core (db_klipper_mqtt_arm.h) is
-    # header-only and host-tested separately.
-    REQUIRES nvs_flash mqtt esp_timer pb_policy esp-tls
+    # dc_mqtt owns the shared ESP-MQTT lifecycle; this product component owns the
+    # Moonraker topic contract, retained-aware arming, and policy mapping.
+    REQUIRES nvs_flash dc_mqtt esp_timer pb_policy
 )

--- a/components/db_klipper_mqtt/db_klipper_mqtt.c
+++ b/components/db_klipper_mqtt/db_klipper_mqtt.c
@@ -12,16 +12,16 @@
 // state. db_klipper_mqtt_tick() (control task) owns pacing, telemetry/power publishing,
 // and all pb_policy_* calls; the s_last_* pacing fields are touched only by tick. Both
 // tasks read/write shared state under s_lock, and s_lock is always released before any
-// esp_mqtt publish or pb_policy_* call.
+// dc_mqtt publish or pb_policy_* call.
 #include "db_klipper_mqtt.h"
 #include "db_klipper_mqtt_arm.h"
+#include "dc_mqtt.h"
 #include "pb_policy.h"
 
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
-#include "mqtt_client.h"
 #include "nvs.h"
 
 #include <math.h>
@@ -53,7 +53,7 @@ static const char *TAG = "db_km";
 static SemaphoreHandle_t        s_lock   = NULL;
 static db_km_config_t           s_cfg    = {0};
 static db_km_status_t           s_status = { .conn = DB_KM_DISABLED };
-static esp_mqtt_client_handle_t s_client = NULL;
+static dc_mqtt_client_t         *s_client = NULL;
 
 // Shared control state (guarded by s_lock).
 static db_km_arm_t        s_arm         = {0};
@@ -69,7 +69,7 @@ static int64_t  s_last_hb_us    = 0;
 static uint32_t s_rpc_id        = 0;
 static bool     s_last_power_pub = true;
 
-// Topics built once at start (must outlive esp_mqtt_client_init for the LWT).
+// Topics built once at start and retained for logging/topic construction.
 static char s_avail_topic[80]  = {0};   // <base>/status  (device availability, LWT)
 
 static const char *base(void) { return s_cfg.topic[0] ? s_cfg.topic : DEFAULT_PREFIX; }
@@ -231,7 +231,7 @@ static void publish_power_state(bool on)
 {
     char topic[80];
     snprintf(topic, sizeof topic, "%s/power/state", base());
-    esp_mqtt_client_publish(s_client, topic, on ? "on" : "off", 0, 0, 1);  // qos0, retain
+    dc_mqtt_publish(s_client, topic, on ? "on" : "off", 0, 0, true);  // qos0, retain
     s_last_power_pub = on;
 }
 
@@ -261,7 +261,7 @@ static void publish_telemetry(void)
 
     char topic[80];
     snprintf(topic, sizeof topic, "%s/telemetry", base());
-    esp_mqtt_client_publish(s_client, topic, buf, 0, 0, 0);   // qos0, non-retained
+    dc_mqtt_publish(s_client, topic, buf, 0, 0, false);   // qos0, non-retained
 
     // Optional device->Klipper writeback of live chamber temp into a macro variable,
     // so macro logic can read it (Moonraker [sensor] values are invisible to macros).
@@ -274,7 +274,7 @@ static void publish_telemetry(void)
             "VARIABLE=temperature VALUE=%.1f\"}}",
             (unsigned)(++s_rpc_id), snap.chamber_c);
         snprintf(areq, sizeof areq, "%s/moonraker/api/request", s_cfg.inst);
-        esp_mqtt_client_publish(s_client, areq, rpc, 0, 0, 0);
+        dc_mqtt_publish(s_client, areq, rpc, 0, 0, false);
     }
 }
 
@@ -284,21 +284,20 @@ static void subscribe_all(void)
 {
     char sub[128];
     snprintf(sub, sizeof sub, "%s/klipper/state/gcode_macro DRAGONBREATH/#", s_cfg.inst);
-    esp_mqtt_client_subscribe(s_client, sub, 0);
+    dc_mqtt_subscribe(s_client, sub, 0);
     snprintf(sub, sizeof sub, "%s/klipper/state/gcode_macro DB_LINK/#", s_cfg.inst);
-    esp_mqtt_client_subscribe(s_client, sub, 0);
+    dc_mqtt_subscribe(s_client, sub, 0);
     snprintf(sub, sizeof sub, "%s/moonraker/status", s_cfg.inst);
-    esp_mqtt_client_subscribe(s_client, sub, 0);
+    dc_mqtt_subscribe(s_client, sub, 0);
     snprintf(sub, sizeof sub, "%s/power/set", base());
-    esp_mqtt_client_subscribe(s_client, sub, 0);
+    dc_mqtt_subscribe(s_client, sub, 0);
 }
 
-static void mqtt_event_handler(void *args, esp_event_base_t evbase, int32_t id, void *data)
+static void mqtt_event_handler(void *ctx, const dc_mqtt_event_t *event)
 {
-    (void)args; (void)evbase;
-    esp_mqtt_event_handle_t e = (esp_mqtt_event_handle_t)data;
-    switch ((esp_mqtt_event_id_t)id) {
-    case MQTT_EVENT_CONNECTED:
+    (void)ctx;
+    switch (event->type) {
+    case DC_MQTT_EVENT_CONNECTED:
         ESP_LOGI(TAG, "connected to broker");
         xSemaphoreTake(s_lock, portMAX_DELAY);
         s_status.conn = DB_KM_CONNECTED;
@@ -309,20 +308,24 @@ static void mqtt_event_handler(void *args, esp_event_base_t evbase, int32_t id, 
         xSemaphoreGive(s_lock);
         // Availability + subscribes are thread-safe and touch no control-task state,
         // so they stay here; power-state + telemetry publishing is left to tick().
-        esp_mqtt_client_publish(s_client, s_avail_topic, "online", 0, 1, 1);
+        dc_mqtt_publish(s_client, s_avail_topic, "online", 0, 1, true);
         subscribe_all();
         break;
-    case MQTT_EVENT_DISCONNECTED:
+    case DC_MQTT_EVENT_DISCONNECTED:
         xSemaphoreTake(s_lock, portMAX_DELAY);
         s_status.conn = DB_KM_DISCONNECTED;
         s_status.connected = false;
         xSemaphoreGive(s_lock);
         force_disarm();               // no broker -> can't heartbeat -> fail safe off
         break;
-    case MQTT_EVENT_DATA:
-        if (e->topic_len > 0 && e->data_len >= 0)
-            handle_data(e->topic, e->topic_len, e->data, e->data_len);
+    case DC_MQTT_EVENT_MESSAGE:
+        // The subscribed desired-state payloads are tiny and expected in one MQTT
+        // event. Reject fragments rather than parsing a partial safety command.
+        if (event->current_data_offset == 0 &&
+            event->data_len == event->total_data_len && event->topic_len > 0)
+            handle_data(event->topic, event->topic_len, event->data, event->data_len);
         break;
+    case DC_MQTT_EVENT_ERROR:
     default:
         break;
     }
@@ -347,26 +350,20 @@ esp_err_t db_klipper_mqtt_start(void)
     char uri[128];
     snprintf(uri, sizeof uri, "%s://%s:%u", s_cfg.tls ? "mqtts" : "mqtt",
              s_cfg.host, (unsigned)s_cfg.port);
-    esp_mqtt_client_config_t mc = {
-        .broker.address.uri = uri,
-        .session.last_will = {
-            .topic = s_avail_topic, .msg = "offline", .msg_len = 7, .qos = 1, .retain = 1,
-        },
+    dc_mqtt_config_t mc = {
+        .broker_uri = uri,
+        .username = s_cfg.user,
+        .password = s_cfg.pass,
+        .last_will_topic = s_avail_topic,
+        .last_will_message = "offline",
+        .last_will_qos = 1,
+        .last_will_retain = true,
+        .skip_cert_common_name_check = s_cfg.tls,
+        .event_cb = mqtt_event_handler,
     };
-    if (s_cfg.tls) mc.broker.verification.skip_cert_common_name_check = true;
-    if (s_cfg.user[0]) mc.credentials.username = s_cfg.user;
-    if (s_cfg.pass[0]) mc.credentials.authentication.password = s_cfg.pass;
-
-    s_client = esp_mqtt_client_init(&mc);
-    if (s_client == NULL) {
-        ESP_LOGE(TAG, "esp_mqtt_client_init failed");
-        s_status.conn = DB_KM_DISCONNECTED;
-        return ESP_FAIL;
-    }
-    esp_mqtt_client_register_event(s_client, ESP_EVENT_ANY_ID, mqtt_event_handler, NULL);
-    esp_err_t err = esp_mqtt_client_start(s_client);
+    esp_err_t err = dc_mqtt_start(&mc, &s_client);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "esp_mqtt_client_start: %s", esp_err_to_name(err));
+        ESP_LOGE(TAG, "dc_mqtt_start: %s", esp_err_to_name(err));
         s_status.conn = DB_KM_DISCONNECTED;
         return err;
     }
@@ -422,7 +419,9 @@ void db_klipper_mqtt_tick(void)
     // pub_now honors a connect / power-change request from the MQTT callback.
     if (pub_now || now - s_last_state_us >= STATE_PERIOD_US) {
         s_last_state_us = now;
-        if (power_now != s_last_power_pub) publish_power_state(power_now);
+        // A connect request must publish even when the default state is already ON;
+        // otherwise a fresh broker has no retained state until the first toggle.
+        if (pub_now || power_now != s_last_power_pub) publish_power_state(power_now);
         publish_telemetry();
     }
 }

--- a/components/db_klipper_mqtt/include/db_klipper_mqtt.h
+++ b/components/db_klipper_mqtt/include/db_klipper_mqtt.h
@@ -26,7 +26,7 @@ typedef struct {
     char     inst[48];   // Moonraker instance_name (required — derives all topics)
     char     topic[48];  // device topic base (defaults to "dragonbreath")
     bool     tls;        // mqtts (skip-verify LAN, like pb_bambu)
-    bool     writeback;  // push live temp/fault into macro vars (off by default)
+    bool     writeback;  // push live chamber temperature into a macro var (off by default)
 } db_km_config_t;
 
 typedef struct {

--- a/components/pb_ha/CMakeLists.txt
+++ b/components/pb_ha/CMakeLists.txt
@@ -1,8 +1,7 @@
 idf_component_register(
     SRCS "pb_ha.c"
     INCLUDE_DIRS "include"
-    # esp-mqtt to the user's broker; esp_timer for pacing; pb_policy for the
-    # command/snapshot API. All built into ESP-IDF / first-party — no third-party
-    # dependency. State/discovery JSON is built with snprintf (no cJSON needed).
-    REQUIRES nvs_flash mqtt esp_timer pb_policy
+    # dc_mqtt owns the shared ESP-MQTT lifecycle; this product component owns Home
+    # Assistant discovery, command mapping, policy leases, and state telemetry.
+    REQUIRES nvs_flash dc_mqtt esp_timer pb_policy
 )

--- a/components/pb_ha/pb_ha.c
+++ b/components/pb_ha/pb_ha.c
@@ -4,18 +4,18 @@
 // Heat control holds a device-issued POWER_ON lease and heartbeats it like any
 // remote controller. See plans/control-source-bambu-ha.md.
 //
-// Threading: the esp-mqtt event handler runs on the mqtt task (connect/discovery/
+// Threading: the dc_mqtt event handler runs on the mqtt task (connect/discovery/
 // subscribe + inbound commands); pb_ha_tick() runs on the control task (state
-// publish + lease heartbeat). esp_mqtt_client_publish() is thread-safe; the shared
+// publish + lease heartbeat). dc_mqtt_publish() is thread-safe; the shared
 // lease/target state is guarded by s_lock.
 #include "pb_ha.h"
+#include "dc_mqtt.h"
 #include "pb_policy.h"
 
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
-#include "mqtt_client.h"
 #include "nvs.h"
 
 #include <math.h>
@@ -42,7 +42,7 @@ static const char *TAG = "pb_ha";
 static SemaphoreHandle_t        s_lock   = NULL;
 static pb_ha_config_t           s_cfg    = {0};
 static pb_ha_status_t           s_status = { .state = PB_HA_DISABLED };
-static esp_mqtt_client_handle_t s_client = NULL;
+static dc_mqtt_client_t         *s_client = NULL;
 
 // Read-only mode: publish telemetry (sensors + state) but never subscribe to command
 // topics and never take a pb_policy lease — used when HA runs ALONGSIDE another
@@ -62,7 +62,7 @@ static int64_t s_last_state_us = 0;
 static int64_t s_last_hb_us    = 0;
 static bool    s_pub_pending   = false;   // guarded by s_lock
 
-// Availability (LWT) topic — must outlive esp_mqtt_client_init(), so it's static.
+// Availability (LWT) topic retained for discovery and reconnect publications.
 static char s_avail_topic[80] = {0};
 
 static const char *prefix(void) { return s_cfg.topic[0] ? s_cfg.topic : DEFAULT_PREFIX; }
@@ -183,7 +183,7 @@ static void publish_discovery(void)
     // dead buttons); the device just reports via sensors below.
     snprintf(topic, sizeof topic, "homeassistant/climate/%s/config", p);
     if (s_readonly) {
-        esp_mqtt_client_publish(s_client, topic, "", 0, 1, 1);   // clear retained config
+        dc_mqtt_publish(s_client, topic, "", 0, 1, true);   // clear retained config
     } else {
         // Climate entity (HA MQTT discovery, abbreviated keys). State fields are read
         // from the single retained <p>/state JSON via templates.
@@ -203,7 +203,7 @@ static void publish_discovery(void)
             "\"dev\":{\"ids\":[\"%s\"],\"name\":\"DragonBreath\",\"mdl\":\"Panda Breath\",\"mf\":\"DragonBreath\"}}",
             p, p, p, p, p, p, p, p);
         if (cfg > 0 && cfg < (int)sizeof buf)
-            esp_mqtt_client_publish(s_client, topic, buf, 0, 1, 1);   // qos1, retain
+            dc_mqtt_publish(s_client, topic, buf, 0, 1, true);   // qos1, retain
     }
 
     // Chamber temperature sensor.
@@ -214,7 +214,7 @@ static void publish_discovery(void)
         "\"dev_cla\":\"temperature\",\"dev\":{\"ids\":[\"%s\"]}}",
         p, p, p, p);
     snprintf(topic, sizeof topic, "homeassistant/sensor/%s_chamber/config", p);
-    esp_mqtt_client_publish(s_client, topic, buf, 0, 1, 1);
+    dc_mqtt_publish(s_client, topic, buf, 0, 1, true);
 
     // Element (PTC) temperature sensor.
     snprintf(buf, sizeof buf,
@@ -224,7 +224,7 @@ static void publish_discovery(void)
         "\"dev_cla\":\"temperature\",\"dev\":{\"ids\":[\"%s\"]}}",
         p, p, p, p);
     snprintf(topic, sizeof topic, "homeassistant/sensor/%s_ptc/config", p);
-    esp_mqtt_client_publish(s_client, topic, buf, 0, 1, 1);
+    dc_mqtt_publish(s_client, topic, buf, 0, 1, true);
 
     // Read-only mode has no controllable thermostat, so surface target + mode as
     // plain sensors too (so HA still sees the setpoint the active source is driving).
@@ -236,7 +236,7 @@ static void publish_discovery(void)
             "\"dev_cla\":\"temperature\",\"dev\":{\"ids\":[\"%s\"]}}",
             p, p, p, p);
         snprintf(topic, sizeof topic, "homeassistant/sensor/%s_target/config", p);
-        esp_mqtt_client_publish(s_client, topic, buf, 0, 1, 1);
+        dc_mqtt_publish(s_client, topic, buf, 0, 1, true);
 
         snprintf(buf, sizeof buf,
             "{\"name\":\"DragonBreath Mode\",\"uniq_id\":\"%s_mode\","
@@ -244,7 +244,7 @@ static void publish_discovery(void)
             "\"val_tpl\":\"{{value_json.mode}}\",\"dev\":{\"ids\":[\"%s\"]}}",
             p, p, p, p);
         snprintf(topic, sizeof topic, "homeassistant/sensor/%s_mode/config", p);
-        esp_mqtt_client_publish(s_client, topic, buf, 0, 1, 1);
+        dc_mqtt_publish(s_client, topic, buf, 0, 1, true);
     }
 }
 
@@ -265,17 +265,16 @@ static void publish_state(void)
 
     char topic[80];
     snprintf(topic, sizeof topic, "%s/state", prefix());
-    esp_mqtt_client_publish(s_client, topic, buf, 0, 0, 1);   // qos0, retain
+    dc_mqtt_publish(s_client, topic, buf, 0, 0, true);   // qos0, retain
 }
 
 // ---------- mqtt events ----------
 
-static void mqtt_event_handler(void *args, esp_event_base_t base, int32_t id, void *data)
+static void mqtt_event_handler(void *ctx, const dc_mqtt_event_t *event)
 {
-    (void)args; (void)base;
-    esp_mqtt_event_handle_t e = (esp_mqtt_event_handle_t)data;
-    switch ((esp_mqtt_event_id_t)id) {
-    case MQTT_EVENT_CONNECTED: {
+    (void)ctx;
+    switch (event->type) {
+    case DC_MQTT_EVENT_CONNECTED: {
         ESP_LOGI(TAG, "connected to broker");
         xSemaphoreTake(s_lock, portMAX_DELAY);
         s_status.state = PB_HA_CONNECTED;
@@ -284,27 +283,29 @@ static void mqtt_event_handler(void *args, esp_event_base_t base, int32_t id, vo
         xSemaphoreGive(s_lock);
         // Availability online (retained) + discovery. In full-control mode also
         // subscribe the command topics; read-only mode never accepts commands.
-        esp_mqtt_client_publish(s_client, s_avail_topic, "online", 0, 1, 1);
+        dc_mqtt_publish(s_client, s_avail_topic, "online", 0, 1, true);
         publish_discovery();
         if (!s_readonly) {
             char sub[80];
             snprintf(sub, sizeof sub, "%s/mode/set", prefix());
-            esp_mqtt_client_subscribe(s_client, sub, 1);
+            dc_mqtt_subscribe(s_client, sub, 1);
             snprintf(sub, sizeof sub, "%s/temp/set", prefix());
-            esp_mqtt_client_subscribe(s_client, sub, 1);
+            dc_mqtt_subscribe(s_client, sub, 1);
         }
         break;
     }
-    case MQTT_EVENT_DISCONNECTED:
+    case DC_MQTT_EVENT_DISCONNECTED:
         xSemaphoreTake(s_lock, portMAX_DELAY);
         s_status.state = PB_HA_DISCONNECTED;
         s_status.connected = false;
         xSemaphoreGive(s_lock);
         break;
-    case MQTT_EVENT_DATA:
-        if (e->topic_len > 0 && e->data_len >= 0)
-            handle_cmd(e->topic, e->topic_len, e->data, e->data_len);
+    case DC_MQTT_EVENT_MESSAGE:
+        if (event->current_data_offset == 0 &&
+            event->data_len == event->total_data_len && event->topic_len > 0)
+            handle_cmd(event->topic, event->topic_len, event->data, event->data_len);
         break;
+    case DC_MQTT_EVENT_ERROR:
     default:
         break;
     }
@@ -333,29 +334,19 @@ static esp_err_t ha_start_common(void)
 
     char uri[96];
     snprintf(uri, sizeof uri, "mqtt://%s:%u", s_cfg.host, (unsigned)s_cfg.port);
-    esp_mqtt_client_config_t mc = {
-        .broker.address.uri = uri,
-        .session.last_will = {
-            .topic  = s_avail_topic,
-            .msg    = "offline",
-            .msg_len = 7,
-            .qos    = 1,
-            .retain = 1,
-        },
+    dc_mqtt_config_t mc = {
+        .broker_uri = uri,
+        .username = s_cfg.user,
+        .password = s_cfg.pass,
+        .last_will_topic = s_avail_topic,
+        .last_will_message = "offline",
+        .last_will_qos = 1,
+        .last_will_retain = true,
+        .event_cb = mqtt_event_handler,
     };
-    if (s_cfg.user[0]) mc.credentials.username = s_cfg.user;
-    if (s_cfg.pass[0]) mc.credentials.authentication.password = s_cfg.pass;
-
-    s_client = esp_mqtt_client_init(&mc);
-    if (s_client == NULL) {
-        ESP_LOGE(TAG, "esp_mqtt_client_init failed");
-        s_status.state = PB_HA_DISCONNECTED;
-        return ESP_FAIL;
-    }
-    esp_mqtt_client_register_event(s_client, ESP_EVENT_ANY_ID, mqtt_event_handler, NULL);
-    esp_err_t err = esp_mqtt_client_start(s_client);
+    esp_err_t err = dc_mqtt_start(&mc, &s_client);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "esp_mqtt_client_start: %s", esp_err_to_name(err));
+        ESP_LOGE(TAG, "dc_mqtt_start: %s", esp_err_to_name(err));
         s_status.state = PB_HA_DISCONNECTED;
         return err;
     }

--- a/components/pb_portal/pb_portal.c
+++ b/components/pb_portal/pb_portal.c
@@ -1023,6 +1023,10 @@ static esp_err_t km_config_page(httpd_req_t *req)
     if (!user[0]) strcpy(user, "dragonbreath");
     if (!inst[0]) strcpy(inst, "myprinter");
     if (!base[0]) strcpy(base, "dragonbreath");
+    // Generate a separate Moonraker identity so the broker ACL can preserve
+    // directional least privilege. The saved km_user remains DragonBreath's login.
+    char mrk_user[48];
+    snprintf(mrk_user, sizeof mrk_user, "%s_moonraker", user);
 
     httpd_resp_set_type(req, "text/plain; charset=utf-8");
     char b[640];
@@ -1047,7 +1051,7 @@ static esp_err_t km_config_page(httpd_req_t *req)
         "status_objects:\n"
         "  gcode_macro DRAGONBREATH\n"
         "  gcode_macro DB_LINK\n\n",
-        host, (unsigned)port, user, inst);
+        host, (unsigned)port, mrk_user, inst);
     SEND(req, b);
 
     snprintf(b, sizeof b, "[sensor %s]\ntype: mqtt\nname: DragonBreath\nstate_topic: %s/telemetry\n",
@@ -1103,21 +1107,41 @@ static esp_err_t km_config_page(httpd_req_t *req)
     // ---- mosquitto ACL ----
     snprintf(b, sizeof b,
         "########## mosquitto ACL (least privilege) ##########\n"
-        "# Create the user + password:  mosquitto_passwd -c /etc/mosquitto/passwd %s\n"
+        "# Add/update both users (do not use -c on an existing password file):\n"
+        "#   mosquitto_passwd /etc/mosquitto/passwd %s\n"
+        "#   mosquitto_passwd /etc/mosquitto/passwd %s\n"
+        "# DragonBreath device identity\n"
         "user %s\n"
         "topic write %s/telemetry\n"
         "topic write %s/power/state\n"
         "topic write %s/status\n"
         "topic read  %s/power/set\n",
-        user, user, base, base, base, base);
+        user, mrk_user, user, base, base, base, base);
     SEND(req, b);
     snprintf(b, sizeof b,
         "topic read  %s/moonraker/status\n"
         "topic read  %s/klipper/state/gcode_macro DRAGONBREATH/#\n"
         "topic read  %s/klipper/state/gcode_macro DB_LINK/#\n"
         "# writeback (only if you enabled it):\n"
-        "topic write %s/moonraker/api/request\n"
-        "topic read  %s/moonraker/api/response\n",
+        "topic write %s/moonraker/api/request\n",
+        inst, inst, inst, inst);
+    SEND(req, b);
+    snprintf(b, sizeof b,
+        "\n"
+        "# Moonraker identity (opposite direction on the same scoped topics)\n"
+        "user %s\n"
+        "topic read  %s/telemetry\n"
+        "topic read  %s/power/state\n"
+        "topic read  %s/status\n"
+        "topic write %s/power/set\n",
+        mrk_user, base, base, base, base);
+    SEND(req, b);
+    snprintf(b, sizeof b,
+        "topic write %s/moonraker/status\n"
+        "topic write %s/klipper/state/gcode_macro DRAGONBREATH/#\n"
+        "topic write %s/klipper/state/gcode_macro DB_LINK/#\n"
+        "topic read  %s/moonraker/api/request\n"
+        "topic write %s/moonraker/api/response\n",
         inst, inst, inst, inst, inst);
     SEND(req, b);
 

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -22,4 +22,4 @@ dependencies:
   dc_mqtt:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_mqtt
-    version: 19ad1002c2cbe71b634092cb2ab904db34811b88
+    version: f283708268298af1e0e1197b923283c50079f539

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -19,3 +19,7 @@ dependencies:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_moonraker
     version: 431983c38c0fe37c2bea9c7afe393207b97e9004
+  dc_mqtt:
+    git: https://github.com/justinh-rahb/dragon-core.git
+    path: components/dc_mqtt
+    version: 19ad1002c2cbe71b634092cb2ab904db34811b88

--- a/plans/mqtt-klipper-implementation-design.md
+++ b/plans/mqtt-klipper-implementation-design.md
@@ -24,7 +24,7 @@ uses the **verified** facts. The corrections that matter:
 | 2 | split-status payload = raw scalar | **`{"eventtime":…,"value":…}` JSON, retained** | parser reads `.value`; retained ⇒ arming must ignore it (see §6) |
 | 3 | (unstated) | combined `.../klipper/status` topic is **non-retained**; split topics **are** | we require `publish_split_status: True` |
 | 4 | object name sanitized | **literal space** kept: `.../gcode_macro DRAGONBREATH/…` | topic filters/parser handle the space |
-| 5 | (unstated) | API correlation by **globally-unique `id`** on a shared response topic; add **`mqtt_timestamp`** (or QoS 0/2) to avoid double-exec | writeback correlation + dedup |
+| 5 | (unstated) | API writes need duplicate protection via **`mqtt_timestamp`** or QoS 0/2 | optional writeback uses QoS 0; responses are ignored |
 | 6 | M191 "normally blocking" | **M141/M191 don't exist natively in Klipper**; a macro cannot block on an external value; `TEMPERATURE_WAIT` needs a *hardware* Klipper sensor; **no MQTT-fed Klipper sensor exists** | M141 shim only; blocking M191 impossible by construction |
 | 7 | (unstated) | `SET_GCODE_VARIABLE` is **in-memory only** (resets on FIRMWARE_RESTART) | device re-publishes desired-state + re-asserts `seq` on reconnect |
 | 8 | (unstated) | Moonraker `[sensor]` is **invisible to Klipper macros** | dashboard temp and macro-visible temp are **two paths** (sensor + writeback) |
@@ -101,7 +101,6 @@ to lease TTL) is the hardware backstop that forces heat off if we stop heartbeat
 | `INST/klipper/state/gcode_macro DRAGONBREATH/#` | Moonraker split-status (retained) | desired-state fields |
 | `INST/klipper/state/gcode_macro DB_LINK/#` | Moonraker split-status (retained) | heartbeat counter |
 | `INST/moonraker/status` | Moonraker (retained/LWT) | Klipper-stack availability |
-| `INST/moonraker/api/response` | Moonraker (non-retained) | JSON-RPC writeback responses |
 | `DB/power/set` | Moonraker `[power]` command | master enable on/off |
 
 **Device publishes:**
@@ -156,7 +155,8 @@ by a self-rescheduling `[delayed_gcode]` (doc-idiomatic; body stays motion-free)
 ## 5. Desired-state → arming state machine (the safety core)
 
 > **Invariant:** DragonBreath never energizes heat merely because it received desired
-> state. It requires an explicit **arm edge observed live** *and* a **fresh heartbeat**.
+> state. It requires a fresh coherent **`seq` update observed live** *and* a
+> **fresh heartbeat**.
 
 Because split-status is **retained**, a reconnecting device is handed `armed=1`,
 `target=55`, `seq=7`, and the last `heartbeat` value **immediately** — all potentially
@@ -166,7 +166,7 @@ State per (re)connect starts **DISARMED**, and:
 
 1. **Connect snapshot** — the first value received for each field (target/mode/seq/
    armed/heartbeat) is recorded as the initial snapshot. An `armed=1` *in the snapshot*
-   is **not** an arm edge; the snapshot `heartbeat` is **not** proof of liveness.
+   is not permission to arm; the snapshot `heartbeat` is **not** proof of liveness.
 2. **Liveness** — becomes true only after we observe the `heartbeat` value **change**
    at least once post-connect, and stays true while the last change was `< 15 s` ago
    (3 × 5 s cadence). Loss of liveness ⇒ force heat off, latch `comms_lost`.
@@ -174,37 +174,36 @@ State per (re)connect starts **DISARMED**, and:
    - `seq` advanced beyond last-applied (a coherent new desired-state — `seq` is
      written last, so all other fields are consistent when it changes);
    - `mode == "heat"` and `armed == 1`;
-   - the `0→1` **arm edge was observed live** (not the connect snapshot);
    - liveness is currently true.
 4. **Apply** — on a qualifying update: `pb_policy_set_power_on(target, …, &lease)`;
    publish `seq_ack = seq`. While armed+live, `pb_policy_heartbeat(&lease)` on each
    fresh heartbeat (period `< pb_heater` comms timeout).
 5. **Disarm / recover** — `armed→0`, `mode→off`, liveness lost, Moonraker `offline`,
    or master-power off ⇒ `pb_policy_set_mode_off`. Recovery re-enters at DISARMED and
-   requires a **new** live arm edge (a retained `armed=1` after reconnect never
+   requires a **new** live `seq` update (a retained `armed=1` after reconnect never
    re-arms on its own).
 
-Fan (`variable_fan`) and one-shots (`purge_nonce` edge) apply independently of the heat
-arm. Thermal cutoffs, max-temp, the `pb_heater` watchdog and fail-off all remain inside
-firmware and are unchanged — this mode cannot weaken them.
+`variable_fan` and `purge_nonce` are reserved protocol fields in 1.0.5; they are parsed
+and retained-safe but do not yet drive product actions. Thermal cutoffs, max-temp, the
+`pb_heater` watchdog and fail-off all remain inside firmware and are unchanged — this
+mode cannot weaken them.
 
 ---
 
-## 6. Device→Klipper writeback (macro-visible temp/fault)
+## 6. Device→Klipper writeback (macro-visible temperature)
 
 Moonraker `[sensor]` values are invisible to macros (§0 #8), so for macro logic the
-device writes temp/humidity/fault back into `DRAGONBREATH` vars via the API bridge:
+current implementation can write chamber temperature back into a `DRAGONBREATH`
+variable via the API bridge:
 ```json
 {"jsonrpc":"2.0","method":"printer.gcode.script","id":<uniq>,
- "params":{"script":"SET_GCODE_VARIABLE MACRO=DRAGONBREATH VARIABLE=temperature VALUE=42.3",
-           "mqtt_timestamp":<us>}}
+ "params":{"script":"SET_GCODE_VARIABLE MACRO=DRAGONBREATH VARIABLE=temperature VALUE=42.3"}}
 ```
-Rules from the docs: `id` **globally unique** (shared response topic); include
-`mqtt_timestamp` (or QoS 0/2) to prevent duplicate execution; **rate-limit to ~2 s,
-on-change only** — `printer.gcode.script` enters the G-code queue and must not compete
-with print moves. String values need doubled quoting (`VALUE='"latched"'`); numbers
-bare. This path is **optional** (telemetry-out via `[sensor]` covers the dashboard);
-enable it only when a customer's macros need live device state.
+The firmware publishes this request at QoS 0 every ~2 s and does not consume the API
+response. QoS 0 follows Moonraker's duplicate-execution guidance without requiring an
+`mqtt_timestamp`. Humidity and fault-variable writeback remain future protocol work.
+This path is **optional** (`[sensor]` telemetry covers the dashboard); enable it only
+when a customer's macros need the live chamber temperature.
 
 ---
 

--- a/tests/check_api_v2_contract.sh
+++ b/tests/check_api_v2_contract.sh
@@ -5,6 +5,7 @@ root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 httpd="$root/components/pb_httpd/pb_httpd.c"
 # The dashboard/control UI now lives in the embedded SPA, not a C string.
 portal="$root/components/pb_portal/www/app.html"
+portal_c="$root/components/pb_portal/pb_portal.c"
 
 for route in info state command heartbeat events health; do
     grep -q "\"/api/v2/$route\"" "$httpd" || {
@@ -57,6 +58,16 @@ grep -q 's->params.manual_target_c' "$httpd" || {
     exit 1
 }
 grep -q 'expected->valuedouble < UINT32_MAX' "$httpd"
+
+# Never tell users to recreate an existing password file; `-c` overwrites it.
+if grep -Fq 'mosquitto_passwd -c /etc/mosquitto/passwd' "$portal_c"; then
+    echo "generated broker instructions can overwrite an existing password file" >&2
+    exit 1
+fi
+grep -Fq 'char mrk_user[48]' "$portal_c"
+grep -Fq 'topic write %s/klipper/state/gcode_macro DRAGONBREATH/#' "$portal_c"
+grep -Fq 'topic read  %s/telemetry' "$portal_c"
+grep -Fq 'topic read  %s/moonraker/api/request' "$portal_c"
 
 if grep -q 'cJSON_AddStringToObject(lease, "id"' "$httpd"; then
     echo "unauthenticated state exposes raw lease id" >&2


### PR DESCRIPTION
## What changed

- Migrate `pb_ha` and `db_klipper_mqtt` from duplicated ESP-MQTT lifecycle code to `dc_mqtt` from justinh-rahb/dragon-core#4.
- Preserve product-local NVS keys, topics, telemetry, policy leases, retained-aware arming, and heater safety behavior.
- Reject fragmented command payloads rather than parsing partial control messages.
- Publish the retained Klipper-MQTT power state on every broker connection, including the default ON state.
- Generate separate least-privilege Mosquitto users for DragonBreath and Moonraker, with the publish/subscribe directions each client actually needs.
- Stop recommending `mosquitto_passwd -c` on an existing password file.
- Correct the implementation design to match shipped behavior: fresh sequence plus heartbeat arming, reserved fan/purge fields, and temperature-only QoS 0 writeback.
- Extend the static configuration contract checks for the broker-account split and safe password-file instructions.

## Why

PR #67 shipped two kinds of follow-up debt: common MQTT transport remained duplicated in the product repository, and the generated broker configuration could not work with its own directional ACL because Moonraker and DragonBreath were assigned the same user. It also skipped the initial retained power-state publication and documented several behaviors that were not implemented.

The new boundary keeps transport lifecycle in dragon-core and all product policy in DragonBreath.

## Dependency and landing order

dragon-core#4 is merged and tagged `v0.4.0`. This PR now pins `dc_mqtt` to permanent merge commit `f283708268298af1e0e1197b923283c50079f539`.

## Validation

- Full ESP-IDF 5.3 ESP32-C3 firmware build with `-Wall -Wextra -Werror`: pass
- Safe dev-board HIL-profile build: pass
- HIL compile-out audit: pass
- All host state-machine and safety tests: pass
- MQTT-Klipper retained-aware arming tests: pass
- API v2 and dashboard contracts: pass
- HIL runner unit tests: 11 pass
- `git diff --check`: pass

Local `cppcheck` was unavailable; GitHub Actions runs the repository's required analyzer.

