### PR TITLE
feat(policy): restore AUTO after a one-off manual override (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+### Added
+- **Restore AUTO after a one-off manual override (#72).** When the heater is in
+  **AUTO** and you do a one-off **manual** run, the device now returns to AUTO
+  "waiting" when that run ends — either a local timed run completing or the
+  on-device **On** button stopping it — instead of dropping to idle. An explicit
+  **OFF** (the `off` command or the front-panel **Power** button) still stays off,
+  and any safety-driven off (fault, comms/lease timeout, panic) latches off and
+  never reverts. Only AUTO is resumed (not drying); the memory is RAM-only and
+  never persists across a reboot.
+
 ## [1.1.4] - 2026-08-10
 
 **Firmware-update UX restored on the shared setup surface, from `dragon-core` v0.7.0.**

--- a/components/pb_policy/pb_policy.c
+++ b/components/pb_policy/pb_policy.c
@@ -64,6 +64,13 @@ typedef struct {
     db_source_t source;
     uint32_t revision;
 
+    // #72: one-off manual-override memory (RAM-only, never persisted, not in the
+    // snapshot). When a POWER_ON run replaces AUTO, this remembers AUTO so the
+    // run's natural completion or an on-device stop returns to AUTO "waiting"
+    // instead of OFF. PB_MODE_OFF = no resume; explicit OFF and every safety path
+    // clear it, so only a run ending as a run can revert.
+    pb_mode_t resume_mode;
+
     float requested_target_c;
     uint8_t requested_fan_percent;
 
@@ -188,6 +195,30 @@ static void set_off_locked(db_source_t source)
     s.auto_engaged = false;
     s.drying_deadline_us = 0;
     s.local_power_deadline_us = 0;
+    s.resume_mode = PB_MODE_OFF;   // #72: explicit/hard OFF never reverts
+    lease_invalidate_locked();
+    revision_advance_locked(source);
+}
+
+// #72: end a POWER_ON run. If it was a one-off override of AUTO, return to AUTO
+// "waiting" (re-armed from the remembered params); otherwise drop to OFF. Explicit
+// OFF and every safety path use set_off_locked directly (which clears resume_mode),
+// so only a run's natural completion or an on-device stop can revert here.
+static void restore_or_off_locked(db_source_t source)
+{
+    if (s.resume_mode != PB_MODE_AUTO) {
+        set_off_locked(source);
+        return;
+    }
+    (void)pb_heater_set_target_c(0.0f);   // AUTO "waiting" applies no heat until engaged
+    s.mode = PB_MODE_AUTO;
+    s.requested_target_c = s.params.auto_target_c;         // remembered, already clamped
+    s.auto_bed_threshold_c = s.params.auto_bed_threshold_c;
+    s.auto_engaged = false;
+    s.auto_filtering = false;
+    s.drying_deadline_us = 0;
+    s.local_power_deadline_us = 0;
+    s.resume_mode = PB_MODE_OFF;
     lease_invalidate_locked();
     revision_advance_locked(source);
 }
@@ -445,8 +476,13 @@ pb_policy_result_t pb_policy_set_power_on(
     }
 
     int64_t now = esp_timer_get_time();
+    // #72: a manual run started while AUTO is a one-off override — remember to
+    // return to AUTO "waiting" when it ends. From any other mode there is nothing
+    // to revert to.
+    pb_mode_t prev_mode = s.mode;
     lease_invalidate_locked();
     s.mode = PB_MODE_POWER_ON;
+    s.resume_mode = (prev_mode == PB_MODE_AUTO) ? PB_MODE_AUTO : PB_MODE_OFF;
     s.requested_target_c = pb_heater_get_target_c(); // includes heater clamp
     s.auto_engaged = false;
     s.drying_deadline_us = 0;
@@ -486,6 +522,7 @@ pb_policy_result_t pb_policy_set_auto(
     }
     lease_invalidate_locked();
     s.mode = PB_MODE_AUTO;
+    s.resume_mode = PB_MODE_OFF;   // #72: an explicit AUTO command is not an override
     float max_target_c = pb_heater_get_max_target_c();
     s.requested_target_c =
         target_c > max_target_c ? max_target_c : target_c;
@@ -529,6 +566,7 @@ pb_policy_result_t pb_policy_start_drying(
     }
     lease_invalidate_locked();
     s.mode = PB_MODE_DRYING;
+    s.resume_mode = PB_MODE_OFF;   // #72: drying is not resumable; no revert to AUTO
     s.requested_target_c = pb_heater_get_target_c();
     s.auto_engaged = false;
     s.local_power_deadline_us = 0;
@@ -549,6 +587,18 @@ void pb_policy_set_mode_off(db_source_t source)
     if (!s_lock) return;
     xSemaphoreTake(s_lock, portMAX_DELAY);
     set_off_locked(source);
+    xSemaphoreGive(s_lock);
+    wake_control_task();
+}
+
+// #72: stop a manual run *as a run* (the on-device On-button toggle-off) — revert
+// to AUTO "waiting" if this run was a one-off override of AUTO, else OFF. This is
+// NOT the master-OFF path; the Power button and the `off` command stay hard OFF.
+static void pb_policy_stop_power_on(db_source_t source)
+{
+    if (!s_lock) return;
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    restore_or_off_locked(source);
     xSemaphoreGive(s_lock);
     wake_control_task();
 }
@@ -700,6 +750,7 @@ void pb_policy_request_panic_off(db_source_t source, const char *reason)
     s.auto_engaged = false;
     s.drying_deadline_us = 0;
     s.local_power_deadline_us = 0;
+    s.resume_mode = PB_MODE_OFF;   // #72: safety off never reverts
     lease_invalidate_locked();
     revision_advance_locked(source);
     // Claim the fault edge so pb_policy_tick() sees last_faulted already true and
@@ -732,7 +783,12 @@ static const char *button_str(pb_button_id_t id)
 static pb_policy_result_t button_toggle_mode(pb_mode_t target_mode)
 {
     if (pb_policy_get_mode() == target_mode) {
-        pb_policy_set_mode_off(DB_SOURCE_BUTTON);
+        // #72: toggling OFF a manual run reverts to AUTO "waiting" if it overrode
+        // AUTO; toggling off AUTO/DRY is a plain stop.
+        if (target_mode == PB_MODE_POWER_ON)
+            pb_policy_stop_power_on(DB_SOURCE_BUTTON);
+        else
+            pb_policy_set_mode_off(DB_SOURCE_BUTTON);
         return PB_POLICY_OK;
     }
     pb_policy_params_t p;
@@ -872,7 +928,9 @@ void pb_policy_tick(void)
             } else if (!s.lease_active && s.local_power_deadline_us > 0
                        && now >= s.local_power_deadline_us) {
                 local_limit_expired = true;
-                set_off_locked(DB_SOURCE_WATCHDOG);
+                // #72: an on-device timed manual run completing is the run "done" —
+                // revert to AUTO "waiting" if it overrode AUTO, else OFF.
+                restore_or_off_locked(DB_SOURCE_WATCHDOG);
             } else {
                 target = s.requested_target_c;
                 autonomous = !s.lease_active;
@@ -938,6 +996,7 @@ void pb_policy_tick(void)
         s.auto_engaged = false;
         s.drying_deadline_us = 0;
         s.local_power_deadline_us = 0;
+        s.resume_mode = PB_MODE_OFF;   // #72: lease/local timeout latches off, no revert
         revision_advance_locked(DB_SOURCE_WATCHDOG);
     }
 
@@ -976,6 +1035,7 @@ void pb_policy_tick(void)
         s.auto_engaged = false;
         s.drying_deadline_us = 0;
         s.local_power_deadline_us = 0;
+        s.resume_mode = PB_MODE_OFF;   // #72: fault sync latches off, no revert
         lease_invalidate_locked();
         // Preserve WATCHDOG attribution for a policy-triggered expiry.
         if (!watchdog_trip) revision_advance_locked(DB_SOURCE_SAFETY);

--- a/tests/pb_policy_host_test.c
+++ b/tests/pb_policy_host_test.c
@@ -1092,6 +1092,112 @@ static void test_auto_source_zone_overrides_bed_threshold(void)
     CHECK(snapshot().effective_target_c == 70.0f);
 }
 
