### PR TITLE
v1.1.3: /setup shows only the selected source + /console auth fix (core v0.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+## [1.1.3] - 2026-08-10
+
+**Shared-UI polish for the /setup and /console pages, from `dragon-core` v0.6.1.**
+
+### Changed
+- **`/setup` shows only the selected control source.** Instead of listing every source
+  (Klipper/Moonraker, Bambu, HA, Klipper-MQTT) at once, the setup surface now reveals
+  only the section for the configured `ctl_src` — changing the selector reveals the
+  chosen source live. **Home Assistant stays always-visible**, since it carries over as
+  read-only telemetry alongside any control source. (Product sections tagged with
+  `visible_when`; `dc_ui` honors it — dragon-core #13.)
+- **Re-pinned `dragon-core` v0.6.0 → v0.6.1.**
+
+### Fixed
+- **`/console` no longer prompts for a control token on presence-only devices.** The
+  page now sends a non-empty auth header by default, so a device with no control token
+  configured loads the log without a spurious prompt; only a real 403 prompts. (Core
+  `dc_portal`, dragon-core #13.)
+
 ## [1.1.2] - 2026-08-10
 
 **Restores the `/diag` and `/console` pages dropped in 1.1.1, now split by where they

--- a/components/db_portal/db_portal.c
+++ b/components/db_portal/db_portal.c
@@ -218,6 +218,16 @@ static void add_field(cJSON *s, cJSON *f)
     cJSON_AddItemToArray(cJSON_GetObjectItem(s, "fields"), f);
 }
 
+// Reveal a section only when the control-source selector equals this value. Sections
+// without it always render; HA is intentionally left always-on since it carries over
+// as read-only telemetry alongside any selected control source.
+static void visible_when(cJSON *s, const char *field_key, const char *value)
+{
+    cJSON *vw = cJSON_AddObjectToObject(s, "visible_when");
+    cJSON_AddStringToObject(vw, "field", field_key);
+    cJSON_AddStringToObject(vw, "value", value);
+}
+
 static cJSON *describe_product(void *ctx)
 {
     (void)ctx;
@@ -244,6 +254,7 @@ static cJSON *describe_product(void *ctx)
     dc_moonraker_get_config(&mr);
     char port[8]; snprintf(port, sizeof port, "%u", mr.port ? mr.port : 7125);
     s = section(root, "Klipper / Moonraker");
+    visible_when(s, "ctl_src", "0");
     add_field(s, field("mr_host", "Host", "text", mr.host, false));
     add_field(s, field("mr_port", "Port", "number", port, false));
     add_field(s, field("mr_key", "API key (leave blank to keep)", "password", "", true));
@@ -251,6 +262,7 @@ static cJSON *describe_product(void *ctx)
     dc_bambu_config_t bb = {0};
     dc_bambu_get_config(&bb);
     s = section(root, "Bambu LAN");
+    visible_when(s, "ctl_src", "1");
     add_field(s, field("bb_host", "Printer host", "text", bb.host, false));
     add_field(s, field("bb_serial", "Serial", "text", bb.serial, false));
     add_field(s, field("bb_code", "Access code (leave blank to keep)", "password", "", true));
@@ -269,6 +281,7 @@ static cJSON *describe_product(void *ctx)
     db_klipper_mqtt_get_config(&km);
     snprintf(port, sizeof port, "%u", (unsigned)(km.port ? km.port : (km.tls ? 8883 : 1883)));
     s = section(root, "Klipper MQTT");
+    visible_when(s, "ctl_src", "4");
     cJSON_AddStringToObject(s, "description",
         "After saving, open /km-config to generate moonraker.conf, printer.cfg, and the Mosquitto ACL.");
     add_field(s, field("km_host", "Broker host", "text", km.host, false));

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -2,32 +2,32 @@ dependencies:
   dc_evlog:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_evlog
-    version: v0.6.0
+    version: v0.6.1
   dc_source:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_source
-    version: v0.6.0
+    version: v0.6.1
   dc_bambu:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_bambu
-    version: v0.6.0
+    version: v0.6.1
   dc_wifi:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_wifi
-    version: v0.6.0
+    version: v0.6.1
   dc_moonraker:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_moonraker
-    version: v0.6.0
+    version: v0.6.1
   dc_ui:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_ui
-    version: v0.6.0
+    version: v0.6.1
   dc_mqtt:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_mqtt
-    version: v0.6.0
+    version: v0.6.1
   dc_portal:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_portal
-    version: v0.6.0
+    version: v0.6.1


### PR DESCRIPTION
Ships the DragonBreath side of dragon-core #13 (tagged v0.6.1).

- **/setup shows only the selected control source.** Moonraker/Bambu/Klipper-MQTT sections tagged with `visible_when` against `ctl_src`; `dc_ui` v0.6.1 reveals only the configured source. **Home Assistant stays always-visible** (carries over as read-only telemetry).
- **/console** no longer prompts for a token on presence-only devices (core fix).
- Re-pin all `dc_*` v0.6.0 → v0.6.1.

Build: ESP-IDF v5.3 ESP32-C3 PASS; guard reports lock matches every manifest git ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)