### PR TITLE
bambu: add opt-in direct chamber temperature regulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ sdkconfig.old
 managed_components/
 dependencies.lock
 
+# Local firmware checkpoints
+firmware-checkpoints/
+
 # Editor / OS
 .vscode/
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,23 @@ below into the GitHub Release notes.
   disengages — and an incomplete/partial status response is treated as loss-of-source
   rather than heating on a stale bed target. Validated end-to-end by a Prusa user.
   Bumps **dragon-core** to **v0.28.1**.
+- **Bambu printer-chamber diagnostics.** `GET /api/v2/state` now exposes
+  `environment.printer_chamber_temperature_c` and `printer_chamber_age_ms`.
+  Stale or unavailable Bambu chamber samples are reported as `null`.
 
 ### Fixed
 - **Bambu chamber temperature no longer goes stale silently** — a chamber reading that
   stops updating over MQTT is now expired rather than held indefinitely (dragon-core #47).
+
+### Changed
+- **Bambu chamber regulation now follows the printer's chamber sensor** while keeping
+  DragonBreath's local chamber NTC and PTC safety-authoritative. External-sensor
+  regulation is bounded by a local chamber thermal limiter: heat cuts at **72 °C**
+  local and may resume below **67 °C**, while the independent hard chamber
+  over-temperature latch remains unchanged.
+- **Privacy:** `environment.bambu_serial` is no longer exposed by API v2 state
+  responses. The configured printer serial remains internal and is still used for
+  Bambu MQTT topic selection.
 
 ## [1.1.11] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,17 @@ below into the GitHub Release notes.
   DragonBreath's local chamber NTC and PTC safety-authoritative. External-sensor
   regulation is bounded by a local chamber thermal limiter: heat cuts at **72 °C**
   local and may resume below **67 °C**, while the independent hard chamber
-  over-temperature latch remains unchanged.
+  over-temperature latch remains unchanged. Direct printer-chamber regulation applies
+  only in **Auto**; **Manual** and **Drying** always regulate from DragonBreath's local
+  chamber NTC.
+- **External-regulation operating range:** hardware validation was performed at a
+  **60 °C** chamber target. Because the local soft limiter cuts at 72 °C, targets near
+  the configurable 65–70 °C ceiling may be limited before the printer's bulk chamber
+  sensor reaches setpoint, depending on heater/outlet temperature rise.
+- **Bambu model compatibility:** direct chamber regulation currently depends on the
+  legacy `chamber_temper` telemetry field. Bambu models that report chamber temperature
+  only through newer `device.ctc.info.temp` telemetry will safely fall back to local
+  NTC regulation until that source is supported by `dc_bambu`.
 - **Privacy:** `environment.bambu_serial` is no longer exposed by API v2 state
   responses. The configured printer serial remains internal and is still used for
   Bambu MQTT topic selection.

--- a/components/db_portal/db_portal.c
+++ b/components/db_portal/db_portal.c
@@ -22,6 +22,31 @@
 
 static const char *TAG = "db_portal";
 
+#define DB_NVS_NAMESPACE "app_nvs"
+#define DB_NVS_KEY_BAMBU_CHAMBER_CTL "bb_ch_ctl"
+
+static bool bambu_direct_chamber_control_get(void)
+{
+    uint8_t enabled = 0;   // opt-in: absent key means local DragonBreath regulation
+    nvs_handle_t h;
+    if (nvs_open(DB_NVS_NAMESPACE, NVS_READONLY, &h) == ESP_OK) {
+        (void)nvs_get_u8(h, DB_NVS_KEY_BAMBU_CHAMBER_CTL, &enabled);
+        nvs_close(h);
+    }
+    return enabled != 0;
+}
+
+static esp_err_t bambu_direct_chamber_control_set(bool enabled)
+{
+    nvs_handle_t h;
+    esp_err_t err = nvs_open(DB_NVS_NAMESPACE, NVS_READWRITE, &h);
+    if (err != ESP_OK) return err;
+    err = nvs_set_u8(h, DB_NVS_KEY_BAMBU_CHAMBER_CTL, enabled ? 1 : 0);
+    if (err == ESP_OK) err = nvs_commit(h);
+    nvs_close(h);
+    return err;
+}
+
 // A zero-length chunk terminates an ESP-IDF chunked response, so skip empty text.
 #define SEND(req, text) do { \
     const char *chunk_ = (text); \
@@ -264,9 +289,13 @@ static cJSON *describe_product(void *ctx)
     dc_bambu_get_config(&bb);
     s = section(root, "Bambu LAN");
     visible_when(s, "ctl_src", "1");
+    cJSON_AddStringToObject(s, "description",
+        "Experimental: when enabled, DragonBreath regulates from the printer-reported chamber temperature. The local chamber NTC and PTC remain authoritative for thermal limits, sensor faults, and emergency shutdown.");
     add_field(s, field("bb_host", "Printer host", "text", bb.host, false));
     add_field(s, field("bb_serial", "Serial", "text", bb.serial, false));
     add_field(s, field("bb_code", "Access code (leave blank to keep)", "password", "", true));
+    add_field(s, boolean_field("bb_chamber_ctl", "Use Bambu chamber sensor for heater control",
+                               bambu_direct_chamber_control_get()));
     // LAN discovery: the shared SPA renders a Search picker from this block and
     // fills bb_host + bb_serial, so the user only enters the access code. This MUST
     // stay attached to the Bambu section's `s` — keep it before the next section().
@@ -481,6 +510,14 @@ static esp_err_t apply_product(const cJSON *values, void *ctx, char *message, si
     db_portal_product_request_t request;
     err = parse_product_request(values, &request, message, message_size);
     if (err != ESP_OK) return err;
+    db_portal_bool_value_t bb_chamber_ctl = {0};
+    err = parse_bool_field(values, "bb_chamber_ctl", &bb_chamber_ctl,
+                           message, message_size);
+    if (err != ESP_OK) return err;
+    bool bb_chamber_ctl_changed =
+        bb_chamber_ctl.present &&
+        bb_chamber_ctl.value != bambu_direct_chamber_control_get();
+
     db_portal_product_plan_t plan;
     err = db_portal_plan_product_save(&request, dc_source_get(), &mr, &bb, &ha, &km, &pr,
                                       &plan, message, message_size);
@@ -506,7 +543,11 @@ static esp_err_t apply_product(const cJSON *values, void *ctx, char *message, si
         err = dc_prusa_set_config(&plan.prusa);
         if (err != ESP_OK) return persistence_error("Prusa", err, message, message_size);
     }
-
+    if (bb_chamber_ctl_changed) {
+        err = bambu_direct_chamber_control_set(bb_chamber_ctl.value);
+        if (err != ESP_OK)
+            return persistence_error("Bambu chamber control", err, message, message_size);
+    }
     // Source is deliberately last: an invalid or failed config save can never bind
     // a different controller. Selecting None changes only this enum; credentials stay.
     if (plan.source_changed) {
@@ -515,9 +556,10 @@ static esp_err_t apply_product(const cJSON *values, void *ctx, char *message, si
     }
 
     bool changed = plan.moonraker_changed || plan.bambu_changed || plan.ha_changed ||
-                   plan.klipper_mqtt_changed || plan.prusa_changed || plan.source_changed;
+                   plan.klipper_mqtt_changed || plan.prusa_changed ||
+                   plan.source_changed || bb_chamber_ctl_changed;
     snprintf(message, message_size, changed
-             ? "Configuration saved; restart to apply source changes."
+             ? "Configuration saved; restart to apply source/control changes."
              : "Configuration already up to date.");
     return ESP_OK;
 }

--- a/components/pb_heater/include/pb_heater.h
+++ b/components/pb_heater/include/pb_heater.h
@@ -67,6 +67,26 @@ static inline bool pb_heater_fault_decide(bool open_ok, bool ns_not_found,
 #define PB_HEATER_PTC_CUTOFF_C   105.0f   // element over-temp -> force off (stock parity)
 #define PB_HEATER_CHAMBER_MAX_C  85.0f    // chamber over-temp -> force off
 #define PB_HEATER_HYSTERESIS_C   1.0f
+
+// When regulation uses a remote/printer chamber sensor, the local chamber NTC can
+// be much hotter because it sits in DragonBreath's outlet/near-heater airflow. Keep
+// that local region below a non-latching SOFT ceiling instead of relying on the 85 C
+// emergency trip as normal control. This limiter applies only while an external
+// control temperature is active; local-sensor regulation is unchanged.
+#define PB_HEATER_LOCAL_FOLDBACK_CUT_C     72.0f
+#define PB_HEATER_LOCAL_FOLDBACK_RESUME_C  67.0f
+
+// Pure hysteresis helper for the local thermal limiter. A bad local read holds the
+// previous state; the fail-closed sensor-fault path in pb_heater_eval_trip() remains
+// authoritative while armed.
+static inline bool pb_heater_local_foldback_cut(bool chamber_ok, float chamber_c,
+                                                 bool prev_cut)
+{
+    if (!chamber_ok) return prev_cut;
+    if (chamber_c >= PB_HEATER_LOCAL_FOLDBACK_CUT_C) return true;
+    if (chamber_c < PB_HEATER_LOCAL_FOLDBACK_RESUME_C) return false;
+    return prev_cut;
+}
 // Soft element-temperature FOLDBACK, a layer strictly BELOW the hard cutoff: it holds
 // the PTC element just under the 105 C trip so a marginal/hot install can reach set-point
 // instead of tripping and needing a manual clear. It never adds heat and never delays the

--- a/components/pb_heater/include/pb_heater.h
+++ b/components/pb_heater/include/pb_heater.h
@@ -194,6 +194,12 @@ esp_err_t pb_heater_init(void);
 esp_err_t pb_heater_set_target_c(float target_c);
 float pb_heater_get_target_c(void);
 
+// Optional external chamber measurement used ONLY for set-point regulation.
+// Pass NAN to fall back to the local chamber NTC. The local chamber NTC and PTC
+// remain authoritative for over-temperature trips, sensor-fault detection, and
+// all other safety decisions regardless of this value.
+void pb_heater_set_control_chamber_c(float temp_c);
+
 // --- Runtime-configurable, persisted settings (pb_heater is the sole owner) ---
 // Load persisted settings from NVS (namespace app_nvs). MUST be called AFTER
 // nvs_init() — pb_heater_init() only sets conservative defaults (nvs isn't up
@@ -231,8 +237,10 @@ float     pb_heater_get_fb_cut_c(void);
 // pb_heater_get_comms_timeout_ms() while heating, the heater latches off.
 void pb_heater_notify_link_alive(void);
 
-// Periodic control tick (call at ~1-2 Hz). Reads chamber + PTC temps, enforces
-// all safety cutoffs, and drives the SSR with hysteresis around the set-point.
+// Periodic control tick (call at ~1-2 Hz). Reads the local chamber + PTC temps,
+// enforces all safety cutoffs from those local sensors, and drives the SSR with
+// hysteresis around the set-point using the optional external regulation
+// temperature when one is supplied.
 void pb_heater_tick(void);
 
 // Immediate, latching shutoff. Clears the target and latches off. Heat stays off

--- a/components/pb_heater/pb_heater.c
+++ b/components/pb_heater/pb_heater.c
@@ -25,6 +25,7 @@ static SemaphoreHandle_t s_persist_lock;
 static portMUX_TYPE s_mux = portMUX_INITIALIZER_UNLOCKED;
 
 static float       s_target_c;      // guarded by s_mux
+static float       s_control_chamber_c; // guarded by s_mux; optional external regulation temp
 static bool        s_latched_off;   // guarded by s_mux (set by a safety trip)
 static bool        s_inhibited;     // guarded by s_mux (PERMANENT; reboot-only)
 static int64_t     s_last_link_us;  // guarded by s_mux
@@ -111,6 +112,7 @@ esp_err_t pb_heater_init(void)
     ssr_set(false);                  // guaranteed OFF before any request
     taskENTER_CRITICAL(&s_mux);
     s_target_c = 0.0f;
+    s_control_chamber_c = NAN;
     s_latched_off = false;
     s_fault_reason = NULL;
     s_fault_code = PB_FAULT_NONE;
@@ -161,6 +163,13 @@ float pb_heater_get_target_c(void)
     float t = s_target_c;
     taskEXIT_CRITICAL(&s_mux);
     return t;
+}
+
+void pb_heater_set_control_chamber_c(float temp_c)
+{
+    taskENTER_CRITICAL(&s_mux);
+    s_control_chamber_c = isfinite(temp_c) ? temp_c : NAN;
+    taskEXIT_CRITICAL(&s_mux);
 }
 
 void pb_heater_load_config(void)
@@ -529,11 +538,13 @@ void pb_heater_tick(void)          // control-task context; sole writer of s_on
     }
 
     float   target;
+    float   control_chamber_c;
     bool    latched;
     int64_t last_link;
     int64_t comms_timeout_us;
     taskENTER_CRITICAL(&s_mux);
     target = s_target_c;
+    control_chamber_c = s_control_chamber_c;
     latched = s_latched_off;
     last_link = s_last_link_us;
     comms_timeout_us = s_comms_timeout_us;
@@ -570,11 +581,13 @@ void pb_heater_tick(void)          // control-task context; sole writer of s_on
 
     // Here: armed && !latched && cs==OK && ps==OK.
     // Step 1 — chamber bang-bang with hysteresis decides the BASE demand (do we want
-    // heat at all). s_heat_intent holds across the hysteresis band; it is the steady
-    // "want heat" latch, distinct from the momentary SSR state s_on.
-    if (chamber_c < (target - PB_HEATER_HYSTERESIS_C)) {
+    // heat at all). If policy supplied a finite external control temperature (for
+    // example the printer-reported chamber sensor), use it ONLY for regulation.
+    // The local chamber NTC above remains authoritative for every safety trip.
+    float regulation_c = isfinite(control_chamber_c) ? control_chamber_c : chamber_c;
+    if (regulation_c < (target - PB_HEATER_HYSTERESIS_C)) {
         s_heat_intent = true;
-    } else if (chamber_c >= target) {
+    } else if (regulation_c >= target) {
         s_heat_intent = false;
     }
 

--- a/components/pb_heater/pb_heater.c
+++ b/components/pb_heater/pb_heater.c
@@ -41,6 +41,8 @@ static bool        s_heat_intent;   // control-task only — chamber-hysteresis 
 static bool        s_fb_cut;        // control-task only — element-foldback hysteresis latch:
                                     // true while the SSR is force-cut for element over-temp
                                     // (holds until the element cools below the resume point)
+static bool        s_local_cut;     // control-task only — local chamber soft-limit latch used
+                                    // only while a remote chamber temperature controls regulation
 static float       s_max_target_c;      // guarded by s_mux — settable set-point ceiling
 static int64_t     s_comms_timeout_us;  // guarded by s_mux — comms deadman (microseconds)
 static float       s_cool_release_c;    // guarded by s_mux — residual-heat purge "cool down to" temp
@@ -576,6 +578,7 @@ void pb_heater_tick(void)          // control-task context; sole writer of s_on
         if (s_on) ssr_set(false);
         s_heat_intent = false;   // drop the chamber + foldback latches so the next arm
         s_fb_cut      = false;   // starts clean rather than mid-cycle
+        s_local_cut   = false;
         return;
     }
 
@@ -591,7 +594,18 @@ void pb_heater_tick(void)          // control-task context; sole writer of s_on
         s_heat_intent = false;
     }
 
