### PR TITLE
fix(prusa): shared-planner config + strict status parse (addresses #86 review)

### DIFF
--- a/components/db_portal/db_portal.c
+++ b/components/db_portal/db_portal.c
@@ -473,13 +473,16 @@ static esp_err_t apply_product(const cJSON *values, void *ctx, char *message, si
     if (err != ESP_OK) return persistence_error("Home Assistant", err, message, message_size);
     err = db_klipper_mqtt_get_config(&km);
     if (err != ESP_OK) return persistence_error("Klipper MQTT", err, message, message_size);
+    dc_prusa_config_t pr = {0};
+    err = dc_prusa_get_config(&pr);
+    if (err != ESP_OK) return persistence_error("Prusa", err, message, message_size);
 
     // Parse and stage every field before the first setter can touch runtime/NVS.
     db_portal_product_request_t request;
     err = parse_product_request(values, &request, message, message_size);
     if (err != ESP_OK) return err;
     db_portal_product_plan_t plan;
-    err = db_portal_plan_product_save(&request, dc_source_get(), &mr, &bb, &ha, &km,
+    err = db_portal_plan_product_save(&request, dc_source_get(), &mr, &bb, &ha, &km, &pr,
                                       &plan, message, message_size);
     if (err != ESP_OK) return err;
 
@@ -499,21 +502,8 @@ static esp_err_t apply_product(const cJSON *values, void *ctx, char *message, si
         err = db_klipper_mqtt_set_config(&plan.klipper_mqtt);
         if (err != ESP_OK) return persistence_error("Klipper MQTT", err, message, message_size);
     }
-    // Prusa (PrusaLink) — handled inline (not in the shared planner). A blank API-key
-    // submission preserves the saved key; host/threshold/target overwrite when present.
-    dc_prusa_config_t pr = {0};
-    (void)dc_prusa_get_config(&pr);
-    bool prusa_changed = false;
-    if (request.pr_host.present) {
-        snprintf(pr.host, sizeof pr.host, "%s", request.pr_host.value ? request.pr_host.value : "");
-        prusa_changed = true;
-    }
-    if (request.pr_key.present && request.pr_key.value && request.pr_key.value[0]) {
-        snprintf(pr.api_key, sizeof pr.api_key, "%s", request.pr_key.value);
-        prusa_changed = true;
-    }
-    if (prusa_changed) {
-        err = dc_prusa_set_config(&pr);
+    if (plan.prusa_changed) {
+        err = dc_prusa_set_config(&plan.prusa);
         if (err != ESP_OK) return persistence_error("Prusa", err, message, message_size);
     }
 
@@ -525,7 +515,7 @@ static esp_err_t apply_product(const cJSON *values, void *ctx, char *message, si
     }
 
     bool changed = plan.moonraker_changed || plan.bambu_changed || plan.ha_changed ||
-                   plan.klipper_mqtt_changed || plan.source_changed || prusa_changed;
+                   plan.klipper_mqtt_changed || plan.prusa_changed || plan.source_changed;
     snprintf(message, message_size, changed
              ? "Configuration saved; restart to apply source changes."
              : "Configuration already up to date.");

--- a/components/db_portal/db_portal_config.c
+++ b/components/db_portal/db_portal_config.c
@@ -49,12 +49,13 @@ esp_err_t db_portal_plan_product_save(
     const dc_bambu_config_t *current_bambu,
     const pb_ha_config_t *current_ha,
     const db_km_config_t *current_klipper_mqtt,
+    const dc_prusa_config_t *current_prusa,
     db_portal_product_plan_t *plan,
     char *message,
     size_t message_size)
 {
     if (!request || !current_moonraker || !current_bambu || !current_ha ||
-        !current_klipper_mqtt || !plan || !message || !message_size)
+        !current_klipper_mqtt || !current_prusa || !plan || !message || !message_size)
         return ESP_ERR_INVALID_ARG;
     if (request->source_present &&
         (request->source < DC_SRC_KLIPPER || request->source >= DC_SRC_MAX))
@@ -70,6 +71,7 @@ esp_err_t db_portal_plan_product_save(
     plan->bambu = *current_bambu;
     plan->ha = *current_ha;
     plan->klipper_mqtt = *current_klipper_mqtt;
+    plan->prusa = *current_prusa;
 
     if (request->source_present && request->source != current_source) {
         plan->source = request->source;
@@ -108,6 +110,9 @@ esp_err_t db_portal_plan_product_save(
                &plan->klipper_mqtt_changed);
     stage_bool(&request->km_writeback, &plan->klipper_mqtt.writeback,
                &plan->klipper_mqtt_changed);
+
+    STAGE_TEXT(prusa, pr_host, host, false);
+    STAGE_TEXT(prusa, pr_key, api_key, true);
 
 #undef STAGE_TEXT
     message[0] = '\0';

--- a/components/db_portal/include/db_portal_config.h
+++ b/components/db_portal/include/db_portal_config.h
@@ -4,6 +4,7 @@
 #include "db_klipper_mqtt.h"
 #include "dc_bambu.h"
 #include "dc_moonraker.h"
+#include "dc_prusa.h"
 #include "dc_source.h"
 #include "pb_ha.h"
 
@@ -37,8 +38,7 @@ typedef struct {
     db_portal_text_value_t km_host, km_user, km_pass, km_inst, km_topic;
     db_portal_port_value_t km_port;
     db_portal_bool_value_t km_tls, km_writeback;
-    db_portal_text_value_t pr_host, pr_key;      // Prusa host + API key (handled inline
-                                                 // in apply_product, not the shared planner)
+    db_portal_text_value_t pr_host, pr_key;      // Prusa (PrusaLink) host + API key
 } db_portal_product_request_t;
 
 typedef struct {
@@ -47,11 +47,13 @@ typedef struct {
     dc_bambu_config_t bambu;
     pb_ha_config_t ha;
     db_km_config_t klipper_mqtt;
+    dc_prusa_config_t prusa;
     bool source_changed;
     bool moonraker_changed;
     bool bambu_changed;
     bool ha_changed;
     bool klipper_mqtt_changed;
+    bool prusa_changed;
 } db_portal_product_plan_t;
 
 // Build a complete, validated save plan without mutating runtime or NVS state.
@@ -63,6 +65,7 @@ esp_err_t db_portal_plan_product_save(
     const dc_bambu_config_t *current_bambu,
     const pb_ha_config_t *current_ha,
     const db_km_config_t *current_klipper_mqtt,
+    const dc_prusa_config_t *current_prusa,
     db_portal_product_plan_t *plan,
     char *message,
     size_t message_size);

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -2,36 +2,36 @@ dependencies:
   dc_prusa:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_prusa
-    version: v0.28.0
+    version: v0.28.1
   dc_evlog:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_evlog
-    version: v0.28.0
+    version: v0.28.1
   dc_source:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_source
-    version: v0.28.0
+    version: v0.28.1
   dc_bambu:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_bambu
-    version: v0.28.0
+    version: v0.28.1
   dc_wifi:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_wifi
-    version: v0.28.0
+    version: v0.28.1
   dc_moonraker:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_moonraker
-    version: v0.28.0
+    version: v0.28.1
   dc_ui:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_ui
-    version: v0.28.0
+    version: v0.28.1
   dc_mqtt:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_mqtt
-    version: v0.28.0
+    version: v0.28.1
   dc_portal:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_portal
-    version: v0.28.0
+    version: v0.28.1

--- a/tests/db_portal_config_host_test.c
+++ b/tests/db_portal_config_host_test.c
@@ -5,8 +5,12 @@
 #include <string.h>
 
 static void current_configs(dc_moonraker_config_t *mr, dc_bambu_config_t *bb,
-                            pb_ha_config_t *ha, db_km_config_t *km)
+                            pb_ha_config_t *ha, db_km_config_t *km,
+                            dc_prusa_config_t *pr)
 {
+    snprintf(pr->host, sizeof(pr->host), "prusa.lan");
+    pr->port = 80;
+    snprintf(pr->api_key, sizeof(pr->api_key), "prusa-secret");
     snprintf(mr->host, sizeof(mr->host), "moonraker.lan");
     mr->port = 7125;
     snprintf(mr->api_key, sizeof(mr->api_key), "moon-secret");
@@ -35,9 +39,10 @@ static esp_err_t plan(const db_portal_product_request_t *request,
     dc_bambu_config_t bb = {0};
     pb_ha_config_t ha = {0};
     db_km_config_t km = {0};
-    current_configs(&mr, &bb, &ha, &km);
+    dc_prusa_config_t pr = {0};
+    current_configs(&mr, &bb, &ha, &km, &pr);
     return db_portal_plan_product_save(request, DC_SRC_KLIPPER, &mr, &bb, &ha,
-                                       &km, out, message, size);
+                                       &km, &pr, out, message, size);
 }
 
 int main(void)
@@ -73,11 +78,12 @@ int main(void)
         .km_user = {true, "km-user"}, .km_pass = {true, ""},
         .km_inst = {true, "printer"}, .km_topic = {true, "dragonbreath"},
         .km_tls = {true, false}, .km_writeback = {true, true},
+        .pr_host = {true, "prusa.lan"}, .pr_key = {true, ""},
     };
     assert(plan(&unchanged, &result, message, sizeof(message)) == ESP_OK);
     assert(!result.source_changed && !result.moonraker_changed &&
            !result.bambu_changed && !result.ha_changed &&
-           !result.klipper_mqtt_changed);
+           !result.klipper_mqtt_changed && !result.prusa_changed);
 
     // Blank secrets retain credentials while ordinary changed fields are staged.
     db_portal_product_request_t changed = {
@@ -107,6 +113,34 @@ int main(void)
     assert(strcmp(result.bambu.code, "bambu-secret") == 0);
     assert(!result.moonraker_changed && !result.ha_changed &&
            !result.klipper_mqtt_changed && !result.source_changed);
+
+    // Prusa: a changed host is staged; a blank API key retains the stored password.
+    db_portal_product_request_t prusa_change = {
+        .pr_host = {true, "prusa-new.lan"},
+        .pr_key = {true, ""},
+    };
+    assert(plan(&prusa_change, &result, message, sizeof(message)) == ESP_OK);
+    assert(result.prusa_changed);
+    assert(strcmp(result.prusa.host, "prusa-new.lan") == 0);
+    assert(strcmp(result.prusa.api_key, "prusa-secret") == 0);
+    assert(!result.moonraker_changed && !result.bambu_changed &&
+           !result.ha_changed && !result.klipper_mqtt_changed &&
+           !result.source_changed);
+
+    // Prusa: a new API key overwrites; the host is left untouched.
+    db_portal_product_request_t prusa_key = {.pr_key = {true, "new-prusa-key"}};
+    assert(plan(&prusa_key, &result, message, sizeof(message)) == ESP_OK);
+    assert(result.prusa_changed);
+    assert(strcmp(result.prusa.api_key, "new-prusa-key") == 0);
+    assert(strcmp(result.prusa.host, "prusa.lan") == 0);
+
+    // Prusa: an overlong host is rejected in the planning phase (no silent truncation).
+    char pr_too_long[80];
+    memset(pr_too_long, 'p', sizeof(pr_too_long));
+    pr_too_long[sizeof(pr_too_long) - 1] = '\0';
+    db_portal_product_request_t prusa_invalid = {.pr_host = {true, pr_too_long}};
+    assert(plan(&prusa_invalid, &result, message, sizeof(message)) == ESP_ERR_INVALID_ARG);
+    assert(strstr(message, "pr_host") != NULL);
 
     // Validation fails in the pure planning phase, before any setter can run.
     char too_long[80];

--- a/tests/stubs/dc_prusa.h
+++ b/tests/stubs/dc_prusa.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <stdint.h>
+
+typedef struct {
+    char     host[64];
+    uint16_t port;
+    char     api_key[65];
+} dc_prusa_config_t;

--- a/tests/stubs/dc_source.h
+++ b/tests/stubs/dc_source.h
@@ -7,5 +7,6 @@ typedef enum {
     DC_SRC_HA = 2,
     DC_SRC_NONE = 3,
     DC_SRC_KLIPPER_MQTT = 4,
+    DC_SRC_PRUSA = 5,
     DC_SRC_MAX,
 } dc_ctl_source_t;


### PR DESCRIPTION
Addresses both items from @justinh-rahb's review of #86.

### P1 — stale bed target could keep the chamber heating (core, via re-pin)
Re-pins **dragon-core v0.28.0 → v0.28.1** ([dragon-core#48](https://github.com/justinh-rahb/dragon-core/pull/48)). `dc_prusa`'s parser now requires a **complete** `/api/v1/status` sample (finite `temp_bed` + `target_bed` + non-empty `state`) and commits it atomically. A partial body (e.g. `{"printer":{"state":"PRINTING"}}`) is rejected → source goes OFFLINE → `bed_target` zeroed → chamber disengages, instead of retaining the old target and continuing to heat.

### P2 — Prusa config bypassed validation & change detection (this PR)
The Prusa host/API-key were applied inline in `apply_product`, which (a) silently **truncated** overlong values via `snprintf` instead of rejecting them, and (b) marked Prusa "changed" whenever `pr_host` was present — so every full-SPA save rewrote NVS and reported "Configuration saved" even when nothing changed.

Now Prusa is staged through the shared `db_portal_plan_product_save()` like every other source:
- **bounds validation** — overlong host/key → `ESP_ERR_INVALID_ARG` (no truncation), before any setter runs;
- **change detection** — only marks changed on a real value difference, so an unchanged echo writes nothing;
- **blank API key preserves** the stored password.

Host-test coverage added: changed host staged, key overwrite (host untouched), unchanged full-SPA echo produces no write, and overlong host rejected. `run_db_portal_config_host_test.sh` + policy/buttons tests pass; clean ESP-IDF build against v0.28.1 links.

Ships as **v1.1.12**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)