+// #72: a one-off manual run started while AUTO returns to AUTO "waiting" when it
+// ends as a run (local timer completion OR the on-device On-button toggle-off),
+// instead of dropping to idle.
+static void test_manual_override_of_auto_reverts_on_run_end(void)
+{
+    // (a) local timed-run completion reverts to AUTO waiting.
+    reset_fixture();
+    CHECK(pb_policy_set_auto(60.0f, 100.0f, DB_SOURCE_WEB, 1) == PB_POLICY_OK);
+    uint32_t rev = snapshot().state_revision;
+    CHECK(pb_policy_set_power_on(
+        45.0f, DB_SOURCE_BUTTON, "panel", rev, NULL) == PB_POLICY_OK);
+    CHECK(snapshot().mode == PB_MODE_POWER_ON);
+    pb_policy_tick();
+    CHECK(snapshot().heater_output);
+
+    fake_now_us += (int64_t)PB_POLICY_LOCAL_POWER_MAX_MS * 1000 + 1;
+    pb_policy_tick();
+    pb_policy_snapshot_t snap = snapshot();
+    CHECK(snap.mode == PB_MODE_AUTO);                 // reverted, not OFF
+    CHECK(!snap.auto_engaged);                        // "waiting"
+    CHECK(snap.auto_bed_threshold_c == 100.0f);       // re-armed from remembered AUTO
+    CHECK(!snap.fault_latched);
+    CHECK(snap.effective_target_c == 0.0f);           // waiting applies no heat
+
+    // (b) on-device On-button toggle-off (stop the run) reverts to AUTO waiting.
+    reset_fixture();
+    pb_policy_load_params();                          // auto=60/bed100
+    pb_policy_on_button(PB_BUTTON_AUTO, PB_BUTTON_SHORT);
+    CHECK(snapshot().mode == PB_MODE_AUTO);
+    pb_policy_on_button(PB_BUTTON_ON, PB_BUTTON_SHORT);
+    CHECK(snapshot().mode == PB_MODE_POWER_ON);
+    pb_policy_on_button(PB_BUTTON_ON, PB_BUTTON_SHORT);   // stop the run
+    snap = snapshot();
+    CHECK(snap.mode == PB_MODE_AUTO);
+    CHECK(!snap.auto_engaged);
+}
+
+// #72: an explicit OFF (off command OR the Power button) after a manual override
+// stays OFF — only a run ending "as a run" reverts.
+static void test_manual_override_explicit_off_stays_off(void)
+{
+    // off command:
+    reset_fixture();
+    CHECK(pb_policy_set_auto(60.0f, 100.0f, DB_SOURCE_WEB, 1) == PB_POLICY_OK);
+    uint32_t rev = snapshot().state_revision;
+    pb_policy_lease_t lease;
+    CHECK(pb_policy_set_power_on(
+        45.0f, DB_SOURCE_WEB, "u1", rev, &lease) == PB_POLICY_OK);
+    pb_policy_set_mode_off(DB_SOURCE_WEB);
+    CHECK(snapshot().mode == PB_MODE_OFF);
+
+    // front-panel Power button (master OFF), distinct from the On toggle:
+    reset_fixture();
+    pb_policy_load_params();
+    pb_policy_on_button(PB_BUTTON_AUTO, PB_BUTTON_SHORT);
+    pb_policy_on_button(PB_BUTTON_ON, PB_BUTTON_SHORT);   // manual override of AUTO
+    CHECK(snapshot().mode == PB_MODE_POWER_ON);
+    pb_policy_on_button(PB_BUTTON_POWER, PB_BUTTON_SHORT);
+    CHECK(snapshot().mode == PB_MODE_OFF);               // stays off, no revert
+}
+
+// #72: a manual run started from OFF (no prior AUTO) ends at OFF — no spurious
+// revert. Also confirms the resume memory is RAM-only: after a reboot a fresh
+// run cannot inherit a stale "resume AUTO".
+static void test_manual_from_off_ends_off(void)
+{
+    reset_fixture();
+    CHECK(pb_policy_set_power_on(
+        45.0f, DB_SOURCE_BUTTON, "panel", 1, NULL) == PB_POLICY_OK);
+    fake_now_us += (int64_t)PB_POLICY_LOCAL_POWER_MAX_MS * 1000 + 1;
+    pb_policy_tick();
+    CHECK(snapshot().mode == PB_MODE_OFF);
+
+    // Override AUTO (resume=AUTO in RAM), reboot, then a run from OFF must end OFF.
+    reset_fixture();
+    pb_policy_load_params();
+    pb_policy_on_button(PB_BUTTON_AUTO, PB_BUTTON_SHORT);
+    pb_policy_on_button(PB_BUTTON_ON, PB_BUTTON_SHORT);
+    CHECK(snapshot().mode == PB_MODE_POWER_ON);
+    CHECK(pb_policy_init() == ESP_OK);                   // reboot: resume memory gone
+    pb_policy_load_params();
+    CHECK(pb_policy_set_power_on(
+        45.0f, DB_SOURCE_BUTTON, "panel", snapshot().state_revision, NULL)
+        == PB_POLICY_OK);
+    fake_now_us += (int64_t)PB_POLICY_LOCAL_POWER_MAX_MS * 1000 + 1;
+    pb_policy_tick();
+    CHECK(snapshot().mode == PB_MODE_OFF);              // not a stale revert to AUTO
+}
+
+// #72: a safety-driven forced OFF during a manual override (remote lease expiry)
+// latches OFF+fault and never silently reverts to AUTO.
+static void test_manual_override_safety_off_no_revert(void)
+{
+    reset_fixture();
+    CHECK(pb_policy_set_auto(60.0f, 100.0f, DB_SOURCE_WEB, 1) == PB_POLICY_OK);
+    uint32_t rev = snapshot().state_revision;
+    pb_policy_lease_t lease;
+    CHECK(pb_policy_set_power_on(
+        45.0f, DB_SOURCE_KLIPPER, "u1", rev, &lease) == PB_POLICY_OK);
+    fake_now_us += (int64_t)heater_comms_timeout_ms * 1000 + 1;
+    pb_policy_tick();
+    pb_policy_snapshot_t snap = snapshot();
+    CHECK(snap.mode == PB_MODE_OFF);                    // safety off, not AUTO
+    CHECK(snap.fault_latched);
+}
+
 int main(void)
 {
     test_boot_is_off();
@@ -1124,6 +1230,10 @@ int main(void)
     test_button_power_long_clears_or_holds_fault();
     test_fault_clear_persist_failure_stays_latched();
     test_purge_decide_session_and_hysteresis();
+    test_manual_override_of_auto_reverts_on_run_end();
+    test_manual_override_explicit_off_stays_off();
+    test_manual_from_off_ends_off();
+    test_manual_override_safety_off_no_revert();
     puts("pb_policy host tests: PASS");
     return 0;
 }