-    // Step 2 — element-temperature foldback (hysteresis hard-cut). While the PTC element
+    // Step 2 — local chamber soft foldback for REMOTE regulation. The printer sensor
+    // represents bulk chamber air, while DragonBreath's local chamber NTC can see much
+    // hotter outlet/near-heater air. When an external control temperature is active, cut
+    // heat at the local soft ceiling and hold it off until the local region cools through
+    // the resume threshold. The fixed 85 C chamber trip above remains the latching backstop.
+    bool external_regulation = isfinite(control_chamber_c);
+    if (external_regulation)
+        s_local_cut = pb_heater_local_foldback_cut(cs == PB_NTC_OK, chamber_c, s_local_cut);
+    else
+        s_local_cut = false;
+
+    // Step 3 — element-temperature foldback (hysteresis hard-cut). While the PTC element
     // is too hot we force the SSR fully OFF and hold it off until the element cools below
     // the resume point — a real cool-down cycle rather than half-power hovering near the
     // 105 C hard cutoff. Thresholds are per board Rref variant (33k boards run hotter, so
@@ -600,8 +614,8 @@ void pb_heater_tick(void)          // control-task context; sole writer of s_on
     pb_heater_effective_foldback(pb_heater_get_fb_cut_c(), pb_ntc_rref_kohm(), &fb_cut, &fb_resume);
     s_fb_cut = pb_heater_foldback_cut(ps == PB_NTC_OK, ptc_c, s_fb_cut, fb_cut, fb_resume);
 
