### PR TITLE
RFC: define Dragon device integration planes

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,19 @@
+# DragonBreath plans and RFCs
+
+The `plans/` directory contains design records for DragonBreath and the wider Dragon
+firmware family.
+
+New cross-product proposals use the numbered [Dragon RFC series](rfcs/README.md).
+They are merged as discussion records before implementation and retain an explicit
+status throughout their lifecycle.
+
+## Current proposed RFC series
+
+- [RFC 0001: Dragon device integration planes](rfcs/0001-dragon-integration-planes.md)
+- [RFC 0002: Wired safety spine for heater-class devices](rfcs/0002-wired-safety-spine.md)
+- [RFC 0003: ESP-NOW low-power peripheral fabric](rfcs/0003-esp-now-peripheral-fabric.md)
+- [RFC 0004: Dragon peer capabilities and remote sensors](rfcs/0004-peer-capability-plane.md)
+
+The other files in this directory are earlier product RFCs, implementation designs,
+and retained architecture records. Their existing locations and status text remain
+authoritative; they do not need to be renumbered to participate in the new process.

--- a/plans/rfcs/0001-dragon-integration-planes.md
+++ b/plans/rfcs/0001-dragon-integration-planes.md
@@ -1,0 +1,182 @@
+# RFC 0001: Dragon device integration planes
+
+Status: **Proposed — feedback requested.**
+
+Date: 2026-08-24
+
+## Summary
+
+The Dragon family should use three distinct integration planes, selected by device
+class rather than by a single preferred transport:
+
+1. a **wired safety spine** for mains-powered, actuator-bearing, timing-sensitive
+   hardware;
+2. an **ESP-NOW peripheral fabric** for simple, low-power leaf devices; and
+3. a **Dragon peer capability plane** for powered, intelligent products exchanging
+   semantic state and capabilities.
+
+These planes complement each other. A product may bridge them, but their authority
+and failure contracts must remain separate.
+
+## Motivation
+
+Current and proposed Dragon devices span incompatible constraints:
+
+- heater controllers must remain safe across host, network, and radio failure;
+- a battery door switch or filament sensor benefits more from low association and
+  idle-power cost than deterministic sub-millisecond timing;
+- products such as a future DragonTouch can understand attached accessories and
+  publish meaningful capabilities to another Dragon product; and
+- some simple devices may be complete on a single ESP32, while others need a wired
+  RP/STM actuator controller plus a network-capable brain.
+
+Treating all of these as one bus would blur safety authority, power budgets, pairing,
+and acceptance criteria. Treating them as unrelated would duplicate identity,
+discovery, freshness, and diagnostics work. This RFC establishes shared vocabulary
+while leaving each plane its own focused design.
+
+## Proposed model
+
+| Plane | Typical devices | Primary goal | Timing/safety authority |
+|---|---|---|---|
+| Wired safety spine | heaters, motors with hazardous failure modes, mains outputs | deterministic local actuation | wired controller owns real-time output safety |
+| ESP-NOW peripheral fabric | switches, runout sensors, buttons, battery probes, indicators | low power and easy installation | never sole hard-safety authority |
+| Dragon peer capability plane | DragonTouch, DragonBreath, DragonVent, DragonStatus | semantic product-to-product cooperation | product policy remains local to the actuator owner |
+
+A fourth shape—one ESP32 running a complete simple product—does not require a fourth
+plane. It is a product composition choice: the device can implement local behavior
+and participate in the peripheral or peer plane where useful.
+
+## System sketch
+
+```text
+ low-power leaves                    powered Dragon products
+┌───────────────┐                   ┌──────────────────────┐
+│ door / sensor │── ESP-NOW ──────▶│ DragonTouch / gateway│
+└───────────────┘                   └──────────┬───────────┘
+                                             │ semantic peer capability
+                                             ▼
+                                  ┌────────────────────────┐
+                                  │ DragonBreath brain     │
+                                  │ product policy         │
+                                  └───────────┬────────────┘
+                                              │ wired safety spine
+                                              ▼
+                                  ┌────────────────────────┐
+                                  │ RP/STM actuator MCU    │
+                                  │ watchdog + safe outputs│
+                                  └────────────────────────┘
+```
+
+The diagram is illustrative. DragonBreath currently runs its product policy and
+hardware control on one ESP32-C3; adopting a wired safety spine is a future product
+architecture, not a claim about current hardware.
+
+## Cross-plane invariants
+
+### 1. The actuator owner retains safety authority
+
+A remote command, measurement, UI, or gateway may influence desired behavior but
+must not disable local sensor checks, fixed cutoffs, watchdogs, safe boot state, or
+output interlocks.
+
+### 2. Transport does not imply authority
+
+Discovery, pairing, and successful delivery do not grant permission to command an
+actuator. Command authority, observation, and regulation input are separate roles.
+
+### 3. Freshness is decided by the consumer
+
+Messages may carry source timestamps and sequence numbers, but a consumer must track
+local receipt time and expire data itself. A remote clock cannot prove a sample is
+fresh.
+
+### 4. Identity and binding are explicit
+
+Discovery presents candidates. A user or an authenticated provisioning flow binds a
+specific stable device and capability. Friendly names and network addresses are not
+identities.
+
+### 5. Loss behavior is part of configuration
+
+Every consumed remote capability defines what happens when it becomes unavailable:
+suspend, fall back, retain for a bounded time, or report unknown. Indefinite stale
+state is never a valid policy.
+
+### 6. Product and wire compatibility are deliberate
+
+Persisted keys, numeric enum values, peer identifiers, API fields, and pairing state
+need explicit migration plans. Source-code naming cleanup alone is not sufficient
+reason to break deployed state.
+
+### 7. Bridges do not erase boundaries
+
+A DragonTouch may bridge an I²C accessory into Dragon peer telemetry, or an ESP-NOW
+gateway may expose a leaf to Klipper. The bridge must preserve source identity,
+freshness, validity, and authority instead of presenting bridged data as local truth.
+
+## Relationship to existing work
+
+- [`dragon-family-unification.md`](../dragon-family-unification.md) defines shared
+  dragon-core services and product-local hardware policy.
+- [`decouple-httpd-device-interface.md`](../decouple-httpd-device-interface.md)
+  proposes a capability boundary between shared transport and product behavior.
+- DragonBreath PR
+  [#89](https://github.com/plastikman/DragonBreath/pull/89) demonstrates a remote
+  chamber measurement used for regulation while local NTC/PTC sensors retain safety
+  authority. It is a product-specific precursor, not the generic peer protocol.
+- [`KLIPPER_DISTRIBUTION_INTEGRATION.md`](../../docs/KLIPPER_DISTRIBUTION_INTEGRATION.md)
+  documents the current host integration and its device-authoritative safety model.
+
+## Decision boundaries
+
+RFC 0001 does not choose:
+
+- UART versus CAN for the wired spine;
+- a final ESP-NOW packet format or gateway topology;
+- HTTP/SSE, UDP, ESP-NOW, or another carrier for smart peer communication;
+- a common firmware image for every Dragon product; or
+- whether a particular proposed sensor is accurate enough for regulation.
+
+Those decisions belong in the focused RFCs or product validation.
+
+## Adoption sequence
+
+1. Agree on the three-plane vocabulary and cross-plane invariants.
+2. Prototype each plane independently with simulated failure injection.
+3. Let one real product validate each boundary before extracting shared code into
+   dragon-core.
+4. Define shared identity/pairing primitives only after comparing prototype needs.
+5. Add bridges after both sides have stable contracts; do not make the first
+   prototype a universal gateway.
+
+## Non-goals
+
+- Replacing DragonBreath's current hardware architecture in this RFC.
+- Treating ordinary telemetry loss as a hardware emergency unless product policy
+  explicitly requires it.
+- Using ESP-NOW for mains heater interlocks or safety watchdog timing.
+- Requiring Klipper for peer-to-peer Dragon product features.
+- Defining a cloud service or cloud identity plane.
+
+## Feedback requested
+
+1. Do these three planes cover the known Dragon product and accessory classes?
+2. Which devices genuinely need to participate in more than one plane?
+3. Are command authority, regulation input, and observation the right minimum role
+   separation?
+4. Which identity and pairing concepts can safely be shared without prematurely
+   forcing one transport?
+5. Which first prototype would provide the strongest evidence for or against this
+   architecture?
+
+## Acceptance criteria for this RFC
+
+The RFC may move from Proposed to Accepted when:
+
+- maintainers agree that safety-critical wired actuation, low-power leaves, and smart
+  peers have distinct contracts;
+- each focused RFC has an owner and a bounded prototype target;
+- no known device class requires violating the cross-plane invariants; and
+- unresolved transport choices are explicitly assigned to a focused RFC rather than
+  hidden in implementation work.

--- a/plans/rfcs/0002-wired-safety-spine.md
+++ b/plans/rfcs/0002-wired-safety-spine.md
@@ -1,0 +1,206 @@
+# RFC 0002: Wired safety spine for heater-class devices
+
+Status: **Proposed — feedback requested from Klipper, firmware, and hardware
+contributors.**
+
+Date: 2026-08-24
+
+Depends on: [RFC 0001](0001-dragon-integration-planes.md)
+
+## Summary
+
+Future Dragon products with hazardous actuators should separate network/product
+orchestration from deterministic hardware control. An RP2040, STM32, or comparable
+MCU runs a real Klipper MCU firmware and owns time-sensitive I/O over a wired link. A
+Dragon brain runs product services and a
+[`klipper-micro`](https://github.com/justinh-rahb/klipper-micro) integration but
+cannot make radio availability part of the hardware safety chain.
+
+This RFC defines the boundary and evidence required before selecting boards or buses.
+It does not propose retrofitting current DragonBreath hardware.
+
+## Device class
+
+This plane is intended for hardware where an incorrect or indefinitely held output
+can create a hazardous condition, including:
+
+- chamber and element heaters;
+- mains-switched loads;
+- motors whose uncontrolled motion can cause damage;
+- safety fans coupled to a heat-producing actuator; and
+- local thermal or current interlocks that must remain effective when the brain is
+  rebooting or disconnected.
+
+It is not required for every wired sensor or LED.
+
+## Proposed topology
+
+```text
+┌──────────────────────────────────┐
+│ Dragon brain                     │
+│                                  │
+│ product policy and UI            │
+│ network/cloud/printer transports │
+│ klipper-micro integration        │
+└───────────────┬──────────────────┘
+                │ wired, framed, versioned
+                ▼
+┌──────────────────────────────────┐
+│ RP/STM safety/actuator MCU       │
+│                                  │
+│ Klipper MCU firmware             │
+│ deterministic GPIO/ADC/timers    │
+│ watchdog and safe boot outputs   │
+└───────────────┬──────────────────┘
+                ▼
+        SSR / fan / sensors
+```
+
+The exact ownership split between Klipper's existing MCU facilities and Dragon-local
+hardware protections remains to be designed. The non-negotiable property is that a
+brain or radio failure cannot leave a hazardous output energized indefinitely.
+
+## Responsibilities
+
+### Actuator MCU
+
+The wired MCU should own:
+
+- safe pin state before firmware initialization;
+- deterministic output scheduling;
+- direct sampling needed by hardware-local protections;
+- an independently enforced command/watchdog timeout;
+- immediate de-energization on malformed, expired, or lost control;
+- a versioned description of supported pins, sensors, and safety features; and
+- enough diagnostics to distinguish watchdog, sensor, protocol, and power faults.
+
+### Dragon brain
+
+The brain should own:
+
+- user-visible product modes and targets;
+- network transports and printer integrations;
+- configuration, UI, OTA coordination, and event history;
+- high-level policy that remains safe when commands are rejected or delayed;
+- compatibility checks before arming an actuator MCU; and
+- explicit presentation of MCU disconnect and fault states.
+
+### Hardware
+
+Software watchdogs do not replace appropriate hardware design. Depending on the
+product, the board may still need pull states, thermal fuses, interlocks, isolation,
+and an output topology that defaults off through reset and partial power conditions.
+
+## Safety contract
+
+### Boot
+
+- Actuator outputs are off before either processor has completed boot.
+- Reboot does not restore an active heat command.
+- The brain must complete protocol/capability negotiation before arming.
+
+### Link loss
+
+- The actuator MCU expires active demand locally within a documented upper bound.
+- Reconnection reports authoritative MCU state before accepting new demand.
+- Restored connectivity does not silently replay a pre-disconnect command.
+
+### Version mismatch
+
+- Unknown protocol or safety capability versions fail unarmed.
+- A compatibility fallback may reduce functionality but cannot bypass required
+  safeguards.
+
+### Brain failure
+
+- A wedged, rebooting, or disconnected brain cannot keep an output alive beyond the
+  MCU watchdog bound.
+- The actuator MCU does not depend on Wi-Fi, MQTT, a browser, or a cloud service.
+
+### MCU failure
+
+- Hardware pull states and independent cutoffs handle MCU reset where feasible.
+- The brain reports loss of the MCU but does not claim that reporting itself made the
+  hardware safe.
+
+## Relationship to Klipper
+
+The intent is to use real Klipper MCU firmware and protocol behavior rather than
+inventing a second approximate pin scheduler. `klipper-micro` on the Dragon brain is
+the proposed integration boundary.
+
+The current `klipper-micro` reference is a native ESP-IDF Klipper host for an ESP32
+CYD. It drives an unmodified Klipper MCU over UART and already demonstrates bounded
+wire frames, retry/resynchronization, selective identify parsing, clock regression,
+scheduled heater/fan updates, a three-second output watchdog, thermistor conversion,
+and host-side safety checks. This is evidence that the brain-side boundary is
+feasible, not evidence that its current CYD product choices or safety implementation
+are ready to transplant unchanged into a Dragon heater product.
+
+Before acceptance, the design needs validation against upstream Klipper assumptions:
+
+- which host responsibilities `klipper-micro` implements;
+- how MCU clocks, configuration, restart, and shutdown are handled;
+- which watchdog behavior exists upstream versus must remain product hardware policy;
+- whether a Dragon product can expose useful local behavior while also participating
+  in a printer's Klipper instance; and
+- how protocol/version compatibility is tested across releases.
+
+No Dragon-specific protocol extension should be proposed until the upstream behavior
+has been measured and documented.
+
+## Candidate wired transports
+
+| Transport | Strengths | Questions |
+|---|---|---|
+| UART | simple, cheap, easy to inspect | distance, framing, isolation, single peer |
+| USB | standard host integration and bootloader options | connector/power behavior, embedded host cost |
+| CAN | robust multidrop and differential signaling | transceiver/termination cost, arbitration and addressing |
+
+Transport selection should follow board topology and fault testing. It is not an
+architectural vote for one bus across every product.
+
+## Prototype proposal
+
+Use a safe dev board with visible low-energy outputs before connecting a heater:
+
+1. run the candidate Klipper MCU firmware on an RP/STM board;
+2. connect it by the simplest candidate wired transport to an ESP32 brain;
+3. schedule an LED or logic-level output and sample simulated sensors;
+4. inject brain reset, link removal, malformed frames, stale commands, MCU reset, and
+   version mismatch;
+5. measure worst-case output-off latency with external instrumentation; and
+6. only then repeat through an isolated dummy load representative of product I/O.
+
+## Acceptance criteria for an implementation
+
+- No radio or IP path is required for actuator watchdog timing.
+- Outputs are demonstrably off during reset, boot, unconfigured, and incompatible
+  states.
+- Link-loss output-off latency has a measured maximum and test margin.
+- A stale command cannot be replayed after either processor reboots.
+- Hardware-local sensor failures de-energize affected outputs without brain help.
+- Protocol and capability mismatch leave the actuator unarmed.
+- Host tests cover framing/state transitions and hardware tests cover actual output
+  timing.
+- Recovery and firmware update order cannot strand the product with unsafe or
+  permanently incompatible processor versions.
+
+## Non-goals
+
+- Wireless actuator control.
+- A generic replacement for Klipper's existing MCU protocol.
+- Moving product UI or network integrations onto the actuator MCU.
+- Assuming a second processor alone makes a design safe.
+- Selecting the production MCU or bus in this RFC.
+
+## Feedback requested
+
+1. Is `klipper-micro` the correct brain-side boundary, and which upstream assumptions
+   need a proof-of-concept first?
+2. Which protections belong in ordinary Klipper MCU configuration versus dedicated
+   product firmware or hardware?
+3. What wired transport best represents the likely board-to-board topology?
+4. How should coordinated brain/MCU firmware upgrades and rollback work?
+5. Which measurements are required before this architecture can be considered for a
+   heater-class product?

--- a/plans/rfcs/0003-esp-now-peripheral-fabric.md
+++ b/plans/rfcs/0003-esp-now-peripheral-fabric.md
@@ -1,0 +1,231 @@
+# RFC 0003: ESP-NOW low-power peripheral fabric
+
+Status: **Proposed — feedback requested from ESP-NOW, low-power, and Klipper
+contributors.**
+
+Date: 2026-08-24
+
+Depends on: [RFC 0001](0001-dragon-integration-planes.md)
+
+## Summary
+
+Simple Dragon peripherals may use ESP-NOW to avoid Wi-Fi association and continuous
+IP-stack costs. Battery-powered switches, filament sensors, buttons, environmental
+probes, and indicators communicate with a powered ESP32 gateway. The gateway may
+expose them to Klipper through an extension of
+[`klipper-esp32`](https://github.com/justinh-rahb/klipper-esp32), to Dragon products
+through the peer capability plane, or to both through explicit adapters.
+
+This fabric is optimized for power, installation, and bounded stale-state behavior.
+It is not a heater interlock or deterministic actuator bus.
+
+## Device class
+
+Good candidates include:
+
+- filament presence or motion sensors;
+- door and enclosure switches;
+- user buttons and simple remotes;
+- ambient, humidity, or monitor-only temperature sensors;
+- battery level and accessory-health telemetry; and
+- low-duty indicators where delayed or lost updates are non-hazardous.
+
+Excluded from this RFC:
+
+- the sole cutoff for a heater or hazardous motor;
+- an output that must be de-energized within a hard radio-dependent deadline;
+- high-bandwidth media or firmware streaming; and
+- general product-to-product semantic control, which belongs to
+  [RFC 0004](0004-peer-capability-plane.md).
+
+## Proposed topology
+
+```text
+┌─────────────────┐       ESP-NOW       ┌────────────────────────┐
+│ sleeping leaf   │ ──────────────────▶ │ powered ESP32 gateway  │
+│ sensor/switch   │ ◀── optional ACK ── │ pairing + freshness    │
+└─────────────────┘                     └────────────┬───────────┘
+                                                   │
+                                  ┌────────────────┴──────────────┐
+                                  ▼                               ▼
+                         Klipper-facing adapter          Dragon peer capability
+```
+
+The initial topology should be leaf-to-gateway, not arbitrary mesh. A gateway can
+support several leaves, but every extra routing role increases awake time, state, and
+failure complexity.
+
+## Why ESP-NOW
+
+ESP-NOW can exchange small frames without joining an access point, acquiring an IP
+address, or keeping a conventional Wi-Fi session alive. That can reduce connection
+latency and average energy for a device that wakes, samples, transmits, and sleeps.
+
+It does not eliminate RF power constraints. ESP32 transmit peaks can exceed what a
+bare coin cell supplies reliably. Candidate hardware must measure peak current,
+brownout margin, storage capacitance, sleep leakage, sensor current, and real message
+cadence. Small LiPo or primary cells may be more realistic than a coin cell for some
+nodes.
+
+## Roles
+
+### Leaf
+
+A leaf owns its physical sensor or indicator and should:
+
+- wake on a timer or hardware event;
+- report a complete current state, not only edges;
+- carry stable identity, boot/session ID, and monotonic sequence;
+- report battery/health when available;
+- retransmit according to bounded policy rather than remaining awake indefinitely;
+- store only the pairing material required for its gateway; and
+- return to a known low-power state after failure.
+
+### Gateway
+
+A powered gateway should:
+
+- pair and authenticate leaves;
+- track replay, sequence, local receipt time, and freshness per capability;
+- expose disconnected/stale/unknown separately from false/off;
+- map leaf identity to a stable configured name;
+- adapt state to Klipper or Dragon peer semantics without hiding its remote origin;
+- rate-limit noisy or failing leaves; and
+- provide diagnostics for RSSI, last receipt, battery, retries, and protocol version.
+
+## Proposed message properties
+
+The first protocol should be binary and bounded rather than open-ended JSON. A frame
+needs, at minimum:
+
+| Field | Purpose |
+|---|---|
+| protocol version | reject incompatible layouts |
+| message type | state, event, acknowledgement, pairing, diagnostic |
+| leaf identity | stable binding independent of address/name |
+| boot/session ID | distinguish restart from replay |
+| sequence | order and deduplicate frames |
+| capability ID | identify door, filament, temperature, battery, etc. |
+| value + validity | distinguish false/zero from unknown |
+| optional sample age | describe sampling delay; gateway still uses receipt time |
+| authentication data | integrity and peer authentication |
+
+The exact encoding, key management, and ESP-NOW encryption use remain open. Version 1
+should reserve extension space without creating an unbounded generic object model.
+
+## State and event semantics
+
+A switch transition is useful as an event, but current state is authoritative. Leaves
+must periodically send a full state snapshot so a lost edge cannot leave a door or
+filament state wrong forever.
+
+The gateway exposes at least four conditions:
+
+```text
+true / active
+false / inactive
+unknown / no valid sample
+stale / previously valid but expired
+```
+
+Consumers may collapse these only through explicit policy. `unknown` must never
+silently become `false` merely because no packet arrived.
+
+## Pairing and trust
+
+Discovery is not pairing. A proposed user flow is:
+
+1. put one gateway into a short pairing window;
+2. physically activate or reset the intended leaf;
+3. show a device type and short confirmation code where UI exists;
+4. establish per-peer key material;
+5. persist the stable identity and allowed capabilities; and
+6. leave pairing mode automatically after a short bound.
+
+Factory reset, ownership transfer, gateway replacement, and lost-leaf removal require
+explicit flows. A MAC address may help transport delivery but is not sufficient as the
+long-term application identity or proof of authorization.
+
+## Channel and coexistence constraints
+
+ESP-NOW and ordinary Wi-Fi channel behavior must be measured on the actual gateway
+hardware. A gateway that also joins a WLAN may constrain ESP-NOW peers to the WLAN's
+channel. Channel changes, AP replacement, and 2.4 GHz congestion can therefore affect
+availability even without IP association on the leaf.
+
+The product UI should expose this dependency rather than promising radio behavior that
+cannot survive arbitrary AP channel changes.
+
+## Relationship to `klipper-esp32`
+
+The current Dragon-maintained `klipper-esp32` project is an experimental ESP-IDF port
+of Klipper MCU firmware derived from
+[`nikhil-robinson/klipper_esp32`](https://github.com/nikhil-robinson/klipper_esp32).
+Its documented transports are native USB Serial/JTAG and UART; it does not currently
+claim ESP-NOW transport. It already supports useful leaf building blocks including
+scheduled digital output, ADC, hardware I²C, LEDC PWM, and RMT NeoPixel output.
+
+This RFC therefore proposes new ESP-NOW transport/gateway work around that project; it
+does not describe a feature that has already landed. `klipper-esp32` is a candidate
+Klipper-facing implementation, not automatically the wire contract for every Dragon
+leaf. Before acceptance, a prototype should establish:
+
+- whether each leaf presents as a Klipper MCU or the gateway aggregates leaves;
+- where timing, pin configuration, and restart semantics live;
+- how a sleeping node fits Klipper's expectations of MCU availability;
+- whether non-Klipper Dragon consumers can reuse the leaf protocol without emulating a
+  Klipper host; and
+- which functionality belongs in dragon-core versus an integration repository.
+
+The likely boundary is a small leaf protocol plus a gateway adapter. The adapter can
+translate eligible capabilities into Klipper objects while preserving native Dragon
+telemetry for other consumers.
+
+## Power model and prototype evidence
+
+No battery-life claim should be accepted from sleep-current figures alone. A prototype
+report should include:
+
+- supply chemistry and usable capacity;
+- regulator and sensor quiescent current;
+- deep-sleep current of the complete assembled node;
+- wake, sample, transmit, retry, and acknowledgement durations;
+- peak current and minimum observed voltage;
+- normal heartbeat interval and worst-case retry behavior;
+- measured packet success under representative enclosure and distance; and
+- projected life with an explicit event-rate assumption.
+
+## Acceptance criteria for an implementation
+
+- Pairing binds one stable leaf identity to an explicit gateway.
+- Authenticated frames reject modification, replay, and stale boot sessions.
+- A lost transition is repaired by periodic full-state publication.
+- The gateway reports unknown/stale distinctly and expires state from local receipt
+  time.
+- AP/channel disruption and gateway reboot have documented recovery behavior.
+- A noisy leaf cannot starve other leaves or the gateway's product duties.
+- Battery measurements include real peak current and complete-board sleep current.
+- No acceptance test uses this radio path as the sole hazardous-actuator cutoff.
+- Klipper exposure and Dragon peer exposure preserve the same leaf identity and
+  freshness rather than creating unrelated duplicate devices.
+
+## Non-goals
+
+- General ESP-NOW mesh routing.
+- Heater, mains, or hazardous-motion safety control.
+- Guaranteed delivery of every event.
+- Cloud provisioning.
+- Treating a friendly name or MAC address as authorization.
+- Committing to `klipper-esp32` internals before a gateway prototype is measured.
+
+## Feedback requested
+
+1. Should leaves speak a Dragon-specific bounded protocol with a Klipper adapter, or
+   can `klipper-esp32` cleanly provide the common wire contract?
+2. Should the gateway aggregate leaves as one MCU or expose one logical MCU per leaf?
+3. Which pairing UX works on products with and without a screen?
+4. What heartbeat and retry ranges are realistic for door, filament, and environmental
+   sensor classes?
+5. Which battery hardware should be the reference platform so power claims are
+   reproducible?
+6. How should a Wi-Fi-connected gateway communicate channel changes to sleeping leaves?

--- a/plans/rfcs/0003-esp-now-peripheral-fabric.md
+++ b/plans/rfcs/0003-esp-now-peripheral-fabric.md
@@ -11,10 +11,16 @@ Depends on: [RFC 0001](0001-dragon-integration-planes.md)
 
 Simple Dragon peripherals may use ESP-NOW to avoid Wi-Fi association and continuous
 IP-stack costs. Battery-powered switches, filament sensors, buttons, environmental
-probes, and indicators communicate with a powered ESP32 gateway. The gateway may
-expose them to Klipper through an extension of
-[`klipper-esp32`](https://github.com/justinh-rahb/klipper-esp32), to Dragon products
-through the peer capability plane, or to both through explicit adapters.
+probes, and indicators communicate with a powered ESP32 gateway.
+
+The existing `klipper-esp32`
+[`codex/transport-abstraction`](https://github.com/justinh-rahb/klipper-esp32/tree/codex/transport-abstraction)
+branch already validates one form of this fabric: a continuously connected C3 Klipper
+MCU carries its bidirectional byte stream over reliable ESP-NOW through an S3 USB
+bridge. This RFC distinguishes that working **wireless MCU stream** from a future
+**sleeping battery leaf** protocol; the latter has different availability and power
+semantics and may require a capability adapter rather than a continuous Klipper MCU
+session.
 
 This fabric is optimized for power, installation, and bounded stale-state behavior.
 It is not a heater interlock or deterministic actuator bus.
@@ -30,6 +36,11 @@ Good candidates include:
 - battery level and accessory-health telemetry; and
 - low-duty indicators where delayed or lost updates are non-hazardous.
 
+Some candidates can remain continuously connected as Klipper MCUs. Others need to
+wake, report state, and sleep for long intervals. The RFC does not assume those two
+operating models can share an unchanged application protocol merely because both use
+ESP-NOW.
+
 Excluded from this RFC:
 
 - the sole cutoff for a heater or hazardous motor;
@@ -39,6 +50,14 @@ Excluded from this RFC:
   [RFC 0004](0004-peer-capability-plane.md).
 
 ## Proposed topology
+
+The existing connected-MCU prototype is:
+
+```text
+Klipper host ⇄ S3 native-USB bridge ⇄ reliable ESP-NOW ⇄ C3 Klipper MCU
+```
+
+The proposed sleeping-leaf shape is:
 
 ```text
 ┌─────────────────┐       ESP-NOW       ┌────────────────────────┐
@@ -55,6 +74,32 @@ The initial topology should be leaf-to-gateway, not arbitrary mesh. A gateway ca
 support several leaves, but every extra routing role increases awake time, state, and
 failure complexity.
 
+## Existing ESP-NOW prototype
+
+At
+[`bfb5d9b`](https://github.com/justinh-rahb/klipper-esp32/commit/bfb5d9baad3350b3a18d05e73e3334a871c5dade),
+the `codex/transport-abstraction` branch is eight commits ahead of the current
+`klipper-esp32` main branch. It adds:
+
+- a transport abstraction beneath the Klipper console;
+- coordinator/node diagnostic profiles and bridge/remote stream profiles;
+- a bounded version-1 binary frame with source, destination, sequence,
+  acknowledgement, type, flags, CRC, and up to 192 bytes of payload;
+- discovery and one-second heartbeats;
+- one reliable DATA frame in flight per direction;
+- protocol acknowledgements, duplicate suppression, a 100 ms ACK deadline, and three
+  bounded retransmissions;
+- queue, decode, delivery, duplicate, acknowledgement, timeout, and RSSI diagnostics;
+- host tests for frame and transport behavior; and
+- hardware probes that carry the real Klipper dictionary/queries through the bridge
+  and drive a remote C3 GPIO8 NeoPixel blink and color wipe.
+
+The branch explicitly scopes this first stream to protocol bring-up, not motion or
+heater control. It does not yet establish production pairing, per-peer authentication,
+encrypted application identity, multiple leaves, deep-sleep behavior, WLAN channel
+coexistence, or a battery power budget. Those are RFC requirements rather than reasons
+to ignore the working transport.
+
 ## Why ESP-NOW
 
 ESP-NOW can exchange small frames without joining an access point, acquiring an IP
@@ -69,9 +114,16 @@ nodes.
 
 ## Roles
 
-### Leaf
+### Continuously connected MCU node
 
-A leaf owns its physical sensor or indicator and should:
+A connected node runs `klipper-esp32` and keeps a reliable byte stream through the
+gateway. Klipper owns its configuration and availability semantics. This is the model
+already demonstrated by the bridge/remote profiles and is appropriate only where the
+node can remain awake and responsive.
+
+### Sleeping leaf
+
+A sleeping leaf owns its physical sensor or indicator and should:
 
 - wake on a timer or hardware event;
 - report a complete current state, not only edges;
@@ -95,8 +147,16 @@ A powered gateway should:
 
 ## Proposed message properties
 
-The first protocol should be binary and bounded rather than open-ended JSON. A frame
-needs, at minimum:
+The existing version-1 transport frame is already binary and bounded. It supplies the
+link fields needed to carry a reliable Klipper byte stream:
+
+```text
+version / type / flags / source / destination / sequence / acknowledgement /
+payload length / payload / CRC
+```
+
+A sleeping semantic leaf needs application state that the raw byte stream does not
+define. Its messages need, at minimum:
 
 | Field | Purpose |
 |---|---|
@@ -110,8 +170,10 @@ needs, at minimum:
 | optional sample age | describe sampling delay; gateway still uses receipt time |
 | authentication data | integrity and peer authentication |
 
-The exact encoding, key management, and ESP-NOW encryption use remain open. Version 1
-should reserve extension space without creating an unbounded generic object model.
+The exact encoding, key management, and ESP-NOW encryption use remain open. The
+sleeping-leaf protocol may reuse the transport frame after adding the necessary session
+and trust behavior, but it should not overload a raw Klipper stream with an unbounded
+generic object model.
 
 ## State and event semantics
 
@@ -161,14 +223,14 @@ cannot survive arbitrary AP channel changes.
 The current Dragon-maintained `klipper-esp32` project is an experimental ESP-IDF port
 of Klipper MCU firmware derived from
 [`nikhil-robinson/klipper_esp32`](https://github.com/nikhil-robinson/klipper_esp32).
-Its documented transports are native USB Serial/JTAG and UART; it does not currently
-claim ESP-NOW transport. It already supports useful leaf building blocks including
-scheduled digital output, ADC, hardware I²C, LEDC PWM, and RMT NeoPixel output.
+The main branch documents native USB Serial/JTAG and UART transports and useful
+peripheral building blocks including scheduled digital output, ADC, hardware I²C,
+LEDC PWM, and RMT NeoPixel output. Its `codex/transport-abstraction` branch adds the
+working reliable ESP-NOW stream described above.
 
-This RFC therefore proposes new ESP-NOW transport/gateway work around that project; it
-does not describe a feature that has already landed. `klipper-esp32` is a candidate
-Klipper-facing implementation, not automatically the wire contract for every Dragon
-leaf. Before acceptance, a prototype should establish:
+The branch makes `klipper-esp32` the demonstrated implementation for a continuously
+connected wireless MCU. It is not automatically the application contract for a
+sleeping Dragon leaf. Before acceptance, follow-up work should establish:
 
 - whether each leaf presents as a Klipper MCU or the gateway aggregates leaves;
 - where timing, pin configuration, and restart semantics live;
@@ -177,9 +239,10 @@ leaf. Before acceptance, a prototype should establish:
   Klipper host; and
 - which functionality belongs in dragon-core versus an integration repository.
 
-The likely boundary is a small leaf protocol plus a gateway adapter. The adapter can
-translate eligible capabilities into Klipper objects while preserving native Dragon
-telemetry for other consumers.
+One possible boundary is to retain the existing reliable stream unchanged for
+connected Klipper MCUs and add a small sleeping-leaf protocol plus gateway adapter for
+battery devices. The adapter can translate eligible capabilities into Klipper objects
+while preserving native Dragon telemetry for other consumers.
 
 ## Power model and prototype evidence
 
@@ -197,6 +260,8 @@ report should include:
 
 ## Acceptance criteria for an implementation
 
+- The existing bridge/remote hardware probe remains reproducible and its reliability
+  counters are captured under packet loss and reconnect tests.
 - Pairing binds one stable leaf identity to an explicit gateway.
 - Authenticated frames reject modification, replay, and stale boot sessions.
 - A lost transition is repaired by periodic full-state publication.
@@ -208,6 +273,8 @@ report should include:
 - No acceptance test uses this radio path as the sole hazardous-actuator cutoff.
 - Klipper exposure and Dragon peer exposure preserve the same leaf identity and
   freshness rather than creating unrelated duplicate devices.
+- Documentation distinguishes continuously connected Klipper nodes from sleeping
+  semantic leaves and does not apply battery-life claims from one to the other.
 
 ## Non-goals
 
@@ -216,16 +283,20 @@ report should include:
 - Guaranteed delivery of every event.
 - Cloud provisioning.
 - Treating a friendly name or MAC address as authorization.
-- Committing to `klipper-esp32` internals before a gateway prototype is measured.
+- Treating the existing experimental branch as production-ready for motion, heaters,
+  pairing, or battery operation.
 
 ## Feedback requested
 
-1. Should leaves speak a Dragon-specific bounded protocol with a Klipper adapter, or
-   can `klipper-esp32` cleanly provide the common wire contract?
-2. Should the gateway aggregate leaves as one MCU or expose one logical MCU per leaf?
-3. Which pairing UX works on products with and without a screen?
-4. What heartbeat and retry ranges are realistic for door, filament, and environmental
+1. Should the reliable ESP-NOW stream remain the connected-MCU path while sleeping
+   leaves use a smaller Dragon capability protocol?
+2. Can the existing transport frame safely become their common link envelope, or
+   should sleeping leaves use a separate format?
+3. Should the gateway aggregate sleeping leaves as one MCU, expose one logical MCU per
+   leaf, or publish them only as Dragon peer capabilities?
+4. Which pairing UX works on products with and without a screen?
+5. What heartbeat and retry ranges are realistic for door, filament, and environmental
    sensor classes?
-5. Which battery hardware should be the reference platform so power claims are
+6. Which battery hardware should be the reference platform so power claims are
    reproducible?
-6. How should a Wi-Fi-connected gateway communicate channel changes to sleeping leaves?
+7. How should a Wi-Fi-connected gateway communicate channel changes to sleeping leaves?

--- a/plans/rfcs/0004-peer-capability-plane.md
+++ b/plans/rfcs/0004-peer-capability-plane.md
@@ -1,0 +1,300 @@
+# RFC 0004: Dragon peer capabilities and remote sensors
+
+Status: **Proposed — feedback requested from Dragon product, networking, UI, and
+safety contributors.**
+
+Date: 2026-08-24
+
+Depends on: [RFC 0001](0001-dragon-integration-planes.md)
+
+## Summary
+
+Powered Dragon products should be able to discover, explicitly bind, and consume
+semantic capabilities from trusted peers. A future DragonTouch could read an attached
+I²C chamber sensor and provide that measurement to DragonBreath; DragonBreath could use
+it for regulation while retaining local sensors and policy as safety authority.
+
+The peer plane exchanges meaning—temperature, presence, input events, display or
+status capabilities—not remote GPIO numbers or Klipper MCU commands.
+
+## Motivating example
+
+Some printer ecosystems can display an accessory chamber sensor on a touchscreen but
+cannot make the printer firmware use it for chamber regulation. A DragonTouch-style
+product could bridge that locally attached sensor to DragonBreath:
+
+```text
+┌────────────────┐  I²C   ┌────────────────┐  Dragon peer telemetry  ┌──────────────┐
+│ chamber sensor │───────▶│ DragonTouch    │────────────────────────▶│ DragonBreath │
+└────────────────┘        │ provider/bridge│                         │ consumer      │
+                          └────────────────┘                         └──────┬───────┘
+                                                                          │
+                                                local NTC + PTC safety ────┤
+                                                                          ▼
+                                                                       heater
+```
+
+DragonBreath PR
+[#89](https://github.com/plastikman/DragonBreath/pull/89) establishes a useful
+product-local precedent: a fresh Bambu-reported chamber temperature can be selected
+for regulation, while DragonBreath's local chamber NTC, PTC, fixed cutoffs, fault
+handling, and output ownership remain local. This RFC generalizes the measurement
+provider without making Bambu or DragonTouch special cases in heater policy.
+
+## Scope
+
+Initial peer capabilities may include:
+
+- temperature, humidity, and other environmental observations;
+- switches, presence, and user input events;
+- accessory identity and health;
+- status/display surfaces; and
+- read-only product state useful to a unified family UI.
+
+Command capabilities may be proposed later, but observation does not imply command
+authority. Heater target/mode control and remote regulation input are distinct roles.
+
+## Roles
+
+### Provider
+
+A provider owns a capability and publishes its current state, validity, and metadata.
+It may bridge local hardware, but must preserve the sensor's remote/bridged identity.
+
+### Consumer
+
+A consumer explicitly binds a provider capability to a local purpose, tracks freshness
+using local receipt time, and owns loss/fallback policy.
+
+### Gateway
+
+A gateway adapts another integration plane—for example an ESP-NOW leaf—into peer
+capabilities. It does not erase the leaf identity or reset sample age merely because
+the gateway itself is online.
+
+### Browser/UI
+
+The family SPA may discover and present peer candidates or grouped product state. The
+browser is not required to relay safety-relevant telemetry between devices.
+
+## Capability identity
+
+A binding should address a stable tuple resembling:
+
+```text
+peer_id / capability_id
+```
+
+Example:
+
+```text
+dragontouch-a1b2 / sensor.chamber_air
+```
+
+Network address, mDNS name, model name, and user-facing label may change without
+changing the binding. A capability identifier remains stable across ordinary reboot
+and software update. Ownership transfer or factory reset creates a new trust decision.
+
+## Proposed observation model
+
+A temperature observation needs at least:
+
+| Field | Meaning |
+|---|---|
+| peer identity | paired source device |
+| capability identity | stable sensor/function within that device |
+| kind | e.g. `temperature.chamber_air` |
+| value and unit | finite temperature in a canonical wire unit |
+| valid | source believes the sample is usable |
+| sequence | ordering and duplicate detection |
+| boot/session ID | restart and replay boundary |
+| sampled age | optional source-side acquisition delay |
+| local receipt time | consumer-owned freshness authority |
+| optional accuracy/calibration metadata | diagnostic, not proof of correctness |
+
+A provider timestamp alone cannot establish freshness because peer clocks may be
+unset, skewed, or reset.
+
+## Regulation-source model
+
+DragonBreath should eventually replace provider-specific booleans with an explicit
+regulation binding, conceptually:
+
+```text
+local
+printer:bambu/chamber
+peer:<peer-id>/<capability-id>
+```
+
+The selected input affects set-point demand only. Local DragonBreath sensors retain:
+
+- chamber and element over-temperature trips;
+- sensor-open/short failure handling;
+- local thermal foldback;
+- communications/watchdog policy;
+- safe boot and fault-latch behavior; and
+- sole ownership of physical heater output.
+
+No remote sensor can raise local target ceilings or disable these protections.
+
+## Loss policies
+
+The consumer stores an explicit policy with each regulation binding:
+
+| Policy | Behavior when remote data is stale/unavailable |
+|---|---|
+| `suspend` | stop heater demand while retaining the user's armed mode/target |
+| `fallback_local` | regulate from the local chamber NTC |
+| `monitor_only` | never use the peer for regulation |
+
+`suspend` is the proposed default for a generic peer sensor. `fallback_local` may be
+appropriate when the product has validated that transition, but it is not universally
+conservative: a local sensor and remote bulk-air sensor can disagree in either
+direction.
+
+Recovery from a non-latching stale-data suspension may resume regulation when a fresh,
+authenticated sample returns. Whether a product requires manual acknowledgement is a
+product-policy decision and must be visible in its UI.
+
+## Freshness and plausibility
+
+The consumer should enforce:
+
+- a configured maximum receipt age;
+- finite and product-bounded values;
+- sequence/replay checks;
+- boot/session changes;
+- optional rate-of-change or jump diagnostics; and
+- immediate invalidation when the paired transport session loses trust.
+
+Plausibility filtering cannot turn a remote sensor into a safety sensor. It can only
+prevent clearly invalid data from influencing ordinary regulation.
+
+## Pairing and authorization
+
+Discovery lists candidates but grants no access. Pairing should:
+
+1. require a short explicit window or physical confirmation on at least one product;
+2. authenticate a stable peer identity;
+3. exchange or derive per-peer key material;
+4. record which capabilities may be consumed or commanded;
+5. show the binding on both products where UI exists; and
+6. support revocation, factory reset, and ownership transfer.
+
+Observation, regulation, and command permissions should be distinct. A peer authorized
+to publish a temperature is not thereby allowed to set a heater target.
+
+## Transport direction
+
+This RFC deliberately separates the semantic contract from its carrier. Candidate
+same-LAN transports include:
+
+- provider HTTP state with consumer polling;
+- provider SSE/WebSocket stream with bounded polling fallback;
+- authenticated periodic UDP/unicast telemetry; and
+- ESP-NOW where both powered products and channel constraints make it appropriate.
+
+The first implementation should favor existing ESP-IDF and dragon-core facilities,
+measure socket/memory cost, and fail cleanly under reconnect storms. A browser must not
+be the required relay.
+
+ESP-NOW leaves from [RFC 0003](0003-esp-now-peripheral-fabric.md) may enter this plane
+through a powered gateway. Their application identity and original sample age must be
+preserved across the bridge.
+
+## Discovery and grouping
+
+The existing
+[`dragon-family-unification.md`](../dragon-family-unification.md) proposes opt-in
+same-LAN discovery and explicit device groups for a unified family SPA. Peer discovery
+can reuse product identity and capability descriptions, but grouping and control
+authorization remain separate:
+
+- discovered does not mean paired;
+- paired does not mean grouped in the UI;
+- grouped does not mean authorized to command; and
+- a browser group is not a device-to-device safety path.
+
+## API and diagnostics
+
+A consumer should expose generic regulation diagnostics rather than requiring the UI
+to know every provider name. A future state shape could resemble:
+
+```json
+{
+  "regulation": {
+    "source": "peer:dragontouch-a1b2/sensor.chamber_air",
+    "temperature_c": 41.2,
+    "age_ms": 420,
+    "fresh": true,
+    "loss_policy": "suspend",
+    "active": true
+  }
+}
+```
+
+This is illustrative, not a frozen API. Existing Bambu-specific fields and persisted
+settings require an additive migration and compatibility period if generalized.
+
+Diagnostics should also show:
+
+- paired peer identity and display name;
+- capability identity and kind;
+- current validity/freshness reason;
+- last sequence/session transition;
+- transport reconnect/error counts; and
+- whether regulation is remote, local fallback, or suspended.
+
+Secrets, printer serials, raw credentials, and stable identifiers not needed by the
+client should not be exposed in public state or logs.
+
+## Prototype proposal
+
+The first proof should use simulated temperature values and no mains load:
+
+1. create a minimal provider exposing one `temperature.chamber_air` capability;
+2. pair one consumer to its stable identity;
+3. feed the observation into the existing DragonBreath external-regulation seam;
+4. use LEDs or a logic-level dummy output to observe demand;
+5. inject stale samples, replay, provider reboot, gateway reboot, address change,
+   corrupted values, and trust revocation;
+6. verify local safety inputs remain authoritative in every case; and
+7. then replace the simulator with DragonTouch plus a real attached sensor.
+
+## Acceptance criteria for an implementation
+
+- Discovery and pairing are separate, explicit operations.
+- Bindings use stable peer/capability identity, not address or friendly name.
+- The consumer owns freshness from local receipt time and never holds a sample
+  indefinitely.
+- Regulation, observation, and command permissions are distinct.
+- Loss policy is stored, visible, and covered by tests.
+- Remote regulation cannot bypass local limits, cutoffs, faults, or output ownership.
+- Provider restart, replay, address change, and malformed values have deterministic
+  behavior.
+- A bridge preserves original source identity and sample age.
+- UI/API diagnostics state whether regulation is remote, local fallback, or suspended.
+- A browser, cloud service, MQTT broker, or printer firmware is not required for the
+  direct product-to-product path unless explicitly selected by a later transport RFC.
+
+## Non-goals
+
+- Generic remote GPIO access.
+- Replacing Klipper MCU semantics.
+- Multi-sensor averaging or automatic sensor fusion in version 1.
+- Letting discovery grant command authority.
+- Making remote measurements local hard-safety sensors.
+- Selecting a final carrier before prototype measurements.
+
+## Feedback requested
+
+1. Is `peer_id/capability_id` sufficient for durable binding, or is another namespace
+   layer needed?
+2. Should `suspend` be the default loss policy for all remote regulation sources?
+3. What freshness bounds are appropriate for chamber regulation versus ordinary
+   environmental display?
+4. Should pairing and group management reuse one trust store or remain independent?
+5. Which carrier best fits powered peers without consuming too many ESP32 sockets or
+   coupling to browser availability?
+6. Which parts belong in dragon-core only after DragonTouch and DragonBreath validate
+   the boundary?

--- a/plans/rfcs/README.md
+++ b/plans/rfcs/README.md
@@ -1,0 +1,53 @@
+# Dragon RFC series
+
+This directory holds proposed cross-product architecture for the Dragon firmware
+family. RFCs are discussion documents: they define constraints, boundaries, and
+questions before implementation work is committed.
+
+Historical RFCs remain in [`plans/`](../) and are not being renumbered. New
+cross-product proposals use numbered files here so their relationships and status
+are easy to follow.
+
+## Status vocabulary
+
+| Status | Meaning |
+|---|---|
+| **Proposed** | Open for feedback; no implementation commitment. |
+| **Accepted** | Direction agreed; unresolved details may remain. |
+| **Implementing** | Accepted and represented by active implementation work. |
+| **Implemented** | Shipped and retained as a design record. |
+| **Superseded** | Replaced by another RFC, linked from both documents. |
+| **Withdrawn** | Deliberately abandoned. |
+
+A status change should happen in a reviewed pull request. Merging a Proposed RFC
+records the proposal and discussion; it does not by itself mark the proposal
+Accepted.
+
+## Current series
+
+| RFC | Title | Status |
+|---|---|---|
+| [0001](0001-dragon-integration-planes.md) | Dragon device integration planes | Proposed |
+| [0002](0002-wired-safety-spine.md) | Wired safety spine for heater-class devices | Proposed |
+| [0003](0003-esp-now-peripheral-fabric.md) | ESP-NOW low-power peripheral fabric | Proposed |
+| [0004](0004-peer-capability-plane.md) | Dragon peer capabilities and remote sensors | Proposed |
+
+RFC 0001 is the umbrella vocabulary. RFCs 0002–0004 are intentionally separate:
+they have different power, timing, trust, and failure requirements even when a
+future product participates in more than one plane.
+
+## Review expectations
+
+Feedback is especially useful when it identifies:
+
+- a device class that does not fit the proposed boundaries;
+- a safety property that accidentally depends on a network or radio path;
+- a transport assumption that is being confused with an application contract;
+- a compatibility or migration problem for deployed devices;
+- a failure mode that is not observable or testable;
+- a power, memory, socket, or timing cost missing from the proposal; or
+- a smaller first implementation that still validates the boundary.
+
+Implementation PRs should link the RFC they implement and state which acceptance
+criteria they cover. Material protocol or safety changes should update the RFC or
+supersede it rather than silently diverging.


### PR DESCRIPTION
## Summary

Starts a numbered RFC series for the emerging Dragon device architecture:

- RFC 0001 defines the umbrella model and cross-plane invariants
- RFC 0002 scopes the wired Klipper-MCU safety spine for heater-class devices
- RFC 0003 scopes both the existing reliable klipper-esp32 ESP-NOW MCU stream and the proposed low-power sleeping-leaf fabric
- RFC 0004 defines semantic Dragon peer capabilities and remote-sensor regulation
- adds RFC status/review conventions and a discoverable plans index

All four RFCs are Proposed. Merging this PR records the proposals for discussion; it does not mark them Accepted or commit us to implementation.

## Feedback requested

The documents call out detailed questions, but the highest-value review is:

1. Is the three-plane split correct for known Dragon products and accessories?
2. Should generic remote regulation suspend by default when its sensor becomes stale, or fall back locally?
3. Should the existing reliable klipper-esp32 ESP-NOW stream remain the continuously connected MCU path while sleeping leaves use a smaller Dragon capability protocol, and can both safely share the same frame envelope?
4. Is leaf-to-gateway the right initial topology?
5. Which pairing and identity concepts should be shared across wireless leaves and smart peers?
6. Which first prototype would test the architecture with the least hardware and safety risk?

## Grounding and validation

- incorporates the working [`klipper-esp32` `codex/transport-abstraction` branch](https://github.com/justinh-rahb/klipper-esp32/tree/codex/transport-abstraction) at [`bfb5d9b`](https://github.com/justinh-rahb/klipper-esp32/commit/bfb5d9baad3350b3a18d05e73e3334a871c5dade): S3 USB bridge to a C3 Klipper MCU over reliable ESP-NOW
- distinguishes that continuously connected prototype from unimplemented sleeping/battery-leaf requirements such as pairing, authentication, multi-node operation, deep sleep, and measured power budgets
- preserves DragonBreath product-local safety authority and dragon-core boundaries
- `git diff --check` passes
- relative links were checked against the current repository tree
- documentation only; no firmware behavior changes
