### PR TITLE
feat: Bambu LAN discovery in setup (core v0.13.0) — 1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+## [1.1.6] - 2026-08-11
+
+### Added
+- **Bambu LAN discovery in setup.** When configuring a Bambu printer, a
+  **Search for printers on the network** button now finds Bambu printers over
+  SSDP and fills in the host + serial for you — you only enter the LAN access
+  code. Discovery is user-initiated only (it runs when you open/click Bambu
+  setup, never in the background) and holds no socket open between scans.
+
+### Changed
+- Bumped **dragon-core** to **v0.13.0** (brings the shared on-demand Bambu
+  discovery plus the intervening core work).
+
 ## [1.1.5] - 2026-08-10
 
 ### Added

--- a/components/db_portal/db_portal.c
+++ b/components/db_portal/db_portal.c
@@ -266,6 +266,16 @@ static cJSON *describe_product(void *ctx)
     add_field(s, field("bb_host", "Printer host", "text", bb.host, false));
     add_field(s, field("bb_serial", "Serial", "text", bb.serial, false));
     add_field(s, field("bb_code", "Access code (leave blank to keep)", "password", "", true));
+    // LAN discovery: the shared SPA renders a Search picker from this block and
+    // fills bb_host + bb_serial, so the user only enters the access code.
+    cJSON *disc = cJSON_AddObjectToObject(s, "discovery");
+    cJSON_AddStringToObject(disc, "scan", "/api/v2/bambu/scan");
+    cJSON_AddStringToObject(disc, "endpoint", "/api/v2/bambu/discovered");
+    cJSON_AddStringToObject(disc, "list", "printers");
+    cJSON_AddStringToObject(disc, "label", "Search for printers on the network");
+    cJSON *bb_fill = cJSON_AddObjectToObject(disc, "fill");   // discovered key -> field key
+    cJSON_AddStringToObject(bb_fill, "host", "bb_host");
+    cJSON_AddStringToObject(bb_fill, "serial", "bb_serial");
 
     pb_ha_config_t ha = {0};
     pb_ha_get_config(&ha);
@@ -674,10 +684,58 @@ static esp_err_t favicon_get(httpd_req_t *req)
     return httpd_resp_send(req, (const char *)favicon_png_start, length);
 }
 
+static esp_err_t send_json_obj(httpd_req_t *req, cJSON *root)
+{
+    char *s = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    if (!s) { httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "oom"); return ESP_FAIL; }
+    httpd_resp_set_type(req, "application/json");
+    esp_err_t err = httpd_resp_send(req, s, HTTPD_RESP_USE_STRLEN);
+    free(s);
+    return err;
+}
+
+// POST /api/v2/bambu/scan — start a one-shot LAN scan (user-initiated only). The
+// setup UI calls this when the operator opens/clicks Bambu setup, then polls GET.
+static esp_err_t bambu_scan_post(httpd_req_t *req)
+{
+    dc_bambu_scan_start();
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "scanning", dc_bambu_scanning());
+    return send_json_obj(req, root);
+}
+
+// GET /api/v2/bambu/discovered — printers found by the most recent scan, plus
+// whether a scan is still running, for the setup picker to fill host + serial.
+static esp_err_t bambu_discovered_get(httpd_req_t *req)
+{
+    dc_bambu_found_t found[DC_BAMBU_DISCOVER_MAX];
+    int n = dc_bambu_discover_get(found, DC_BAMBU_DISCOVER_MAX);
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "scanning", dc_bambu_scanning());
+    cJSON *arr = cJSON_AddArrayToObject(root, "printers");
+    for (int i = 0; i < n; ++i) {
+        cJSON *p = cJSON_CreateObject();
+        cJSON_AddStringToObject(p, "host", found[i].host);
+        cJSON_AddStringToObject(p, "serial", found[i].serial);
+        cJSON_AddStringToObject(p, "model", found[i].model);
+        cJSON_AddStringToObject(p, "name", found[i].name);
+        cJSON_AddNumberToObject(p, "age_s", found[i].age_s);
+        cJSON_AddItemToArray(arr, p);
+    }
+    return send_json_obj(req, root);
+}
+
 static esp_err_t register_product_routes(httpd_handle_t server, void *ctx)
 {
     (void)ctx;
     esp_err_t err = pb_httpd_register(server);
+    if (err != ESP_OK) return err;
+    const httpd_uri_t bambu_scan = { .uri = "/api/v2/bambu/scan", .method = HTTP_POST, .handler = bambu_scan_post };
+    err = httpd_register_uri_handler(server, &bambu_scan);
+    if (err != ESP_OK) return err;
+    const httpd_uri_t bambu_disc = { .uri = "/api/v2/bambu/discovered", .method = HTTP_GET, .handler = bambu_discovered_get };
+    err = httpd_register_uri_handler(server, &bambu_disc);
     if (err != ESP_OK) return err;
     const httpd_uri_t km_config = { .uri = "/km-config", .method = HTTP_GET, .handler = km_config_get };
     err = httpd_register_uri_handler(server, &km_config);

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -2,32 +2,32 @@ dependencies:
   dc_evlog:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_evlog
-    version: v0.7.0
+    version: v0.13.0
   dc_source:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_source
-    version: v0.7.0
+    version: v0.13.0
   dc_bambu:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_bambu
-    version: v0.7.0
+    version: v0.13.0
   dc_wifi:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_wifi
-    version: v0.7.0
+    version: v0.13.0
   dc_moonraker:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_moonraker
-    version: v0.7.0
+    version: v0.13.0
   dc_ui:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_ui
-    version: v0.7.0
+    version: v0.13.0
   dc_mqtt:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_mqtt
-    version: v0.7.0
+    version: v0.13.0
   dc_portal:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_portal
-    version: v0.7.0
+    version: v0.13.0


### PR DESCRIPTION
Carries the shared on-demand Bambu discovery into DragonBreath. Setup gains a Search picker (POST /api/v2/bambu/scan + GET /api/v2/bambu/discovered) that fills bb_host + bb_serial over SSDP — user-initiated only, no background scanning, no socket held open. Bumps dragon-core v0.7.0 -> v0.13.0 (built clean on esp32c3, no API adaptation). Hardware-validated: dashboard renders under the core jump, scan finds a printer and fills the fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)