-    // Step 3 — drive the SSR: heat only when the chamber wants it AND the element is not
-    // in foldback cut. (Zero-cross SSR: plain on/off, no phase-cut.)
-    bool drive = s_heat_intent && !s_fb_cut;
+    // Step 4 — drive the SSR only when regulation wants heat and neither soft limiter
+    // is holding it off. (Zero-cross SSR: plain on/off, no phase-cut.)
+    bool drive = s_heat_intent && !s_local_cut && !s_fb_cut;
     if (drive != s_on) ssr_set(drive);
 }

--- a/components/pb_hil/pb_hil.c
+++ b/components/pb_hil/pb_hil.c
@@ -292,22 +292,38 @@ static void handle_request(const cJSON *request)
     } else if (strcmp(cmd->valuestring, "env") == 0) {
         const cJSON *connected =
             cJSON_GetObjectItemCaseSensitive(request, "connected");
+
         double bed_c = 0.0;
         if (!cJSON_IsBool(connected) || !json_number(request, "bed_c", &bed_c)) {
             response_error(response, "invalid_env");
             emit(response);
             return;
         }
+
         // bed_target_c is the AUTO/filter trigger (bed setpoint); optional, so a
         // harness that only injects bed_c still works (defaults to bed_c so the old
         // "measured == trigger" behavior is preserved for existing HIL scenarios).
         double bed_target_c = bed_c;
         json_number(request, "bed_target_c", &bed_target_c);
+
         // src_target_c: optional source-requested chamber target (Bambu filament zone);
         // absent -> 0 (normal bed-AUTO), so existing scenarios are unchanged.
         double src_target_c = 0.0;
         json_number(request, "src_target_c", &src_target_c);
-        pb_policy_set_env((float)bed_c, (float)bed_target_c, cJSON_IsTrue(connected), (float)src_target_c);
+
+        // chamber_src_c: optional printer-reported chamber temperature.
+        // Absent -> NAN, preserving existing HIL behaviour.
+        double chamber_src_c = NAN;
+        json_number(request, "chamber_src_c", &chamber_src_c);
+
+        pb_policy_set_env(
+            (float)bed_c,
+            (float)bed_target_c,
+            cJSON_IsTrue(connected),
+            (float)src_target_c,
+            (float)chamber_src_c
+        );
+
         cJSON_AddBoolToObject(response, "ok", true);
     } else if (strcmp(cmd->valuestring, "zero_cross") == 0) {
         double count = 1.0;

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -161,12 +161,8 @@ static cJSON *state_json(const pb_policy_snapshot_t *s)
     // Source capability: filament-aware (AUTO follows the filament zone) vs bed-follow
     // (AUTO follows the bed setpoint). The dashboard's AUTO card keys off this.
     cJSON_AddBoolToObject(environment, "source_has_filament", dc_source_has_filament(ctl_src));
-    // In Bambu mode, surface the configured serial so the dashboard can label the
-    // row "Bambu (<serial>)" — the LAN report carries no friendly printer name.
+
     if (ctl_src == DC_SRC_BAMBU) {
-        dc_bambu_config_t bc;
-        if (dc_bambu_get_config(&bc) == ESP_OK && bc.serial[0])
-            cJSON_AddStringToObject(environment, "bambu_serial", bc.serial);
         // Surface the active print's filament so the dashboard status card can show
         // "Filament: PETG" while a Bambu print runs (Bambu-only; Klipper drives the
         // chamber via macros and reports no filament here).

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -175,6 +175,17 @@ static cJSON *state_json(const pb_policy_snapshot_t *s)
             cJSON_AddBoolToObject(environment, "bambu_printing", bs.printing);
             if (bs.printing && bs.filament[0])
                 cJSON_AddStringToObject(environment, "bambu_filament", bs.filament);
+
+            // Diagnostic view of the printer's own chamber sensor. dc_bambu
+            // invalidates chamber_temp when its sample is stale, so the API emits
+            // JSON null rather than letting an old value masquerade as live data.
+            // The local DragonBreath NTC/PTC remain the safety-authoritative sensors.
+            add_num1(environment, "printer_chamber_temperature_c", bs.chamber_temp);
+            if (bs.chamber_temp_age_ms == UINT32_MAX)
+                cJSON_AddNullToObject(environment, "printer_chamber_age_ms");
+            else
+                cJSON_AddNumberToObject(environment, "printer_chamber_age_ms",
+                                        bs.chamber_temp_age_ms);
         }
     } else if (ctl_src == DC_SRC_KLIPPER) {
         // Klipper now follows filament zones too: surface Moonraker's active-print

--- a/components/pb_policy/include/pb_policy.h
+++ b/components/pb_policy/include/pb_policy.h
@@ -184,7 +184,17 @@ bool  pb_policy_get_filter_auto_enable(void);
 // zone while a print is active): when > 0 in AUTO mode it engages heat to that target
 // directly, overriding the configured AUTO target and bypassing the bed threshold
 // ("zone wins"). Pass 0 for the normal bed-threshold AUTO behaviour.
-void pb_policy_set_env(float bed_c, float bed_target_c, bool source_connected, float src_target_c);
+//
+// chamber_src_c is an optional printer-reported chamber temperature used as
+// observer state. Pass NAN when unavailable. It does not affect heater control
+// until explicitly selected by policy.
+void pb_policy_set_env(
+    float bed_c,
+    float bed_target_c,
+    bool source_connected,
+    float src_target_c,
+    float chamber_src_c
+);
 
 // Refresh exactly the active lease.  A stale/superseded lease cannot keep heat
 // alive.

--- a/components/pb_policy/include/pb_policy.h
+++ b/components/pb_policy/include/pb_policy.h
@@ -185,9 +185,10 @@ bool  pb_policy_get_filter_auto_enable(void);
 // directly, overriding the configured AUTO target and bypassing the bed threshold
 // ("zone wins"). Pass 0 for the normal bed-threshold AUTO behaviour.
 //
-// chamber_src_c is an optional printer-reported chamber temperature used as
-// observer state. Pass NAN when unavailable. It does not affect heater control
-// until explicitly selected by policy.
+// chamber_src_c is an optional printer-reported chamber temperature. Pass NAN
+// when unavailable. While the source is live, policy supplies a finite value to
+// pb_heater for set-point regulation; the local chamber NTC and PTC remain
+// authoritative for safety.
 void pb_policy_set_env(
     float bed_c,
     float bed_target_c,

--- a/components/pb_policy/pb_policy.c
+++ b/components/pb_policy/pb_policy.c
@@ -83,6 +83,8 @@ typedef struct {
     float src_target_c;          // source-requested chamber target (e.g. Bambu filament
                                  // zone); 0 = none. When >0 in AUTO it engages heat to
                                  // this target directly, bypassing the bed threshold.
+    float chamber_src_c;         // printer-reported chamber temperature;
+                                 // NAN = unavailable, observer-only for now
 
     int64_t drying_deadline_us;
     int64_t local_power_deadline_us;
@@ -674,18 +676,31 @@ void pb_policy_stop_drying(db_source_t source)
     pb_policy_set_mode_off(source);
 }
 
-void pb_policy_set_env(float bed_c, float bed_target_c, bool source_connected, float src_target_c)
+void pb_policy_set_env(
+    float bed_c,
+    float bed_target_c,
+    bool source_connected,
+    float src_target_c,
+    float chamber_src_c)
 {
     if (!s_lock) return;
+
     // Clamp the source-requested target to the settable ceiling; the fixed heater
     // cutoffs (chamber/element over-temp) still protect regardless.
-    if (!isfinite(src_target_c) || src_target_c < 0.0f) src_target_c = 0.0f;
-    if (src_target_c > PB_HEATER_ABS_MAX_TARGET_C) src_target_c = PB_HEATER_ABS_MAX_TARGET_C;
+    if (!isfinite(src_target_c) || src_target_c < 0.0f)
+        src_target_c = 0.0f;
+
+    if (src_target_c > PB_HEATER_ABS_MAX_TARGET_C)
+        src_target_c = PB_HEATER_ABS_MAX_TARGET_C;
+
     xSemaphoreTake(s_lock, portMAX_DELAY);
+
     s.bed_c = isfinite(bed_c) ? bed_c : 0.0f;
     s.bed_target_c = isfinite(bed_target_c) ? bed_target_c : 0.0f;
     s.mk_connected = source_connected;
     s.src_target_c = src_target_c;
+    s.chamber_src_c = isfinite(chamber_src_c) ? chamber_src_c : NAN;
+
     xSemaphoreGive(s_lock);
 }
 

--- a/components/pb_policy/pb_policy.c
+++ b/components/pb_policy/pb_policy.c
@@ -1013,8 +1013,12 @@ void pb_policy_tick(void)
             pb_heater_notify_link_alive();
     }
 
+    // Printer-reported chamber temperature is an AUTO-follow input only.
+    // Manual and Drying are local device modes and must regulate from the
+    // DragonBreath chamber NTC even when Bambu telemetry is connected/fresh.
     float control_chamber_c =
-        (s.mk_connected && isfinite(s.chamber_src_c))
+        (s.mode == PB_MODE_AUTO &&
+         s.mk_connected && isfinite(s.chamber_src_c))
             ? s.chamber_src_c
             : NAN;
 

--- a/components/pb_policy/pb_policy.c
+++ b/components/pb_policy/pb_policy.c
@@ -84,7 +84,8 @@ typedef struct {
                                  // zone); 0 = none. When >0 in AUTO it engages heat to
                                  // this target directly, bypassing the bed threshold.
     float chamber_src_c;         // printer-reported chamber temperature;
-                                 // NAN = unavailable, observer-only for now
+                                 // NAN = unavailable; used for regulation when
+                                 // the external source is live
 
     int64_t drying_deadline_us;
     int64_t local_power_deadline_us;
@@ -1012,6 +1013,12 @@ void pb_policy_tick(void)
             pb_heater_notify_link_alive();
     }
 
+    float control_chamber_c =
+        (s.mk_connected && isfinite(s.chamber_src_c))
+            ? s.chamber_src_c
+            : NAN;
+
+    pb_heater_set_control_chamber_c(control_chamber_c);
     pb_heater_tick();
 
     bool heat = pb_heater_heat_mode();

--- a/docs/api-v2.md
+++ b/docs/api-v2.md
@@ -70,7 +70,12 @@ The complete snapshot, not locally remembered intent, is the source of truth:
     "ptc": {"temperature_c": 73.1, "status": "ok"}
   },
   "environment": {
-    "control_source": "klipper",
+    "control_source": "bambu",
+    "bambu_serial": "00M00A000000000",
+    "bambu_printing": true,
+    "bambu_filament": "ASA",
+    "printer_chamber_temperature_c": 42.3,
+    "printer_chamber_age_ms": 380,
     "moonraker_connected": true,
     "bed_temperature_c": 100.0,
     "bed_target_c": 100.0,
@@ -116,6 +121,12 @@ the last actor that changed state). In `bambu` mode the environment also carries
 `bambu_serial`. `environment.bed_target_c` is the **commanded** bed setpoint from that
 source; it (not the measured `bed_temperature_c`) drives the AUTO heat-engage and the
 fan-only filtration band.
