### PR TITLE
feat(reset): USB --erase-nvs + on-device Power+Auto reset combo

### DIFF
--- a/components/pb_buttons/include/pb_buttons.h
+++ b/components/pb_buttons/include/pb_buttons.h
@@ -8,11 +8,19 @@
 // A short press fires on release; a long press (2 s) fires once at the threshold
 // and suppresses the trailing short. A button held at power-on (or a shorted
 // line) is ignored until it releases — see pb_buttons_sm.h.
+//
+// Recovery combo: Power + Auto held together for PB_BTN_RESET_COMBO_MS emits a
+// single PB_BUTTON_RESET event (and suppresses those two buttons' own
+// short/long events for that hold). app_main handles it by erasing NVS and
+// rebooting — the on-device twin of `flash.py --erase-nvs`.
 #pragma once
 
 #include <stdbool.h>
 
 #include "esp_err.h"
+
+// Hold time for the Power+Auto recovery combo.
+#define PB_BTN_RESET_COMBO_MS 5000
 
 typedef enum {
     PB_BUTTON_POWER = 0,   // GPIO9  (⚠ ROM download-mode strap)
@@ -25,6 +33,7 @@ typedef enum {
 typedef enum {
     PB_BUTTON_SHORT,
     PB_BUTTON_LONG,
+    PB_BUTTON_RESET,   // Power+Auto held PB_BTN_RESET_COMBO_MS: erase NVS + reboot
 } pb_button_event_t;
 
 typedef void (*pb_button_cb_t)(pb_button_id_t id, pb_button_event_t ev);

--- a/components/pb_buttons/pb_buttons.c
+++ b/components/pb_buttons/pb_buttons.c
@@ -67,15 +67,41 @@ static void configure_pin(gpio_num_t pin)
 }
 #endif
 
+#define PB_BTN_RESET_COMBO_TICKS (PB_BTN_RESET_COMBO_MS / PB_BTN_TICK_MS)
+
 static void button_task(void *arg)
 {
     (void)arg;
+    int combo_ticks = 0;
     for (;;) {
+        // Step every button first so debounce/long-press timing is unaffected,
+        // capturing this tick's event per button.
+        pb_btn_event_t evs[PB_BUTTON_COUNT];
+        for (int i = 0; i < PB_BUTTON_COUNT; ++i)
+            evs[i] = pb_buttons_sm_step(&s_btns[i].sm, sample(&s_btns[i]));
+
+        // Recovery combo: Power + Auto both debounced-held. While it's building we
+        // swallow those two buttons' own short/long events (so the hold doesn't
+        // also fire Power's panic-off or Auto's mode toggle); at the threshold we
+        // emit exactly one PB_BUTTON_RESET. esp_restart() in the handler means the
+        // == test can never re-fire.
+        bool combo = s_btns[PB_BUTTON_POWER].sm.pressed &&
+                     s_btns[PB_BUTTON_AUTO].sm.pressed;
+        if (combo) {
+            if (++combo_ticks == PB_BTN_RESET_COMBO_TICKS) {
+                ESP_LOGW(TAG, "Power+Auto held %d ms: emitting reset combo",
+                         PB_BTN_RESET_COMBO_MS);
+                if (s_cb) s_cb(PB_BUTTON_POWER, PB_BUTTON_RESET);
+            }
+        } else {
+            combo_ticks = 0;
+        }
+
         for (int i = 0; i < PB_BUTTON_COUNT; ++i) {
-            pb_btn_event_t ev = pb_buttons_sm_step(&s_btns[i].sm, sample(&s_btns[i]));
-            if (ev == PB_BTN_EV_NONE || !s_cb) continue;
+            if (evs[i] == PB_BTN_EV_NONE || !s_cb) continue;
+            if (combo && (i == PB_BUTTON_POWER || i == PB_BUTTON_AUTO)) continue;
             s_cb(s_btns[i].id,
-                 ev == PB_BTN_EV_LONG ? PB_BUTTON_LONG : PB_BUTTON_SHORT);
+                 evs[i] == PB_BTN_EV_LONG ? PB_BUTTON_LONG : PB_BUTTON_SHORT);
         }
         vTaskDelay(pdMS_TO_TICKS(PB_BTN_TICK_MS));
     }

--- a/components/pb_leds/include/pb_leds.h
+++ b/components/pb_leds/include/pb_leds.h
@@ -48,6 +48,14 @@ void pb_leds_set_code(pb_led_id_t id, uint8_t pulses);
 // Current logical pattern, including when dev-board HIL compiles GPIO out.
 pb_led_pattern_t pb_leds_get(pb_led_id_t id);
 
+// Blocking, all-LEDs acknowledgement flash: suspends the driver task (so nothing
+// re-asserts patterns underneath it), then drives every physically-driven panel
+// LED on/off `times`, and returns with the driver still suspended. Ignores the
+// master-enable flag — the flash always shows. Intended as a terminal
+// confirmation right before a reboot (e.g. the Power+Auto NVS-reset combo); the
+// caller is expected to esp_restart() after, so the task is never resumed.
+void pb_leds_flash_all(uint8_t times, uint16_t on_ms, uint16_t off_ms);
+
 // --- Status-LED master enable (NVS-backed, namespace app_nvs, default ON) -----
 // When disabled the driver task leaves every panel LED physically off; pb_policy
 // still computes patterns (pb_leds just no-ops the GPIO output). The pattern

--- a/components/pb_leds/pb_leds.c
+++ b/components/pb_leds/pb_leds.c
@@ -111,6 +111,26 @@ static void led_task(void *arg)
     }
 }
 
