### PR TITLE
feat(prusa): wire the PrusaLink (dc_prusa) bed-follow source

### DIFF
--- a/components/db_portal/CMakeLists.txt
+++ b/components/db_portal/CMakeLists.txt
@@ -1,7 +1,7 @@
 idf_component_register(
     SRCS "db_portal.c" "db_portal_config.c"
     INCLUDE_DIRS "include"
-    REQUIRES dc_portal pb_httpd pb_policy dc_source dc_moonraker dc_bambu pb_ha
+    REQUIRES dc_portal pb_httpd pb_policy dc_source dc_moonraker dc_bambu dc_prusa pb_ha
              db_klipper_mqtt nvs_flash json app_update
 )
 

--- a/components/db_portal/db_portal.c
+++ b/components/db_portal/db_portal.c
@@ -4,6 +4,7 @@
 
 #include "db_klipper_mqtt.h"
 #include "dc_bambu.h"
+#include "dc_prusa.h"
 #include "dc_moonraker.h"
 #include "dc_portal.h"
 #include "dc_source.h"
@@ -239,7 +240,7 @@ static cJSON *describe_product(void *ctx)
     snprintf(selected_source, sizeof selected_source, "%d", dc_source_get());
     cJSON *src = field("ctl_src", "Source", "select", selected_source, false);
     cJSON *opts = cJSON_AddArrayToObject(src, "options");