+
+When the active source is Bambu, `printer_chamber_temperature_c` exposes the printer's
+own chamber sensor for diagnostics. It is `null` when that sample is unavailable or has
+aged out in `dc_bambu`; `printer_chamber_age_ms` is likewise `null` when no usable sample
+exists. These fields are observational only at the API boundary: heater safety still uses
+DragonBreath's local chamber NTC and PTC sensors.
 
 `fan.reason` is one of: `off`, `heater` (airflow while heating), `thermal_purge`
 (residual-heat cooldown purge), `auto_filter` (the fan-only filtration band),

--- a/docs/api-v2.md
+++ b/docs/api-v2.md
@@ -71,7 +71,6 @@ The complete snapshot, not locally remembered intent, is the source of truth:
   },
   "environment": {
     "control_source": "bambu",
-    "bambu_serial": "00M00A000000000",
     "bambu_printing": true,
     "bambu_filament": "ASA",
     "printer_chamber_temperature_c": 42.3,
@@ -117,16 +116,18 @@ increment it.
 
 `environment.control_source` is the configured control binding — `klipper`,
 `bambu`, or `ha` — chosen on `/setup` (distinct from the top-level `source`, which is
-the last actor that changed state). In `bambu` mode the environment also carries
-`bambu_serial`. `environment.bed_target_c` is the **commanded** bed setpoint from that
-source; it (not the measured `bed_temperature_c`) drives the AUTO heat-engage and the
-fan-only filtration band.
+the last actor that changed state). The printer's configured Bambu serial is intentionally
+not exposed by the public state API; it remains internal to the Bambu MQTT connection.
+`environment.bed_target_c` is the **commanded** bed setpoint from the active source and
+drives the fan-only filtration band.
 
 When the active source is Bambu, `printer_chamber_temperature_c` exposes the printer's
-own chamber sensor for diagnostics. It is `null` when that sample is unavailable or has
-aged out in `dc_bambu`; `printer_chamber_age_ms` is likewise `null` when no usable sample
-exists. These fields are observational only at the API boundary: heater safety still uses
-DragonBreath's local chamber NTC and PTC sensors.
+own chamber sensor used for chamber set-point regulation. It is `null` when that sample is
+unavailable or has aged out in `dc_bambu`; `printer_chamber_age_ms` is likewise `null`
+when no usable sample exists. The API fields are read-only diagnostics. DragonBreath's
+local chamber NTC and PTC remain safety-authoritative; external-sensor regulation is also
+bounded by the local chamber thermal limiter before the independent hard over-temperature
+cutoff.
 
 `fan.reason` is one of: `off`, `heater` (airflow while heating), `thermal_purge`
 (residual-heat cooldown purge), `auto_filter` (the fan-only filtration band),

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -206,8 +206,9 @@ static void control_task(void *arg)
 
         // Feed the AUTO seam from whichever ONE source is bound.
         // All paths converge on pb_policy_set_env(); the policy remains