+void pb_leds_flash_all(uint8_t times, uint16_t on_ms, uint16_t off_ms)
+{
+    // Take the panel away from the pattern-driven task for the duration so a
+    // concurrent pb_policy update can't stomp the flash mid-blink. We never
+    // resume it — the caller reboots right after this returns.
+    if (s_task) vTaskSuspend(s_task);
+    for (uint8_t n = 0; n < times; n++) {
+#ifndef CONFIG_PB_HIL_DEVBOARD
+        for (int i = 0; i < PB_LED_COUNT; i++)
+            if (PB_LED_DRIVEN(i)) gpio_set_level(s_gpio[i], 1);
+#endif
+        vTaskDelay(pdMS_TO_TICKS(on_ms));
+#ifndef CONFIG_PB_HIL_DEVBOARD
+        for (int i = 0; i < PB_LED_COUNT; i++)
+            if (PB_LED_DRIVEN(i)) gpio_set_level(s_gpio[i], 0);
+#endif
+        vTaskDelay(pdMS_TO_TICKS(off_ms));
+    }
+}
+
 esp_err_t pb_leds_start(void)
 {
     if (s_task) return ESP_ERR_INVALID_STATE;

--- a/docs/WINDOWS_RECOVERY.md
+++ b/docs/WINDOWS_RECOVERY.md
@@ -74,6 +74,22 @@ no separate post-write verify: the firmware rewrites its own NVS/calibration on 
 boot, so a re-read would falsely "mismatch" — the inline hash above is the real
 check.)
 
+## Reset the config only (keep the firmware)
+
+If the device is booting fine but you're locked out — wrong Wi-Fi, a forgotten
+control token, or a bad saved setting — you don't need a full restore. Erase just
+the config (NVS) region and the device comes back up unconfigured, serving its own
+setup AP again:
+
+```
+py flash.py --erase-nvs
+```
+
+This clears Wi-Fi credentials, the control token, saved policy, and sensor
+calibration; the firmware itself is untouched. It's the USB equivalent of the
+on-device **Power + Auto reset combo** (hold both front buttons for 5 seconds — all
+panel LEDs flash 3× to confirm, then the board reboots erased).
+
 ## Notes
 
 - **Always `py`, never `python`.** If `py` somehow isn't available, use the full path

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -14,6 +14,7 @@
 #include "freertos/task.h"
 #include "esp_log.h"
 #include "esp_task_wdt.h"