### PR DESCRIPTION
Closes #72.

## Behavior
In **AUTO**, a one-off **manual** run now returns to AUTO "waiting" when it ends as a run, instead of dropping to idle:
- **Reverts:** a local timed manual run completing, or the on-device **On** button stopping it.
- **Stays OFF:** an explicit `off` command or the front-panel **Power** button, and every safety-driven off (fault, comms/lease timeout, panic, fault-sync).
- Only **AUTO** is resumed (not drying).

## Implementation (all DragonBreath-local `pb_policy`, no core change)
- New RAM-only `policy_state_t.resume_mode` — never persisted, not in the snapshot; set to AUTO only when POWER_ON replaces AUTO, cleared on every OFF/AUTO/DRY/safety transition.
- `restore_or_off_locked()` reverts to AUTO waiting (re-armed from the remembered AUTO params) or falls back to hard OFF. Consumed by the local-limit tick path and a new `pb_policy_stop_power_on()` wired to the On-button toggle-off.

## Tests
4 new host cases in `pb_policy_host_test.c`: local-expiry revert, On-button-stop revert, explicit-off stays off, from-OFF ends off (+ RAM-only across a simulated reboot), and safety-off (lease expiry) no revert. Full host suite + ESP-IDF v5.3 ESP32-C3 build PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)