-        // source-agnostic. Printer-reported chamber temperature is passed
-        // as observer state only and does not affect heater control yet.
+        // source-agnostic. Printer-reported chamber temperature is passed through
+        // for set-point regulation when available; DragonBreath's local sensors
+        // remain authoritative for heater safety.
         float bed_c = 0.0f;
         float bed_target_c = 0.0f;
         float src_target_c = 0.0f;

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -203,26 +203,43 @@ static void control_task(void *arg)
     for (;;) {
         dc_moonraker_status_t st = {0};
 #ifndef CONFIG_PB_HIL_DEVBOARD
-        // Feed the AUTO seam from whichever ONE source is bound. All three paths
-        // converge on pb_policy_set_env(bed_c, bed_target_c, connected); the policy
-        // is source-agnostic and triggers AUTO on the bed SETPOINT (bed_target_c).
-        // Not-connected feeds zeros/false (identical to the pre-selector behavior
-        // when Moonraker was down).
-        float bed_c = 0.0f, bed_target_c = 0.0f, src_target_c = 0.0f;
+
+        // Feed the AUTO seam from whichever ONE source is bound.
+        // All paths converge on pb_policy_set_env(); the policy remains
+        // source-agnostic. Printer-reported chamber temperature is passed
+        // as observer state only and does not affect heater control yet.
+        float bed_c = 0.0f;
+        float bed_target_c = 0.0f;
+        float src_target_c = 0.0f;
+        float chamber_src_c = NAN;
         bool  src_connected = false;
+
         if (s_net_up) {
             switch (s_src) {
+
             case DC_SRC_BAMBU:
                 if (s_bambu_up) {
                     dc_bambu_status_t bs;
                     dc_bambu_get_status(&bs);
+
                     src_connected = (bs.state == DC_BAMBU_SUBSCRIBED);
+
                     if (src_connected) {
-                        if (isfinite(bs.bed_temp))   bed_c = bs.bed_temp;
-                        if (isfinite(bs.bed_target)) bed_target_c = bs.bed_target;
-                        // Filament chamber zone: while a print is active, request the
-                        // active filament's zone target (0 = no zone -> normal bed-AUTO).
-                        if (bs.printing) src_target_c = (float)dc_bambu_zone_target(bs.filament);
+                        if (isfinite(bs.bed_temp))
+                            bed_c = bs.bed_temp;
+
+                        if (isfinite(bs.bed_target))
+                            bed_target_c = bs.bed_target;
+
+                        if (isfinite(bs.chamber_temp))
+                            chamber_src_c = bs.chamber_temp;
+
+                        // Filament chamber zone: while a print is active,
+                        // request the active filament's zone target
+                        // (0 = no zone -> normal bed-AUTO).
+                        if (bs.printing)
+                            src_target_c =
+                                (float)dc_bambu_zone_target(bs.filament);
                     }
                 }
                 break;
@@ -277,7 +294,13 @@ static void control_task(void *arg)
                 break;
             }
         }
-        pb_policy_set_env(bed_c, bed_target_c, src_connected, src_target_c);
+        pb_policy_set_env(
+            bed_c,
+            bed_target_c,
+            src_connected,
+            src_target_c,
+            chamber_src_c
+        );
         // Home Assistant: pump the client whenever it's up — full-control when HA is
         // the selected source, or read-only when it runs alongside another source
         // (Bambu/Klipper) as a monitor. pb_ha_tick() no-ops until connected.

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -201,7 +201,11 @@ static void control_task(void *arg)
     }
 
     for (;;) {
+        // Keep source-specific snapshots alive through the status logger below.
+        // Previously only the Moonraker snapshot survived that far, so Bambu mode
+        // misleadingly rendered zero-initialized Moonraker diagnostics.
         dc_moonraker_status_t st = {0};
+        dc_bambu_status_t bs = {0};
 #ifndef CONFIG_PB_HIL_DEVBOARD
 
         // Feed the AUTO seam from whichever ONE source is bound.
@@ -220,7 +224,6 @@ static void control_task(void *arg)
 
             case DC_SRC_BAMBU:
                 if (s_bambu_up) {
-                    dc_bambu_status_t bs;
                     dc_bambu_get_status(&bs);
 
                     src_connected = (bs.state == DC_BAMBU_SUBSCRIBED);
@@ -330,29 +333,51 @@ static void control_task(void *arg)
             static char     s_dbg_last[224];
             static uint32_t s_dbg_rep;
             int wifi = net ? (int)dc_wifi_state() : -1;
-            // Displayed line: 0.1 °C precision.
+            // Displayed line: 0.1 °C precision. Keep diagnostics source-native:
+            // Bambu must never be rendered through a zeroed Moonraker struct.
             char line[224];
-            snprintf(line, sizeof line,
-                "rev=%lu mode=%s source=%s target=%.0fC heater=%s | chamber=%.1fC ptc=%.1fC | "
-                "wifi=%d src=%s mk=%d printer=%s bed=%.1f",
-                (unsigned long)snap.state_revision,
-                pb_policy_mode_str(snap.mode), pb_policy_source_str(snap.source),
-                snap.effective_target_c, snap.heater_output ? "ON" : "off",
-                snap.chamber_c, snap.ptc_c,
-                wifi, dc_source_str(s_src), (int)st.state,
-                dc_printer_state_str(st.printer), st.bed_temp);
-            // Dedup key: same fields but temps rounded to whole degrees, so sub-degree
-            // sensor drift/jitter doesn't re-trigger a fresh line every 2 s.
             char key[224];
-            snprintf(key, sizeof key,
-                "rev=%lu mode=%s source=%s target=%.0fC heater=%s | chamber=%.0fC ptc=%.0fC | "
-                "wifi=%d src=%s mk=%d printer=%s bed=%.0f",
-                (unsigned long)snap.state_revision,
-                pb_policy_mode_str(snap.mode), pb_policy_source_str(snap.source),
-                snap.effective_target_c, snap.heater_output ? "ON" : "off",
-                snap.chamber_c, snap.ptc_c,
-                wifi, dc_source_str(s_src), (int)st.state,
-                dc_printer_state_str(st.printer), st.bed_temp);
+            if (s_src == DC_SRC_BAMBU) {
+                const char *filament = bs.filament[0] ? bs.filament : "-";
+                snprintf(line, sizeof line,
+                    "rev=%lu mode=%s source=%s target=%.0fC heater=%s | chamber=%.1fC ptc=%.1fC | "
+                    "wifi=%d src=bambu link=%d print=%s filament=%s bed=%.1f/%.1f chsrc=%.1f",
+                    (unsigned long)snap.state_revision,
+                    pb_policy_mode_str(snap.mode), pb_policy_source_str(snap.source),
+                    snap.effective_target_c, snap.heater_output ? "ON" : "off",
+                    snap.chamber_c, snap.ptc_c,
+                    wifi, (int)bs.state, bs.printing ? "yes" : "no", filament,
+                    bs.bed_temp, bs.bed_target, bs.chamber_temp);
+                // Dedup key: same fields but temps rounded to whole degrees.
+                snprintf(key, sizeof key,
+                    "rev=%lu mode=%s source=%s target=%.0fC heater=%s | chamber=%.0fC ptc=%.0fC | "
+                    "wifi=%d src=bambu link=%d print=%s filament=%s bed=%.0f/%.0f chsrc=%.0f",
+                    (unsigned long)snap.state_revision,
+                    pb_policy_mode_str(snap.mode), pb_policy_source_str(snap.source),
+                    snap.effective_target_c, snap.heater_output ? "ON" : "off",
+                    snap.chamber_c, snap.ptc_c,
+                    wifi, (int)bs.state, bs.printing ? "yes" : "no", filament,
+                    bs.bed_temp, bs.bed_target, bs.chamber_temp);
+            } else {
+                snprintf(line, sizeof line,
+                    "rev=%lu mode=%s source=%s target=%.0fC heater=%s | chamber=%.1fC ptc=%.1fC | "
+                    "wifi=%d src=%s mk=%d printer=%s bed=%.1f",
+                    (unsigned long)snap.state_revision,
+                    pb_policy_mode_str(snap.mode), pb_policy_source_str(snap.source),
+                    snap.effective_target_c, snap.heater_output ? "ON" : "off",
+                    snap.chamber_c, snap.ptc_c,
+                    wifi, dc_source_str(s_src), (int)st.state,
+                    dc_printer_state_str(st.printer), st.bed_temp);
+                snprintf(key, sizeof key,
+                    "rev=%lu mode=%s source=%s target=%.0fC heater=%s | chamber=%.0fC ptc=%.0fC | "
+                    "wifi=%d src=%s mk=%d printer=%s bed=%.0f",
+                    (unsigned long)snap.state_revision,
+                    pb_policy_mode_str(snap.mode), pb_policy_source_str(snap.source),
+                    snap.effective_target_c, snap.heater_output ? "ON" : "off",
+                    snap.chamber_c, snap.ptc_c,
+                    wifi, dc_source_str(s_src), (int)st.state,
+                    dc_printer_state_str(st.printer), st.bed_temp);
+            }
 
             if (strcmp(key, s_dbg_last) == 0) {
                 s_dbg_rep++;

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -57,6 +57,8 @@
 static const char *TAG = "dragonbreath";
 
 #define PB_TICK_PERIOD_MS 500
+#define DB_NVS_NAMESPACE "app_nvs"
+#define DB_NVS_KEY_BAMBU_CHAMBER_CTL "bb_ch_ctl"
 
 // Set true once the network components have been started, so the control loop
 // doesn't touch pb_* state before it's initialized.
@@ -71,6 +73,10 @@ static volatile bool s_km_up    = false;   // Klipper (MQTT)
 static volatile bool s_prusa_up = false;   // PrusaLink HTTP
 // The persisted control source, read once at boot. Default Klipper.
 static dc_ctl_source_t s_src = DC_SRC_KLIPPER;
+// Opt-in only: when true, a fresh Bambu-reported chamber temperature may drive
+// set-point regulation. Local DragonBreath chamber/PTC sensors remain the
+// authoritative safety inputs regardless of this flag.
+static bool s_bambu_direct_chamber_control = false;
 
 // Control-task handle, so accepted policy commands can update outputs/LEDs
 // without waiting up to a full periodic tick. Panic-off uses the same prompt
@@ -148,6 +154,17 @@ static void nvs_init(void)
     }
 }
 
+static bool load_bambu_direct_chamber_control(void)
+{
+    uint8_t enabled = 0;   // default OFF: existing Bambu installs keep local regulation
+    nvs_handle_t h;
+    if (nvs_open(DB_NVS_NAMESPACE, NVS_READONLY, &h) == ESP_OK) {
+        (void)nvs_get_u8(h, DB_NVS_KEY_BAMBU_CHAMBER_CTL, &enabled);
+        nvs_close(h);
+    }
+    return enabled != 0;
+}
+
 #if defined(DB_WIFI_SSID) || defined(DB_MOONRAKER_HOST)
 // Dev-only: seed WiFi creds + Moonraker config into the NVS layout the shared
 // components load at start (namespace app_nvs; keys ssid/password + mk_host/mk_port).
@@ -211,8 +228,8 @@ static void control_task(void *arg)
         // Feed the AUTO seam from whichever ONE source is bound.
         // All paths converge on pb_policy_set_env(); the policy remains
         // source-agnostic. Printer-reported chamber temperature is passed through
-        // for set-point regulation when available; DragonBreath's local sensors
-        // remain authoritative for heater safety.
+        // only when the Bambu direct-control opt-in is enabled. DragonBreath's
+        // local sensors remain authoritative for heater safety in either mode.
         float bed_c = 0.0f;
         float bed_target_c = 0.0f;
         float src_target_c = 0.0f;
@@ -235,7 +252,7 @@ static void control_task(void *arg)
                         if (isfinite(bs.bed_target))
                             bed_target_c = bs.bed_target;
 
-                        if (isfinite(bs.chamber_temp))
+                        if (s_bambu_direct_chamber_control && isfinite(bs.chamber_temp))
                             chamber_src_c = bs.chamber_temp;
 
                         // Filament chamber zone: while a print is active,
@@ -446,6 +463,9 @@ void app_main(void)
     // tick AND be able to persist a fault that trips during early boot — so a
     // safety trip can never be lost across a reboot for want of an initialized NVS.
     nvs_init();
+    s_bambu_direct_chamber_control = load_bambu_direct_chamber_control();
+    ESP_LOGI(TAG, "Bambu direct chamber control: %s",
+             s_bambu_direct_chamber_control ? "enabled" : "disabled");
     pb_heater_load_config();                 // persisted max-target + comms timeout
     pb_heater_load_fault();                  // restore a persisted safety-fault latch (fail-safe on NVS error)
     pb_ntc_load_calibration();               // persisted per-channel offsets (clamped ±5 °C on load)

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -11,10 +11,10 @@ dependencies:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_source
     version: v0.28.1
-dc_bambu:
-  git: https://github.com/justinh-rahb/dragon-core.git
-  path: components/dc_bambu
-  version: v0.28.1
+  dc_bambu:
+    git: https://github.com/justinh-rahb/dragon-core.git
+    path: components/dc_bambu
+    version: v0.28.1
   dc_wifi:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_wifi

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -2,36 +2,36 @@ dependencies:
   dc_prusa:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_prusa
-    version: v0.28.1
+    version: v0.28.2
   dc_evlog:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_evlog
-    version: v0.28.1
+    version: v0.28.2
   dc_source:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_source
-    version: v0.28.1
+    version: v0.28.2
   dc_bambu:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_bambu
-    version: v0.28.1
+    version: v0.28.2
   dc_wifi:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_wifi
-    version: v0.28.1
+    version: v0.28.2
   dc_moonraker:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_moonraker
-    version: v0.28.1
+    version: v0.28.2
   dc_ui:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_ui
-    version: v0.28.1
+    version: v0.28.2
   dc_mqtt:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_mqtt
-    version: v0.28.1
+    version: v0.28.2
   dc_portal:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_portal
-    version: v0.28.1
+    version: v0.28.2

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -11,10 +11,10 @@ dependencies:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_source
     version: v0.28.1
-  dc_bambu:
-    git: https://github.com/justinh-rahb/dragon-core.git
-    path: components/dc_bambu
-    version: v0.28.1
+dc_bambu:
+  git: https://github.com/justinh-rahb/dragon-core.git
+  path: components/dc_bambu
+  version: v0.28.1
   dc_wifi:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_wifi

--- a/tests/check_api_v2_contract.sh
+++ b/tests/check_api_v2_contract.sh
@@ -89,6 +89,16 @@ grep -q 's->params.manual_target_c' "$httpd" || {
 }
 grep -q 'expected->valuedouble < UINT32_MAX' "$httpd"
 
+# Bambu chamber-control diagnostics: the public state must expose the printer
+# chamber sample and its age so hardware validation can distinguish live external
+# regulation from local-NTC fallback without altering heater behavior.
+for field in printer_chamber_temperature_c printer_chamber_age_ms; do
+    grep -q "\"$field\"" "$httpd" || {
+        echo "state document is missing environment.$field" >&2
+        exit 1
+    }
+done
+
 # Ownership boundary: core owns HTTP/provisioning/recovery; the product adapter
 # supplies API registration, authorization, heater safety and image identity.
 grep -q 'dc_portal_start(&cfg)' "$adapter"

--- a/tests/pb_heater_fault_host_test.c
+++ b/tests/pb_heater_fault_host_test.c
@@ -105,5 +105,17 @@ int main(void)
     CHECK(ec < PB_HEATER_PTC_CUTOFF_C && er < ec);
     CHECK(PB_HEATER_FB_CUT_MAX_C < PB_HEATER_PTC_CUTOFF_C);   // override ceiling < hard cutoff
     puts("pb_heater element-foldback checks: PASS");
+
+    // --- Local chamber soft limiter for remote regulation ----------------------
+    CHECK(pb_heater_local_foldback_cut(true, 71.9f, false) == false);
+    CHECK(pb_heater_local_foldback_cut(true, 72.0f, false) == true);
+    CHECK(pb_heater_local_foldback_cut(true, 80.0f, false) == true);
+    CHECK(pb_heater_local_foldback_cut(true, 72.0f, true) == true);   // hysteresis holds
+    CHECK(pb_heater_local_foldback_cut(true, 66.9f, true) == false);
+    CHECK(pb_heater_local_foldback_cut(false, 0.0f, true) == true);
+    CHECK(pb_heater_local_foldback_cut(false, 0.0f, false) == false);
+    CHECK(PB_HEATER_LOCAL_FOLDBACK_CUT_C < PB_HEATER_CHAMBER_MAX_C);
+    CHECK(PB_HEATER_LOCAL_FOLDBACK_RESUME_C < PB_HEATER_LOCAL_FOLDBACK_CUT_C);
+    puts("pb_heater local-chamber foldback checks: PASS");
     return 0;
 }