+#include "esp_system.h"
 #include "nvs_flash.h"
 #include "nvs.h"
 #include <stdbool.h>
@@ -81,9 +82,19 @@ static void control_wake(void)
     if (s_control_task) xTaskNotifyGive(s_control_task);
 }
 
-// Thin adapter: the button driver's event -> the policy handler.
+// Thin adapter: the button driver's event -> the policy handler. The Power+Auto
+// recovery combo is intercepted here (not forwarded to policy): flash all panel
+// LEDs 3x as a "config erased" acknowledgement, wipe NVS, and reboot. The reboot
+// itself cuts the heater, so this is inherently fail-safe.
 static void button_cb(pb_button_id_t id, pb_button_event_t ev)
 {
+    if (ev == PB_BUTTON_RESET) {
+        ESP_LOGW(TAG, "reset combo: erasing NVS (config) and rebooting");
+        pb_leds_flash_all(3, 200, 200);   // ~1.2 s all-LEDs acknowledgement
+        (void)nvs_flash_erase();
+        esp_restart();
+        return;   // unreachable
+    }
     pb_policy_on_button(id, ev);
 }
 

--- a/tests/pb_policy_host_test.c
+++ b/tests/pb_policy_host_test.c
@@ -330,49 +330,44 @@ static void test_lease_expiry_latches_watchdog_fault(void)
     CHECK(pb_policy_heartbeat(&lease) == PB_POLICY_STALE_LEASE);
 }
 
-static void test_auto_requires_live_moonraker_and_uses_hysteresis(void)
+// AUTO now follows the active print's filament-profile target (src_target_c) and
+// ONLY while the source (Moonraker/Bambu) is connected — bed-threshold heating was
+// removed in "AUTO follows the filament profile" (PR #81). This pins the live-source
+// gate (fail-safe: no source, no heat); the engage/target/clamp behavior is covered
+// by test_auto_source_zone_overrides_bed_threshold.
+static void test_auto_requires_live_source(void)
 {
     reset_fixture();
     CHECK(pb_policy_set_auto(
         60.0f, 100.0f, DB_SOURCE_WEB, 1) == PB_POLICY_OK);
 
-    pb_policy_set_env(99.0f, 99.0f, true, 0.0f);
-    pb_policy_tick();
-    CHECK(snapshot().effective_target_c == 0.0f);
-
+    // A high bed setpoint no longer engages AUTO on its own (no zone target).
     pb_policy_set_env(100.0f, 100.0f, true, 0.0f);
     pb_policy_tick();
     pb_policy_snapshot_t snap = snapshot();
-    CHECK(snap.auto_engaged);
-    CHECK(snap.effective_target_c == 60.0f);
+    CHECK(!snap.auto_engaged);
+    CHECK(snap.effective_target_c == 0.0f);
 
-    pb_policy_set_env(98.0f, 98.0f, true, 0.0f);
-    pb_policy_tick();
-    CHECK(snapshot().auto_engaged);
-
-    pb_policy_set_env(96.9f, 96.9f, true, 0.0f);
+    // A zone target with the source DISCONNECTED must not heat (fail-safe).
+    pb_policy_set_env(20.0f, 0.0f, false, 55.0f);
     pb_policy_tick();
     snap = snapshot();
     CHECK(!snap.auto_engaged);
     CHECK(snap.effective_target_c == 0.0f);
 
-    pb_policy_set_env(105.0f, 105.0f, false, 0.0f);
+    // Source connected + zone target -> engage to the zone target.
+    pb_policy_set_env(20.0f, 0.0f, true, 55.0f);
     pb_policy_tick();
-    CHECK(!snapshot().auto_engaged);
+    snap = snapshot();
+    CHECK(snap.auto_engaged);
+    CHECK(snap.effective_target_c == 55.0f);
 
-    // Setpoint parity: AUTO triggers on the commanded bed SETPOINT, not the
-    // measured bed temperature. A cold bed with a high setpoint engages
-    // immediately; a hot bed whose setpoint has dropped disengages.
-    CHECK(pb_policy_set_auto(
-        60.0f, 100.0f, DB_SOURCE_WEB, PB_POLICY_REVISION_ANY) == PB_POLICY_OK);
-    pb_policy_set_env(20.0f /*measured cold*/, 100.0f /*setpoint*/, true, 0.0f);
+    // Losing the source mid-print disengages, even with the zone target still set.
+    pb_policy_set_env(20.0f, 0.0f, false, 55.0f);
     pb_policy_tick();
-    CHECK(snapshot().auto_engaged);
-    CHECK(snapshot().effective_target_c == 60.0f);
-    pb_policy_set_env(99.0f /*measured hot*/, 0.0f /*setpoint cleared*/, true, 0.0f);
-    pb_policy_tick();
-    CHECK(!snapshot().auto_engaged);
-    CHECK(snapshot().effective_target_c == 0.0f);
+    snap = snapshot();
+    CHECK(!snap.auto_engaged);
+    CHECK(snap.effective_target_c == 0.0f);
 }
 
 static void test_auto_filtration_band_fan_only_not_cooldown(void)
