### PR TITLE
v1.1.4: firmware-update UX (progress %, update check, password reveal) via core v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+## [1.1.4] - 2026-08-10
+
+**Firmware-update UX restored on the shared setup surface, from `dragon-core` v0.7.0.**
+
+### Added
+- **On-board firmware update, rebuilt.** Uploading a `.bin` from `/setup` now shows a live
+  **progress %** (was a static message); on success it polls the rebooting device and
+  returns to the dashboard. A dropped connection after upload reports "device rebooting,
+  verifying…" (the dashboard version is the real confirmation), and a configured control
+  token is re-prompted and retried.
+- **Update check.** DragonBreath advertises its release repo via `GET /api/v2/info`, so the
+  UI can check GitHub for a newer stable release and show the version + expected SHA-256 +
+  download link (notify-then-manual-upload; never auto-flashes). Runs one request per load
+  on installed builds only — local/dev (`-dirty`/`-g<hash>`) builds skip it.
+- **Setup password reveal.** Show/Hide toggle on every setup password field (Wi-Fi,
+  fallback AP, product secrets) to catch a mistyped Wi-Fi password.
+
+### Changed
+- **`/fw` and the Settings "Firmware update" button** open setup and scroll to the
+  firmware/maintenance card (was buried at the bottom); the button is now the prominent
+  primary action.
+- **Re-pinned `dragon-core` v0.6.1 → v0.7.0.**
+
 ## [1.1.3] - 2026-08-10
 
 **Shared-UI polish for the /setup and /console pages, from `dragon-core` v0.6.1.**

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -304,6 +304,11 @@ static esp_err_t info_get(httpd_req_t *req)
     } else {
         cJSON_AddNullToObject(o, "inactive_slot");
     }
+    // Release repo for the shared UI's update check (dc_ui reads update.repo +
+    // update.asset_prefix, queries GitHub's latest release, and notifies if newer).
+    cJSON *upd = cJSON_AddObjectToObject(o, "update");
+    cJSON_AddStringToObject(upd, "repo", "plastikman/DragonBreath");
+    cJSON_AddStringToObject(upd, "asset_prefix", "dragonbreath-");
     cJSON *cap = cJSON_AddArrayToObject(o, "capabilities");
     cJSON_AddItemToArray(cap, cJSON_CreateString("power_on"));
     cJSON_AddItemToArray(cap, cJSON_CreateString("auto"));

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -2,32 +2,32 @@ dependencies:
   dc_evlog:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_evlog
-    version: v0.6.1
+    version: v0.7.0
   dc_source:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_source
-    version: v0.6.1
+    version: v0.7.0
   dc_bambu:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_bambu
-    version: v0.6.1
+    version: v0.7.0
   dc_wifi:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_wifi
-    version: v0.6.1
+    version: v0.7.0
   dc_moonraker:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_moonraker
-    version: v0.6.1
+    version: v0.7.0
   dc_ui:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_ui
-    version: v0.6.1
+    version: v0.7.0
   dc_mqtt:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_mqtt
-    version: v0.6.1
+    version: v0.7.0
   dc_portal:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_portal
-    version: v0.6.1
+    version: v0.7.0


### PR DESCRIPTION
Ships the DragonBreath side of dragon-core #15 (tagged v0.7.0).

- **On-board update**: live upload **%**, honest reboot/verify messaging, control-token re-prompt+retry.
- **Update check**: advertises the release repo in `GET /api/v2/info` (`update.repo`/`asset_prefix`) so `dc_ui` notifies of a newer stable release (version + SHA-256 + link; never auto-flashes; dev builds skip it).
- **Setup password reveal** on Wi-Fi/AP/secret fields.
- **/fw + Settings button** open setup and scroll to the (now prominent) firmware update action.
- Re-pin all `dc_*` v0.6.1 → v0.7.0.

Build: ESP-IDF v5.3 ESP32-C3 PASS; guard reports lock matches every manifest git ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)