--- a/tests/pb_policy_host_test.c
+++ b/tests/pb_policy_host_test.c
@@ -342,28 +342,28 @@ static void test_auto_requires_live_source(void)
         60.0f, 100.0f, DB_SOURCE_WEB, 1) == PB_POLICY_OK);
 
     // A high bed setpoint no longer engages AUTO on its own (no zone target).
-    pb_policy_set_env(100.0f, 100.0f, true, 0.0f);
+    pb_policy_set_env(100.0f, 100.0f, true, 0.0f, NAN);
     pb_policy_tick();
     pb_policy_snapshot_t snap = snapshot();
     CHECK(!snap.auto_engaged);
     CHECK(snap.effective_target_c == 0.0f);
 
     // A zone target with the source DISCONNECTED must not heat (fail-safe).
-    pb_policy_set_env(20.0f, 0.0f, false, 55.0f);
+    pb_policy_set_env(20.0f, 0.0f, false, 55.0f, NAN);
     pb_policy_tick();
     snap = snapshot();
     CHECK(!snap.auto_engaged);
     CHECK(snap.effective_target_c == 0.0f);
 
     // Source connected + zone target -> engage to the zone target.
-    pb_policy_set_env(20.0f, 0.0f, true, 55.0f);
+    pb_policy_set_env(20.0f, 0.0f, true, 55.0f, NAN);
     pb_policy_tick();
     snap = snapshot();
     CHECK(snap.auto_engaged);
     CHECK(snap.effective_target_c == 55.0f);
 
     // Losing the source mid-print disengages, even with the zone target still set.