@@ -493,7 +488,8 @@ static void test_runtime_limits_drive_auto_and_remote_lease(void)
     CHECK(pb_policy_set_auto(
         65.0f, 100.0f, DB_SOURCE_WEB, 1) == PB_POLICY_OK);
     CHECK(snapshot().requested_target_c == 52.0f);
-    pb_policy_set_env(100.0f, 100.0f, true, 0.0f);
+    // AUTO heats to the live filament-zone target (65), clamped to the runtime max (52).
+    pb_policy_set_env(20.0f, 0.0f, true, 65.0f);
     pb_policy_tick();
     CHECK(snapshot().effective_target_c == 52.0f);
 
@@ -757,7 +753,8 @@ static void test_panel_leds_track_mode(void)
     CHECK(led_pattern[PB_LED_AUTO] == PB_LED_BLINK_SLOW);
     CHECK(led_pattern[PB_LED_ON] == PB_LED_OFF);
 
-    pb_policy_set_env(105.0f, 105.0f, true, 0.0f);
+    // Live source + a filament-zone target engages AUTO -> solid LED.
+    pb_policy_set_env(20.0f, 0.0f, true, 55.0f);
     pb_policy_tick();
     CHECK(snapshot().auto_engaged);
     CHECK(led_pattern[PB_LED_AUTO] == PB_LED_SOLID);
@@ -1204,7 +1201,7 @@ int main(void)
     test_remote_lease_and_stale_revision();
     test_new_command_supersedes_old_lease_and_off_is_unconditional();
     test_lease_expiry_latches_watchdog_fault();
-    test_auto_requires_live_moonraker_and_uses_hysteresis();
+    test_auto_requires_live_source();
     test_auto_source_zone_overrides_bed_threshold();
     test_auto_filtration_band_fan_only_not_cooldown();
     test_filtration_band_runs_outside_auto();

--- a/tools/flash.py
+++ b/tools/flash.py
@@ -18,6 +18,9 @@ return to stock:
     # Restore a previous backup (e.g. go back to stock):
     python3 tools/flash.py --restore backups/stock-YYYYmmdd-HHMMSS.bin
 
+    # Reset config only (Wi-Fi/token/policy/calibration) — keep the firmware:
+    python3 tools/flash.py --erase-nvs
+
 The Panda Breath has no exposed native-USB (GPIO18 is the SSR), so flashing is
 over the on-board CH340K USB-C UART bridge. Plug the board's USB-C into your PC;
 esptool auto-detects the port (override with --port).
@@ -37,6 +40,12 @@ import sys
 
 CHIP = "esp32c3"
 FLASH_SIZE = 0x400000  # 4 MB