-    static const char *labels[] = {"Klipper (Moonraker)", "Bambu LAN", "Home Assistant", "None", "Klipper MQTT"};
+    static const char *labels[] = {"Klipper (Moonraker)", "Bambu LAN", "Home Assistant", "None", "Klipper MQTT", "Prusa (PrusaLink)"};
     for (int i = 0; i < DC_SRC_MAX; i++) {
         cJSON *o = cJSON_CreateObject();
         char value[4];
@@ -267,7 +268,8 @@ static cJSON *describe_product(void *ctx)
     add_field(s, field("bb_serial", "Serial", "text", bb.serial, false));
     add_field(s, field("bb_code", "Access code (leave blank to keep)", "password", "", true));
     // LAN discovery: the shared SPA renders a Search picker from this block and
-    // fills bb_host + bb_serial, so the user only enters the access code.
+    // fills bb_host + bb_serial, so the user only enters the access code. This MUST
+    // stay attached to the Bambu section's `s` — keep it before the next section().
     cJSON *disc = cJSON_AddObjectToObject(s, "discovery");
     cJSON_AddStringToObject(disc, "scan", "/api/v2/bambu/scan");
     cJSON_AddStringToObject(disc, "endpoint", "/api/v2/bambu/discovered");
@@ -276,6 +278,18 @@ static cJSON *describe_product(void *ctx)
     cJSON *bb_fill = cJSON_AddObjectToObject(disc, "fill");   // discovered key -> field key
     cJSON_AddStringToObject(bb_fill, "host", "bb_host");
     cJSON_AddStringToObject(bb_fill, "serial", "bb_serial");
+
+    dc_prusa_config_t pr = {0};
+    dc_prusa_get_config(&pr);
+    s = section(root, "Prusa (PrusaLink)");   // no discovery: PrusaLink has no SSDP scan
+    visible_when(s, "ctl_src", "5");
+    cJSON_AddStringToObject(s, "description",
+        "Bed-follow: DragonBreath polls the printer's PrusaLink API and, in AUTO, heats the "
+        "chamber once the printer's bed setpoint reaches your threshold (PrusaLink reports no "
+        "filament type). Set the bed threshold and chamber target on the dashboard's Auto "
+        "card. The API key is the printer's PrusaLink password.");
+    add_field(s, field("pr_host", "Printer host", "text", pr.host, false));
+    add_field(s, field("pr_key", "API key / PrusaLink password (leave blank to keep)", "password", "", true));
 
     pb_ha_config_t ha = {0};
     pb_ha_get_config(&ha);
@@ -428,6 +442,7 @@ static esp_err_t parse_product_request(const cJSON *values,
     PARSE_TEXT(km_host); PARSE_PORT(km_port); PARSE_TEXT(km_user);
     PARSE_TEXT(km_pass); PARSE_TEXT(km_inst); PARSE_TEXT(km_topic);
     PARSE_BOOL(km_tls); PARSE_BOOL(km_writeback);
+    PARSE_TEXT(pr_host); PARSE_TEXT(pr_key);
 
 #undef PARSE_TEXT
 #undef PARSE_PORT
@@ -484,6 +499,24 @@ static esp_err_t apply_product(const cJSON *values, void *ctx, char *message, si
         err = db_klipper_mqtt_set_config(&plan.klipper_mqtt);
         if (err != ESP_OK) return persistence_error("Klipper MQTT", err, message, message_size);
     }
+    // Prusa (PrusaLink) — handled inline (not in the shared planner). A blank API-key
+    // submission preserves the saved key; host/threshold/target overwrite when present.
+    dc_prusa_config_t pr = {0};
+    (void)dc_prusa_get_config(&pr);
+    bool prusa_changed = false;
+    if (request.pr_host.present) {
+        snprintf(pr.host, sizeof pr.host, "%s", request.pr_host.value ? request.pr_host.value : "");
+        prusa_changed = true;
+    }
+    if (request.pr_key.present && request.pr_key.value && request.pr_key.value[0]) {
+        snprintf(pr.api_key, sizeof pr.api_key, "%s", request.pr_key.value);
+        prusa_changed = true;
+    }
+    if (prusa_changed) {
+        err = dc_prusa_set_config(&pr);
+        if (err != ESP_OK) return persistence_error("Prusa", err, message, message_size);
+    }
+
     // Source is deliberately last: an invalid or failed config save can never bind
     // a different controller. Selecting None changes only this enum; credentials stay.
     if (plan.source_changed) {
@@ -492,7 +525,7 @@ static esp_err_t apply_product(const cJSON *values, void *ctx, char *message, si
     }
 
     bool changed = plan.moonraker_changed || plan.bambu_changed || plan.ha_changed ||
-                   plan.klipper_mqtt_changed || plan.source_changed;
+                   plan.klipper_mqtt_changed || plan.source_changed || prusa_changed;
     snprintf(message, message_size, changed
              ? "Configuration saved; restart to apply source changes."
              : "Configuration already up to date.");

--- a/components/db_portal/include/db_portal_config.h
+++ b/components/db_portal/include/db_portal_config.h
@@ -37,6 +37,8 @@ typedef struct {
     db_portal_text_value_t km_host, km_user, km_pass, km_inst, km_topic;
     db_portal_port_value_t km_port;
     db_portal_bool_value_t km_tls, km_writeback;
+    db_portal_text_value_t pr_host, pr_key;      // Prusa host + API key (handled inline
+                                                 // in apply_product, not the shared planner)
 } db_portal_product_request_t;
 
 typedef struct {

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -158,6 +158,9 @@ static cJSON *state_json(const pb_policy_snapshot_t *s)
     // between a save and the reboot. Lets the dashboard label the printer/source row.
     dc_ctl_source_t ctl_src = dc_source_get();
     cJSON_AddStringToObject(environment, "control_source", dc_source_str(ctl_src));
+    // Source capability: filament-aware (AUTO follows the filament zone) vs bed-follow
+    // (AUTO follows the bed setpoint). The dashboard's AUTO card keys off this.
+    cJSON_AddBoolToObject(environment, "source_has_filament", dc_source_has_filament(ctl_src));
     // In Bambu mode, surface the configured serial so the dashboard can label the
     // row "Bambu (<serial>)" — the LAN report carries no friendly printer name.
     if (ctl_src == DC_SRC_BAMBU) {

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -2,5 +2,5 @@ idf_component_register(
     SRCS "app_main.c"
     INCLUDE_DIRS "."
     REQUIRES pb_board pb_ntc pb_heater pb_fan pb_policy pb_leds pb_buttons pb_hil pb_httpd db_portal
-             dc_wifi dc_moonraker dc_source dc_bambu dc_ui pb_ha db_klipper_mqtt dc_evlog nvs_flash esp_wifi app_update
+             dc_wifi dc_moonraker dc_source dc_bambu dc_prusa dc_ui pb_ha db_klipper_mqtt dc_evlog nvs_flash esp_wifi app_update
 )

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -37,6 +37,7 @@
 #include "dc_moonraker.h"
 #include "dc_source.h"
 #include "dc_bambu.h"
+#include "dc_prusa.h"
 #include "pb_ha.h"
 #include "db_klipper_mqtt.h"
 #include <math.h>
@@ -67,6 +68,7 @@ static volatile bool s_mk_up    = false;   // Klipper (Moonraker)
 static volatile bool s_bambu_up = false;   // Bambu LAN MQTT
 static volatile bool s_ha_up    = false;   // Home Assistant MQTT
 static volatile bool s_km_up    = false;   // Klipper (MQTT)
+static volatile bool s_prusa_up = false;   // PrusaLink HTTP
 // The persisted control source, read once at boot. Default Klipper.
 static dc_ctl_source_t s_src = DC_SRC_KLIPPER;
 
@@ -234,6 +236,26 @@ static void control_task(void *arg)
                 // macros publish desired-state, the client runs the retained-aware
                 // arming machine and drives target/mode through pb_policy directly.
                 if (s_km_up) db_klipper_mqtt_tick();
+                break;
+            case DC_SRC_PRUSA:
+                // PrusaLink reports no filament type: FOLLOW THE BED. Engage the
+                // chamber (to the AUTO card's target) once the printer's bed setpoint
+                // reaches the AUTO card's bed threshold. Both come from pb_policy — the
+                // Auto card supplies this source's bed->chamber rule (no filament zones).
+                if (s_prusa_up) {
+                    dc_prusa_status_t ps;
+                    dc_prusa_get_status(&ps);
+                    src_connected = ps.online;
+                    if (src_connected) {
+                        if (isfinite(ps.bed_temp)) bed_c = ps.bed_temp;
+                        bed_target_c = ps.bed_target;
+                        pb_policy_snapshot_t pol;
+                        pb_policy_get_snapshot(&pol);
+                        if (pol.params.auto_bed_threshold_c > 0.0f &&
+                            ps.bed_target >= pol.params.auto_bed_threshold_c)
+                            src_target_c = pol.params.auto_target_c;
+                    }
+                }
                 break;
             case DC_SRC_NONE:
                 break;   // unbound: no bed source, feeds zeros/not-connected
@@ -435,6 +457,12 @@ void app_main(void)
             ESP_LOGE(TAG, "db_klipper_mqtt_start: %s (continuing; no MQTT control)", esp_err_to_name(e));
         else
             s_km_up = true;
+        break;
+    case DC_SRC_PRUSA:
+        if ((e = dc_prusa_start()) != ESP_OK)
+            ESP_LOGE(TAG, "dc_prusa_start: %s (continuing; no printer follow)", esp_err_to_name(e));
+        else
+            s_prusa_up = true;
         break;
     case DC_SRC_NONE:
         ESP_LOGI(TAG, "control source: none (unbound) — no external controller");

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,33 +1,37 @@
 dependencies:
+  dc_prusa:
+    git: https://github.com/justinh-rahb/dragon-core.git
+    path: components/dc_prusa
+    version: v0.28.0
   dc_evlog:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_evlog
-    version: v0.27.0
+    version: v0.28.0
   dc_source:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_source
-    version: v0.27.0
+    version: v0.28.0
   dc_bambu:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_bambu
-    version: v0.27.0
+    version: v0.28.0
   dc_wifi:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_wifi
-    version: v0.27.0
+    version: v0.28.0
   dc_moonraker:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_moonraker
-    version: v0.27.0
+    version: v0.28.0
   dc_ui:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_ui
-    version: v0.27.0
+    version: v0.28.0
   dc_mqtt:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_mqtt
-    version: v0.27.0
+    version: v0.28.0
   dc_portal:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_portal
-    version: v0.27.0
+    version: v0.28.0


### PR DESCRIPTION
**Draft for review — not ready to merge.** Requesting @justinh-rahb's review.

Product-side wiring for the new **Prusa (PrusaLink)** control source. Pairs with the core PR: **justinh-rahb/dragon-core#46** (`dc_prusa` + `DC_SRC_PRUSA` + source-aware AUTO card).

⚠️ **CI will be red until the core lands:** this depends on the unreleased core `dc_prusa`/`DC_SRC_PRUSA`. Locally it builds against a project-component copy of `dc_prusa`; once dragon-core#46 merges and we cut a core tag, we pin it here and CI goes green.

## What's here
- **app_main:** start `dc_prusa` for `DC_SRC_PRUSA`; telemetry case FOLLOWS THE BED — engage the chamber to the AUTO card's target once the printer's bed setpoint reaches the AUTO card's threshold (read from `pb_policy`; PrusaLink has no filament type).
- **db_portal:** "Prusa (PrusaLink)" in the source selector; setup section is connection-only (host + API key), placed with the other bed-follow sources (before Home Assistant), **no discovery scanner** (PrusaLink isn't SSDP-discoverable). Threshold/target are set on the dashboard Auto card, not here.
- **pb_httpd:** exposes `environment.source_has_filament` so the shared AUTO card can switch to bed-follow copy/controls.

## Validated on real hardware (mock Core One)
Engage/disengage on the bed setpoint, non-JSON/wrong-host → OFFLINE fail-safe, and **loss of source → heater off in ~6 s → cooldown**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)