-    pb_policy_set_env(20.0f, 0.0f, false, 55.0f);
+    pb_policy_set_env(20.0f, 0.0f, false, 55.0f, NAN);
     pb_policy_tick();
     snap = snapshot();
     CHECK(!snap.auto_engaged);
@@ -380,14 +380,14 @@ static void test_auto_filtration_band_fan_only_not_cooldown(void)
     CHECK(pb_policy_set_filter_config(30.0f, true) == PB_POLICY_OK);
 
     // Bed below filter_temp: no filtration, fan off.
-    pb_policy_set_env(25.0f, 25.0f, true, 0.0f);
+    pb_policy_set_env(25.0f, 25.0f, true, 0.0f, NAN);
     pb_policy_tick();
     pb_policy_snapshot_t snap = snapshot();
     CHECK(!snap.auto_filtering);
     CHECK(snap.effective_fan_percent == 0);
 
     // Bed >= filter_temp but below the heat threshold: fan-only filtration band.
-    pb_policy_set_env(40.0f, 40.0f, true, 0.0f);
+    pb_policy_set_env(40.0f, 40.0f, true, 0.0f, NAN);
     pb_policy_tick();
     snap = snapshot();
     CHECK(snap.auto_filtering);                 // filtering
@@ -397,20 +397,20 @@ static void test_auto_filtration_band_fan_only_not_cooldown(void)
     CHECK(!snap.thermal_purge);                 // P1: must NOT read as cooldown purge
 
     // Hysteresis: stays on within [filter_temp - 3, ...); releases only below it.
-    pb_policy_set_env(28.0f, 28.0f, true, 0.0f);
+    pb_policy_set_env(28.0f, 28.0f, true, 0.0f, NAN);
     pb_policy_tick();
     CHECK(snapshot().auto_filtering);
-    pb_policy_set_env(26.0f, 26.0f, true, 0.0f);
+    pb_policy_set_env(26.0f, 26.0f, true, 0.0f, NAN);
     pb_policy_tick();
     snap = snapshot();
     CHECK(!snap.auto_filtering);
     CHECK(snap.effective_fan_percent == 0);
 
     // Moonraker disconnect fails to no-airflow even with a hot bed.
-    pb_policy_set_env(40.0f, 40.0f, true, 0.0f);
+    pb_policy_set_env(40.0f, 40.0f, true, 0.0f, NAN);
     pb_policy_tick();
     CHECK(snapshot().auto_filtering);
-    pb_policy_set_env(40.0f, 40.0f, false, 0.0f);
+    pb_policy_set_env(40.0f, 40.0f, false, 0.0f, NAN);
     pb_policy_tick();
     snap = snapshot();
     CHECK(!snap.auto_filtering);
@@ -429,7 +429,7 @@ static void test_filtration_band_runs_outside_auto(void)
     CHECK(snap.mode == PB_MODE_OFF);
 
     // OFF BY DEFAULT (opt-in): a hot bed while idle does NOT filter until enabled.
-    pb_policy_set_env(40.0f, 40.0f, true, 0.0f);
+    pb_policy_set_env(40.0f, 40.0f, true, 0.0f, NAN);
     pb_policy_tick();
     snap = snapshot();
     CHECK(!snap.auto_filtering);
@@ -455,7 +455,7 @@ static void test_filtration_band_runs_outside_auto(void)
 
     // Re-enabled but bed setpoint back below filter_temp: no filtration.
     CHECK(pb_policy_set_filter_config(30.0f, true) == PB_POLICY_OK);
-    pb_policy_set_env(20.0f, 20.0f, true, 0.0f);
+    pb_policy_set_env(20.0f, 20.0f, true, 0.0f, NAN);
     pb_policy_tick();
     snap = snapshot();
     CHECK(!snap.auto_filtering);
@@ -489,7 +489,7 @@ static void test_runtime_limits_drive_auto_and_remote_lease(void)
         65.0f, 100.0f, DB_SOURCE_WEB, 1) == PB_POLICY_OK);
     CHECK(snapshot().requested_target_c == 52.0f);
     // AUTO heats to the live filament-zone target (65), clamped to the runtime max (52).
-    pb_policy_set_env(20.0f, 0.0f, true, 65.0f);
+    pb_policy_set_env(20.0f, 0.0f, true, 65.0f, NAN);
     pb_policy_tick();
     CHECK(snapshot().effective_target_c == 52.0f);
 
@@ -748,13 +748,13 @@ static void test_panel_leds_track_mode(void)
     pb_policy_set_mode_off(DB_SOURCE_WEB);
     CHECK(pb_policy_set_auto(
         60.0f, 100.0f, DB_SOURCE_WEB, PB_POLICY_REVISION_ANY) == PB_POLICY_OK);
-    pb_policy_set_env(20.0f, 20.0f, false, 0.0f);
+    pb_policy_set_env(20.0f, 20.0f, false, 0.0f, NAN);
     pb_policy_tick();
     CHECK(led_pattern[PB_LED_AUTO] == PB_LED_BLINK_SLOW);
     CHECK(led_pattern[PB_LED_ON] == PB_LED_OFF);
 
     // Live source + a filament-zone target engages AUTO -> solid LED.
-    pb_policy_set_env(20.0f, 0.0f, true, 55.0f);
+    pb_policy_set_env(20.0f, 0.0f, true, 55.0f, NAN);
     pb_policy_tick();
     CHECK(snapshot().auto_engaged);
     CHECK(led_pattern[PB_LED_AUTO] == PB_LED_SOLID);
@@ -1065,26 +1065,26 @@ static void test_auto_source_zone_overrides_bed_threshold(void)
     CHECK(pb_policy_set_auto(60.0f, 100.0f, DB_SOURCE_WEB, 1) == PB_POLICY_OK);
 
     // Cold bed, no bed setpoint (0 < 100) -> bed-AUTO alone does NOT engage.
-    pb_policy_set_env(20.0f, 0.0f, true, 0.0f);
+    pb_policy_set_env(20.0f, 0.0f, true, 0.0f, NAN);
     pb_policy_tick();
     CHECK(!snapshot().auto_engaged);
 
     // A source zone target (55) engages heat and overrides the 60 AUTO target.
-    pb_policy_set_env(20.0f, 0.0f, true, 55.0f);
+    pb_policy_set_env(20.0f, 0.0f, true, 55.0f, NAN);
     pb_policy_tick();
     pb_policy_snapshot_t snap = snapshot();
     CHECK(snap.auto_engaged);
     CHECK(snap.effective_target_c == 55.0f);
 
     // Zone clears (print end) with no bed setpoint -> disengage (revert to idle/AUTO).
-    pb_policy_set_env(20.0f, 0.0f, true, 0.0f);
+    pb_policy_set_env(20.0f, 0.0f, true, 0.0f, NAN);
     pb_policy_tick();
     snap = snapshot();
     CHECK(!snap.auto_engaged);
     CHECK(snap.effective_target_c == 0.0f);
 
     // Out-of-range zone target is clamped to the settable ceiling (70 C).
-    pb_policy_set_env(20.0f, 0.0f, true, 999.0f);
+    pb_policy_set_env(20.0f, 0.0f, true, 999.0f, NAN);
     pb_policy_tick();
     CHECK(snapshot().effective_target_c == 70.0f);
 }

--- a/tests/pb_policy_host_test.c
+++ b/tests/pb_policy_host_test.c
@@ -377,14 +377,15 @@ static void test_auto_requires_live_source(void)
     CHECK(snap.effective_target_c == 0.0f);
 }
 