+# NVS (config) partition — matches partitions.csv. Erasing only this wipes Wi-Fi
+# credentials, control token, saved policy, and sensor calibration, forcing AP
+# re-provisioning on next boot — WITHOUT touching the firmware. The minimal
+# "reset my config" fix (same effect as the on-device Power+Auto reset combo).
+NVS_OFFSET = 0x9000
+NVS_SIZE   = 0x5000    # 20 KB
 # DragonBreath image layout — matches partitions.csv (stock Panda layout: otadata
 # @ 0xe000, app slot ota_0 @ 0x10000). This is the USB/recovery "factory" write.
 IMAGES = [
@@ -211,6 +220,27 @@ def do_restore(port, bauds, image):
     return 0
 
 
+def do_erase_nvs(port, bauds):
+    # Erase ONLY the NVS/config region — the firmware is untouched. This is the
+    # USB equivalent of the on-device Power+Auto reset combo: it clears Wi-Fi
+    # credentials, the control token, saved policy, and sensor calibration, so
+    # the device comes back up unconfigured (its own AP for re-provisioning).
+    print(f"\nErase config only: NVS region {hex(NVS_OFFSET)} + {hex(NVS_SIZE)} "
+          f"({NVS_SIZE // 1024} KB).")
+    print("  Clears Wi-Fi credentials, control token, saved policy, and sensor")
+    print("  calibration. The firmware is left intact; the device re-provisions")
+    print("  (its own AP) on next boot. Same effect as the Power+Auto reset combo.")
+    if not confirm("Erase the config (NVS)?"):
+        print("Aborted.")
+        return 1
+    rc, _ = run_esptool(port, bauds, "erase_region", hex(NVS_OFFSET), hex(NVS_SIZE))
+    if rc != 0:
+        print("ERROR: NVS erase failed.")
+        return rc
+    print("  config erased — power-cycle the board; it will come up unconfigured.")
+    return 0
+
+
 def main():
     ap = argparse.ArgumentParser(description="DragonBreath flasher (backs up stock first).")
     ap.add_argument("--port", help="serial port (default: esptool auto-detect)")
@@ -228,6 +258,10 @@ def main():
                          "the recommended safety net before a no-USB OTA install")
     ap.add_argument("--no-backup", action="store_true",
                     help="skip the pre-flash backup (NOT recommended)")
+    ap.add_argument("--erase-nvs", action="store_true",
+                    help="erase ONLY the NVS/config region (Wi-Fi, control token, "
+                         "policy, calibration) and exit — a config reset that keeps "
+                         "the firmware; the USB twin of the Power+Auto reset combo")
     args = ap.parse_args()
 
     if not check_esptool():
@@ -238,6 +272,9 @@ def main():
 
     if args.restore:
         return do_restore(args.port, bauds, args.restore)
+
+    if args.erase_nvs:
+        return do_erase_nvs(args.port, bauds)
 
     if args.backup_only:
         path, _ = do_backup(args.port, bauds, args.backup_dir)


### PR DESCRIPTION
Two ways to clear config (Wi-Fi creds / control token / policy / calibration) without touching the firmware — the NVS region only. Motivated by a user (marks) who only needed an NVS wipe but had no on-device way to do it.

## What's new
- **`flash.py --erase-nvs`** — `erase_region 0x9000 0x5000` over USB, with a confirm prompt. Documented in `docs/WINDOWS_RECOVERY.md`.
- **On-device reset combo** — hold **Power + Auto** together for 5 s:
  - `pb_buttons` emits a single new `PB_BUTTON_RESET` event; the two buttons' own short/long events are suppressed while the combo builds (so it doesn't also fire Power's panic-off / Auto's mode toggle).
  - `app_main` flashes **all panel LEDs 3×** as a "config erased" acknowledgement, wipes NVS, and reboots. The reboot cuts the heater, so the action is inherently fail-safe.
  - `pb_leds_flash_all()` suspends the LED driver task so a concurrent policy update can't stomp the confirmation flash. (Power LED is the console-TX pin in release builds, so it flashes 3 LEDs there — acknowledged as fine.)

## Testing
- Build clean; `pb_buttons` host test passes.
- Hardware validation of the physical combo + LED flash pending (note: triggering it wipes the device's config, as intended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)