-// External printer chamber temperature is forwarded to pb_heater only while
-// the source is live. A disconnect (or invalid reading) clears the external
-// control input so pb_heater falls back to its local chamber NTC.
+// External printer chamber temperature is an AUTO-only regulation input.
+// Disconnects, invalid telemetry, Manual, and Drying all fall back to the local NTC.
 static void test_external_chamber_control_forwarding(void)
 {
     reset_fixture();
+    CHECK(pb_policy_set_auto(
+        60.0f, 100.0f, DB_SOURCE_WEB, 1) == PB_POLICY_OK);
 
-    // A valid chamber reading from a live source reaches the heater control seam.
+    // AUTO + live source + finite chamber telemetry reaches the heater seam.
     pb_policy_set_env(20.0f, 0.0f, true, 55.0f, 42.5f);
     pb_policy_tick();
     CHECK(isfinite(heater_control_chamber_c));
@@ -398,6 +399,22 @@ static void test_external_chamber_control_forwarding(void)
 
     // A non-finite source reading also selects the local-NTC fallback.
     pb_policy_set_env(20.0f, 0.0f, true, 55.0f, NAN);
+    pb_policy_tick();
+    CHECK(isnan(heater_control_chamber_c));
+
+    // Manual regulation always stays on the local chamber NTC.
+    reset_fixture();
+    CHECK(pb_policy_set_power_on(
+        50.0f, DB_SOURCE_BUTTON, "panel", 1, NULL) == PB_POLICY_OK);
+    pb_policy_set_env(20.0f, 0.0f, true, 0.0f, 42.5f);
+    pb_policy_tick();
+    CHECK(isnan(heater_control_chamber_c));
+
+    // Drying likewise ignores printer chamber telemetry.
+    reset_fixture();
+    CHECK(pb_policy_start_drying(
+        60.0f, 1, DB_SOURCE_WEB, 1) == PB_POLICY_OK);
+    pb_policy_set_env(20.0f, 0.0f, true, 0.0f, 42.5f);
     pb_policy_tick();
     CHECK(isnan(heater_control_chamber_c));
 }

--- a/tests/pb_policy_host_test.c
+++ b/tests/pb_policy_host_test.c
@@ -13,6 +13,7 @@ static int64_t fake_now_us;
 static unsigned random_generation;
 static float heater_target;
 static bool heater_on;
+static float heater_control_chamber_c = NAN;
 static bool heater_fault;
 static bool heater_inhibited;
 static const char *heater_reason;
@@ -59,6 +60,11 @@ esp_err_t pb_heater_set_target_c(float target)
     if (target > heater_max_target_c) target = heater_max_target_c;
     heater_target = target;
     return ESP_OK;
+}
+
+void pb_heater_set_control_chamber_c(float temp_c)
+{
+    heater_control_chamber_c = isfinite(temp_c) ? temp_c : NAN;
 }
 
 float pb_heater_get_target_c(void) { return heater_target; }
@@ -218,6 +224,7 @@ static void reset_nvs(void)
 static void reset_fixture(void)
 {
     reset_nvs();
+    heater_control_chamber_c = NAN;
     fake_now_us = 1000000;
     heater_target = 0.0f;
     heater_on = false;
@@ -368,6 +375,31 @@ static void test_auto_requires_live_source(void)
     snap = snapshot();
     CHECK(!snap.auto_engaged);
     CHECK(snap.effective_target_c == 0.0f);
+}
+
+// External printer chamber temperature is forwarded to pb_heater only while
+// the source is live. A disconnect (or invalid reading) clears the external
+// control input so pb_heater falls back to its local chamber NTC.
+static void test_external_chamber_control_forwarding(void)
+{
+    reset_fixture();
+
+    // A valid chamber reading from a live source reaches the heater control seam.
+    pb_policy_set_env(20.0f, 0.0f, true, 55.0f, 42.5f);
+    pb_policy_tick();
+    CHECK(isfinite(heater_control_chamber_c));
+    CHECK(fabsf(heater_control_chamber_c - 42.5f) < 0.001f);
+
+    // Losing the source must invalidate the external control reading even if the
+    // last reported chamber value remains present in policy state.
+    pb_policy_set_env(20.0f, 0.0f, false, 55.0f, 42.5f);
+    pb_policy_tick();
+    CHECK(isnan(heater_control_chamber_c));
+
+    // A non-finite source reading also selects the local-NTC fallback.
+    pb_policy_set_env(20.0f, 0.0f, true, 55.0f, NAN);
+    pb_policy_tick();
+    CHECK(isnan(heater_control_chamber_c));
 }
 
 static void test_auto_filtration_band_fan_only_not_cooldown(void)
@@ -1203,6 +1235,7 @@ int main(void)
     test_lease_expiry_latches_watchdog_fault();
     test_auto_requires_live_source();
     test_auto_source_zone_overrides_bed_threshold();
+    test_external_chamber_control_forwarding();
     test_auto_filtration_band_fan_only_not_cooldown();
     test_filtration_band_runs_outside_auto();
     test_drying_is_bounded_and_expires_off();

--- a/tests/stubs/pb_heater.h
+++ b/tests/stubs/pb_heater.h
@@ -6,6 +6,9 @@
 // Mirrors the real ceiling: pb_policy clamps persisted parameters against it.
 #define PB_HEATER_ABS_MAX_TARGET_C 70.0f
 
+// Optional external chamber measurement used for regulation only.
+// Pass NAN to fall back to the local chamber NTC.
+void pb_heater_set_control_chamber_c(float temp_c);
 esp_err_t pb_heater_set_target_c(float target_c);
 float pb_heater_get_target_c(void);
 float pb_heater_get_max_target_c(void);


### PR DESCRIPTION
## Summary

Adds optional direct chamber-temperature regulation for Bambu printers.

When enabled, DragonBreath uses the printer-reported Bambu chamber temperature as the regulation input instead of the local chamber NTC. The local chamber NTC and PTC remain independent safety inputs and retain authority over thermal limiting and fault handling.

The feature is opt-in and disabled by default.

## What changed

- expose Bambu chamber temperature and sample age through the DragonBreath state/API path
- allow fresh Bambu chamber telemetry to be used as the heater regulation input
- fall back to local chamber regulation when Bambu chamber telemetry is unavailable or stale
- retain the local chamber NTC as an independent thermal governor
- retain PTC monitoring and existing hard safety interlocks
- add Bambu chamber diagnostics to console/state output
- add a persisted `Use Bambu chamber sensor for heater control` setting under Bambu LAN configuration
- default direct Bambu chamber control to Disabled
- document the external regulation and local safety relationship

## Safety behavior

The Bambu chamber sensor is used only for temperature regulation.

It does not replace DragonBreath's local thermal safety sensors.

When direct chamber control is enabled:

- Bambu chamber temperature determines heater demand.
- The local chamber NTC independently limits heater output.
- The PTC sensor and existing fault/interlock paths remain active.
- Missing, invalid, or stale Bambu chamber telemetry cannot bypass local safety handling.

## Dependency update

This PR updates the DragonBreath dragon-core dependencies from `v0.27.0` to upstream `v0.28.2`.

During development, `dc_bambu` was temporarily pinned to my `feature/bambu-chamber-freshness` branch while the required stale chamber-telemetry handling was under review.

That change was merged upstream in `dragon-core#47` and released in `v0.28.0`. The submitted branch now uses `v0.28.2`, which retains the freshness support and also includes the `dragon-core#49` Bambu identifier log redaction. It no longer depends on my fork or an unreleased dragon-core commit.

## Testing

Tested on Panda Breath hardware connected to a Bambu X1C.

- ESP-IDF firmware builds successfully from a clean working tree.
- Hardware validation used upstream dragon-core `v0.28.0`; PR CI builds the submitted tree against `v0.28.2`.
- Direct chamber-control setting persists across reboot and firmware update.
- Fresh Bambu chamber telemetry is received and used for regulation when enabled.
- With a 60 C target and Bambu chamber telemetry around 39-40 C, the heater continued requesting heat above 60 C on the local NTC, confirming Bambu telemetry was driving regulation.
- The independent local chamber governor repeatedly disabled heater output around 72 C and re-enabled it after cooling to roughly 67 C.
- PTC monitoring remained active and healthy.
- No heater faults were observed during the validation runs.
- Disabling direct chamber control preserves the existing local-NTC regulation behavior.

## Related

- `justinh-rahb/dragon-core#47` - stale Bambu chamber-temperature expiry support
- `justinh-rahb/dragon-core#49` - follow-up log redaction for Bambu device identifiers
