### PR TITLE
control: port chamber PID to dragon-core dc_pid

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Test heater safety-trip decision (over-temp / fail-closed / watchdog)
         run: sh tests/run_heater_safety_host_test.sh
 
+      - name: Test chamber dc_pid integration and safety hold
+        run: sh tests/run_heater_pid_host_test.sh
+
       - name: Test MQTT-Klipper arming state machine (retained-aware arm/heartbeat)
         run: sh tests/run_db_klipper_mqtt_host_test.sh
 

--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Test heater safety-trip decision (over-temp / fail-closed / watchdog)
         run: sh tests/run_heater_safety_host_test.sh
 
+      - name: Test zero-cross duplicate-edge filter
+        run: sh tests/run_fan_zc_host_test.sh
+
       - name: Test chamber dc_pid integration and safety hold
         run: sh tests/run_heater_pid_host_test.sh
 

--- a/components/pb_fan/CMakeLists.txt
+++ b/components/pb_fan/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS "pb_fan.c"
+    SRCS "pb_fan.c" "pb_fan_zc_filter.c"
     INCLUDE_DIRS "include"
     REQUIRES pb_board driver esp_timer
 )

--- a/components/pb_fan/include/pb_fan.h
+++ b/components/pb_fan/include/pb_fan.h
@@ -19,10 +19,11 @@ esp_err_t pb_fan_init(void);
 void pb_fan_set_level(uint8_t percent);
 uint8_t pb_fan_get_level(void);
 
-// Diagnostics: total zero-cross interrupts since boot, and microseconds between
-// the last two edges (mains cycle period). interval 0 = no zero-cross seen yet
-// (ZCD not working / no mains) — lets us verify the detector without firing.
-void pb_fan_zc_diag(uint32_t *count_out, uint32_t *interval_us_out);
+// Diagnostics: accepted edges since boot, interval between the last two accepted
+// edges, and rejected implausibly-close edges. interval 0 = fewer than two
+// accepted edges (ZCD not working / no mains).
+void pb_fan_zc_diag(uint32_t *count_out, uint32_t *interval_us_out,
+                    uint32_t *rejected_count_out);
 
 #ifdef CONFIG_PB_DEVBOARD_SAFE
 // Inject one or more zero-cross events into the dev-board backend.

--- a/components/pb_fan/include/pb_fan_zc_filter.h
+++ b/components/pb_fan/include/pb_fan_zc_filter.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+// Pure zero-cross edge filter shared by the Panda ISR and host tests.
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// Reject the ~1 ms duplicate edges observed on Panda while retaining valid
+// 60 Hz (~8.33 ms) and 50 Hz (10 ms) half-cycle edges.
+#define PB_FAN_ZC_MIN_INTERVAL_US 4000U
+
+typedef struct {
+    volatile uint32_t accepted_count;
+    volatile uint32_t accepted_interval_us;
+    volatile uint32_t rejected_count;
+    volatile uint64_t last_accepted_us;
+} pb_fan_zc_filter_t;
+
+void pb_fan_zc_filter_reset(pb_fan_zc_filter_t *state);
+
+// Record one observed edge. Rejected edges increment only rejected_count; they
+// never advance accepted timing/count state.
+bool pb_fan_zc_filter_record(pb_fan_zc_filter_t *state, uint64_t now_us);

--- a/components/pb_fan/pb_fan.c
+++ b/components/pb_fan/pb_fan.c
@@ -11,6 +11,7 @@
 // ONE zero-cross-synced pulse per half-cycle (phase control) — never PWM.
 #include "pb_fan.h"
 #include "pb_board.h"
+#include "pb_fan_zc_filter.h"
 
 #include "esp_log.h"
 #include "esp_timer.h"
@@ -21,17 +22,16 @@ static const char *TAG = "pb_fan";
 
 static volatile bool     s_want_on;
 static volatile bool     s_applied;
-static volatile uint32_t s_zc_count;
-static volatile uint32_t s_zc_interval_us;
-static volatile uint64_t s_zc_last_us;
+static pb_fan_zc_filter_t s_zc;
+#ifdef CONFIG_PB_DEVBOARD_SAFE
+static uint64_t s_hil_now_us;
+#endif
 
 #ifndef CONFIG_PB_DEVBOARD_SAFE
 static void IRAM_ATTR zcd_isr(void *arg)
 {
     uint64_t now = esp_timer_get_time();
-    if (s_zc_last_us) s_zc_interval_us = (uint32_t)(now - s_zc_last_us);
-    s_zc_last_us = now;
-    s_zc_count++;
+    if (!pb_fan_zc_filter_record(&s_zc, now)) return;
 
     bool on = s_want_on;                 // apply the commanded level at the zero cross
     if (on != s_applied) {
@@ -46,12 +46,15 @@ esp_err_t pb_fan_init(void)
 #ifdef CONFIG_PB_DEVBOARD_SAFE
     s_want_on = false;
     s_applied = false;
-    s_zc_count = 0;
-    s_zc_interval_us = 0;
-    s_zc_last_us = 0;
+    pb_fan_zc_filter_reset(&s_zc);
+    s_hil_now_us = 0;
     ESP_LOGW(TAG, "safe dev-board backend: fan gate and ZCD GPIOs compiled out");
     return ESP_OK;
 #else
+    s_want_on = false;
+    s_applied = false;
+    pb_fan_zc_filter_reset(&s_zc);
+
     const gpio_config_t gate = {
         .pin_bit_mask = (1ULL << PB_GPIO_FAN_GATE),
         .mode = GPIO_MODE_OUTPUT,
@@ -75,8 +78,6 @@ esp_err_t pb_fan_init(void)
     esp_err_t err = gpio_isr_handler_add(PB_GPIO_ZERO_CROSS, zcd_isr, NULL);
     if (err != ESP_OK) return err;
 
-    s_want_on = false;
-    s_applied = false;
     ESP_LOGI(TAG, "init: ON/OFF held-gate (stock model), gate GPIO%d, ZCD GPIO%d; never PWM'd",
              PB_GPIO_FAN_GATE, PB_GPIO_ZERO_CROSS);
     return ESP_OK;
@@ -98,18 +99,25 @@ void pb_fan_set_level(uint8_t percent)
 
 uint8_t pb_fan_get_level(void) { return s_want_on ? 100 : 0; }
 
-void pb_fan_zc_diag(uint32_t *count_out, uint32_t *interval_us_out)
+void pb_fan_zc_diag(uint32_t *count_out, uint32_t *interval_us_out,
+                    uint32_t *rejected_count_out)
 {
-    if (count_out) *count_out = s_zc_count;
-    if (interval_us_out) *interval_us_out = s_zc_interval_us;
+    if (count_out) *count_out = s_zc.accepted_count;
+    if (interval_us_out) *interval_us_out = s_zc.accepted_interval_us;
+    if (rejected_count_out) *rejected_count_out = s_zc.rejected_count;
 }
 
 #ifdef CONFIG_PB_DEVBOARD_SAFE
 void pb_fan_hil_zero_cross(uint32_t count, uint32_t interval_us)
 {
     if (count == 0) return;
-    s_zc_count += count;
-    s_zc_interval_us = interval_us;
-    s_applied = s_want_on;
+    for (uint32_t i = 0; i < count; i++) {
+        if (s_hil_now_us == 0)
+            s_hil_now_us = 1;
+        else
+            s_hil_now_us += interval_us;
+        if (pb_fan_zc_filter_record(&s_zc, s_hil_now_us))
+            s_applied = s_want_on;
+    }
 }
 #endif

--- a/components/pb_fan/pb_fan_zc_filter.c
+++ b/components/pb_fan/pb_fan_zc_filter.c
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+#include "pb_fan_zc_filter.h"
+
+#ifdef ESP_PLATFORM
+#include "esp_attr.h"
+#else
+#define IRAM_ATTR
+#endif
+
+#include <limits.h>
+
+void pb_fan_zc_filter_reset(pb_fan_zc_filter_t *state)
+{
+    if (!state) return;
+    state->accepted_count = 0;
+    state->accepted_interval_us = 0;
+    state->rejected_count = 0;
+    state->last_accepted_us = 0;
+}
+
+bool IRAM_ATTR pb_fan_zc_filter_record(pb_fan_zc_filter_t *state,
+                                       uint64_t now_us)
+{
+    if (!state) return false;
+
+    const uint64_t last = state->last_accepted_us;
+    if (last != 0) {
+        if (now_us <= last || now_us - last < PB_FAN_ZC_MIN_INTERVAL_US) {
+            state->rejected_count++;
+            return false;
+        }
+
+        const uint64_t interval = now_us - last;
+        state->accepted_interval_us = interval > UINT32_MAX
+            ? UINT32_MAX : (uint32_t)interval;
+    }
+
+    state->last_accepted_us = now_us;
+    state->accepted_count++;
+    return true;
+}

--- a/components/pb_heater/CMakeLists.txt
+++ b/components/pb_heater/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "pb_heater.c"
     INCLUDE_DIRS "include"
-    REQUIRES pb_board pb_ntc driver esp_timer nvs_flash
+    REQUIRES pb_board pb_ntc dc_pid driver esp_timer nvs_flash
 )

--- a/components/pb_heater/include/pb_heater.h
+++ b/components/pb_heater/include/pb_heater.h
@@ -176,7 +176,7 @@ static inline bool pb_heater_foldback_cut(bool ptc_ok, float ptc_c, bool prev_cu
 // priority ordering can be host-tested without the ADC/SSR/RTOS backend. Given the
 // freshest per-channel sensor reads (status-OK flags + instantaneous °C), whether a
 // target is armed, and whether the comms deadman has expired, returns the fault the
-// tick must latch — or PB_FAULT_NONE if it is safe to run the bang-bang loop. The
+// tick must latch — or PB_FAULT_NONE if it is safe to run the control loop. The
 // order is load-bearing and MUST stay identical to pb_heater_tick():
 //   1. PTC over-temp     — only trusted when the PTC sensor reads valid
 //   2. chamber over-temp — only trusted when the chamber sensor reads valid
@@ -257,10 +257,10 @@ float     pb_heater_get_fb_cut_c(void);
 // pb_heater_get_comms_timeout_ms() while heating, the heater latches off.
 void pb_heater_notify_link_alive(void);
 
-// Periodic control tick (call at ~1-2 Hz). Reads the local chamber + PTC temps,
-// enforces all safety cutoffs from those local sensors, and drives the SSR with
-// hysteresis around the set-point using the optional external regulation
-// temperature when one is supplied.
+// Periodic control tick (call at ~2 Hz). Reads the local chamber + PTC temps,
+// enforces all safety cutoffs from those local sensors, and drives the SSR from
+// the shared dc_pid controller using the optional external regulation temperature
+// when one is supplied (otherwise the local chamber NTC is the process variable).
 void pb_heater_tick(void);
 
 // Immediate, latching shutoff. Clears the target and latches off. Heat stays off
@@ -313,9 +313,9 @@ pb_fault_reason_t pb_heater_fault_code(void);
 // Canonical, stable string for a fault code (never NULL; out-of-range -> generic).
 const char *pb_heater_fault_str(pb_fault_reason_t code);
 
-// True if the SSR is currently commanded on (momentary bang-bang state).
+// True if the SSR is currently commanded on (momentary time-proportion state).
 bool pb_heater_is_on(void);
 
 // True in "heat mode": a target is armed and no fault is latched. Steady across
-// the SSR's bang-bang cycling — use this (not pb_heater_is_on) for the fan/LED.
+// the SSR's time-proportion cycling — use this (not pb_heater_is_on) for the fan/LED.
 bool pb_heater_heat_mode(void);

--- a/components/pb_heater/include/pb_heater_pid.h
+++ b/components/pb_heater/include/pb_heater_pid.h
@@ -10,8 +10,8 @@
 // DragonBreath-owned chamber-controller policy. dc_pid supplies only the generic
 // PID math; sensor selection, safety inhibition, approach limiting, and the SSR
 // time-proportioning actuator remain product responsibilities.
-#define PB_HEATER_PID_KP         0.0250f
-#define PB_HEATER_PID_KI         0.0003f
+#define PB_HEATER_PID_KP         0.1000f
+#define PB_HEATER_PID_KI         0.0010f
 #define PB_HEATER_PID_KD         0.0400f
 #define PB_HEATER_PID_D_ALPHA    0.20f
 #define PB_HEATER_PID_DT_S       0.50f
@@ -65,8 +65,8 @@ static inline bool pb_heater_pid_set_source(pb_heater_pid_state_t *state,
 static inline float pb_heater_pid_approach_max_duty(float error_c)
 {
     if (error_c <= 0.0f) return 0.0f;
-    if (error_c < 5.0f)  return 0.40f;
-    if (error_c < 10.0f) return 0.70f;
+    if (error_c < 2.0f) return 0.40f;
+    if (error_c < 5.0f) return 0.70f;
     return 1.0f;
 }
 

--- a/components/pb_heater/include/pb_heater_pid.h
+++ b/components/pb_heater/include/pb_heater_pid.h
@@ -84,6 +84,17 @@ static inline bool pb_heater_pid_step(pb_heater_pid_state_t *state,
 
     const float error_c = target_c - measurement_c;
     const float approach_cap = pb_heater_pid_approach_max_duty(error_c);
+    const float output_max = approach_cap > 0.0f ? approach_cap : 1.0f;
+    const float proportional = PB_HEATER_PID_KP * error_c;
+    // Keep stored, non-derivative demand inside the actuator range that
+    // DragonBreath currently exposes. dc_pid normalizes an existing integral
+    // against a contracted bound transactionally, so a 1.00 -> 0.70 -> 0.40
+    // approach transition cannot leave hidden integral behind the tighter cap.
+    // Derivative/history continuity is preserved; a transient derivative may
+    // still move the requested output within dc_pid's active output range.
+    float integral_max = output_max - proportional;
+    if (integral_max < 0.0f) integral_max = 0.0f;
+    if (integral_max > 1.0f) integral_max = 1.0f;
     const dc_pid_config_t config = {
         .kp = PB_HEATER_PID_KP,
         .ki = PB_HEATER_PID_KI,
@@ -94,9 +105,9 @@ static inline bool pb_heater_pid_step(pb_heater_pid_state_t *state,
         // it while deciding whether additional integration would wind up.
         // At/above target the heater-only policy below commands zero; retain a
         // valid controller range so history and negative-error unwinding advance.
-        .output_max = approach_cap > 0.0f ? approach_cap : 1.0f,
+        .output_max = output_max,
         .integral_min = 0.0f,
-        .integral_max = 1.0f,
+        .integral_max = integral_max,
     };
     dc_pid_result_t result;
     if (!dc_pid_step(&state->controller, &config, target_c, measurement_c,

--- a/components/pb_heater/include/pb_heater_pid.h
+++ b/components/pb_heater/include/pb_heater_pid.h
@@ -82,13 +82,19 @@ static inline bool pb_heater_pid_step(pb_heater_pid_state_t *state,
     if (duty) *duty = 0.0f;
     if (!state || !duty) return false;
 
+    const float error_c = target_c - measurement_c;
+    const float approach_cap = pb_heater_pid_approach_max_duty(error_c);
     const dc_pid_config_t config = {
         .kp = PB_HEATER_PID_KP,
         .ki = PB_HEATER_PID_KI,
         .kd = PB_HEATER_PID_KD,
         .derivative_alpha = PB_HEATER_PID_D_ALPHA,
         .output_min = 0.0f,
-        .output_max = 1.0f,
+        // The approach ceiling is normal actuator shaping, so dc_pid must see
+        // it while deciding whether additional integration would wind up.
+        // At/above target the heater-only policy below commands zero; retain a
+        // valid controller range so history and negative-error unwinding advance.
+        .output_max = approach_cap > 0.0f ? approach_cap : 1.0f,
         .integral_min = 0.0f,
         .integral_max = 1.0f,
     };
@@ -100,8 +106,7 @@ static inline bool pb_heater_pid_step(pb_heater_pid_state_t *state,
     if (measurement_c >= target_c)
         return true;
 
-    float approach_cap = pb_heater_pid_approach_max_duty(target_c - measurement_c);
-    *duty = result.output < approach_cap ? result.output : approach_cap;
+    *duty = result.output;
     return true;
 }
 

--- a/components/pb_heater/include/pb_heater_pid.h
+++ b/components/pb_heater/include/pb_heater_pid.h
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <math.h>
+
+#include "dc_pid.h"
+
+// DragonBreath-owned chamber-controller policy. dc_pid supplies only the generic
+// PID math; sensor selection, safety inhibition, approach limiting, and the SSR
+// time-proportioning actuator remain product responsibilities.
+#define PB_HEATER_PID_KP         0.0250f
+#define PB_HEATER_PID_KI         0.0003f
+#define PB_HEATER_PID_KD         0.0400f
+#define PB_HEATER_PID_D_ALPHA    0.20f
+#define PB_HEATER_PID_DT_S       0.50f
+#define PB_HEATER_PID_WINDOW_US  10000000LL
+
+typedef struct {
+    dc_pid_state_t controller;
+    int64_t window_start_us;
+    bool window_initialized;
+    bool source_known;
+    bool using_external;
+} pb_heater_pid_state_t;
+
+// Select the effective process variable while keeping source policy explicit.
+// The caller decides whether external telemetry is eligible; NAN represents
+// unavailable/stale/not-authorized and therefore falls back to the local NTC.
+static inline float pb_heater_pid_process_variable(float local_chamber_c,
+                                                    float external_chamber_c,
+                                                    bool *using_external)
+{
+    bool external = isfinite(external_chamber_c);
+    if (using_external) *using_external = external;
+    return external ? external_chamber_c : local_chamber_c;
+}
+
+static inline void pb_heater_pid_reset(pb_heater_pid_state_t *state)
+{
+    if (!state) return;
+    dc_pid_reset(&state->controller);
+    state->window_start_us = 0;
+    state->window_initialized = false;
+    state->source_known = false;
+    state->using_external = false;
+}
+
+// Prevent derivative/integral history from crossing between physically distinct
+// chamber sensors. Returns true when a new source became active.
+static inline bool pb_heater_pid_set_source(pb_heater_pid_state_t *state,
+                                            bool using_external)
+{
+    if (!state) return false;
+    if (state->source_known && state->using_external == using_external)
+        return false;
+
+    pb_heater_pid_reset(state);
+    state->source_known = true;
+    state->using_external = using_external;
+    return true;
+}
+
+static inline float pb_heater_pid_approach_max_duty(float error_c)
+{
+    if (error_c <= 0.0f) return 0.0f;
+    if (error_c < 5.0f)  return 0.40f;
+    if (error_c < 10.0f) return 0.70f;
+    return 1.0f;
+}
+
+// Advance the common chamber PID path. When integrate is false, dc_pid still
+// updates measurement/derivative history but holds the integral so product
+// safety governors cannot hide accumulating demand behind an inhibited heater.
+// DragonBreath's heater-only policy commands zero at/above target without
+// discarding valid controller history.
+static inline bool pb_heater_pid_step(pb_heater_pid_state_t *state,
+                                      float target_c, float measurement_c,
+                                      bool integrate, float *duty)
+{
+    if (duty) *duty = 0.0f;
+    if (!state || !duty) return false;
+
+    const dc_pid_config_t config = {
+        .kp = PB_HEATER_PID_KP,
+        .ki = PB_HEATER_PID_KI,
+        .kd = PB_HEATER_PID_KD,
+        .derivative_alpha = PB_HEATER_PID_D_ALPHA,
+        .output_min = 0.0f,
+        .output_max = 1.0f,
+        .integral_min = 0.0f,
+        .integral_max = 1.0f,
+    };
+    dc_pid_result_t result;
+    if (!dc_pid_step(&state->controller, &config, target_c, measurement_c,
+                     PB_HEATER_PID_DT_S, integrate, &result))
+        return false;
+
+    if (measurement_c >= target_c)
+        return true;
+
+    float approach_cap = pb_heater_pid_approach_max_duty(target_c - measurement_c);
+    *duty = result.output < approach_cap ? result.output : approach_cap;
+    return true;
+}
+
+// Convert normalized duty into zero-cross-SSR time proportioning. `now_us`
+// may jump backwards across a timer reset; that simply starts a fresh window.
+static inline bool pb_heater_pid_window_on(pb_heater_pid_state_t *state,
+                                           float duty, int64_t now_us)
+{
+    if (!state || duty <= 0.0f) return false;
+    if (duty > 1.0f) duty = 1.0f;
+
+    if (!state->window_initialized || now_us < state->window_start_us) {
+        state->window_start_us = now_us;
+        state->window_initialized = true;
+    }
+
+    int64_t elapsed = now_us - state->window_start_us;
+    if (elapsed >= PB_HEATER_PID_WINDOW_US) {
+        int64_t windows = elapsed / PB_HEATER_PID_WINDOW_US;
+        state->window_start_us += windows * PB_HEATER_PID_WINDOW_US;
+        elapsed = now_us - state->window_start_us;
+    }
+
+    int64_t on_us = (int64_t)(duty * (float)PB_HEATER_PID_WINDOW_US);
+    return on_us > 0 && elapsed < on_us;
+}

--- a/components/pb_heater/pb_heater.c
+++ b/components/pb_heater/pb_heater.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include "pb_heater.h"
+#include "pb_heater_pid.h"
 #include "pb_board.h"
 #include "pb_ntc.h"
 
@@ -35,9 +36,7 @@ static bool        s_persist_pending;  // guarded by s_mux — a latch persist n
                                        // to NVS; retried from pb_heater_tick until it lands
 static int64_t     s_persist_retry_us; // guarded by s_mux — last persist-retry timestamp
 static bool        s_on;            // written only by the control task; atomic read
-static bool        s_heat_intent;   // control-task only — chamber-hysteresis latch (the
-                                    // "want heat at all" decision, distinct from the
-                                    // momentary SSR state s_on)
+static pb_heater_pid_state_t s_pid; // control-task only — shared dc_pid state + SSR window
 static bool        s_fb_cut;        // control-task only — element-foldback hysteresis latch:
                                     // true while the SSR is force-cut for element over-temp
                                     // (holds until the element cools below the resume point)
@@ -112,6 +111,7 @@ esp_err_t pb_heater_init(void)
     if (err != ESP_OK) return err;
 #endif
     ssr_set(false);                  // guaranteed OFF before any request
+    pb_heater_pid_reset(&s_pid);
     taskENTER_CRITICAL(&s_mux);
     s_target_c = 0.0f;
     s_control_chamber_c = NAN;
@@ -576,30 +576,27 @@ void pb_heater_tick(void)          // control-task context; sole writer of s_on
 
     if (latched || !armed) {
         if (s_on) ssr_set(false);
-        s_heat_intent = false;   // drop the chamber + foldback latches so the next arm
-        s_fb_cut      = false;   // starts clean rather than mid-cycle
+        pb_heater_pid_reset(&s_pid);
+        s_fb_cut      = false;   // drop foldback latches so the next arm starts clean
         s_local_cut   = false;
         return;
     }
 
     // Here: armed && !latched && cs==OK && ps==OK.
-    // Step 1 — chamber bang-bang with hysteresis decides the BASE demand (do we want
-    // heat at all). If policy supplied a finite external control temperature (for
-    // example the printer-reported chamber sensor), use it ONLY for regulation.
-    // The local chamber NTC above remains authoritative for every safety trip.
-    float regulation_c = isfinite(control_chamber_c) ? control_chamber_c : chamber_c;
-    if (regulation_c < (target - PB_HEATER_HYSTERESIS_C)) {
-        s_heat_intent = true;
-    } else if (regulation_c >= target) {
-        s_heat_intent = false;
-    }
+    // Step 1 — select the process variable. Policy supplies a finite external value
+    // only for AUTO mode with fresh Bambu telemetry and the persisted preference on;
+    // NAN means use DragonBreath's local chamber NTC. Both sources feed this same PID
+    // path. Local sensors above remain authoritative for every safety decision.
+    bool external_regulation;
+    float regulation_c = pb_heater_pid_process_variable(
+        chamber_c, control_chamber_c, &external_regulation);
+    pb_heater_pid_set_source(&s_pid, external_regulation);
 
     // Step 2 — local chamber soft foldback for REMOTE regulation. The printer sensor
     // represents bulk chamber air, while DragonBreath's local chamber NTC can see much
     // hotter outlet/near-heater air. When an external control temperature is active, cut
     // heat at the local soft ceiling and hold it off until the local region cools through
     // the resume threshold. The fixed 85 C chamber trip above remains the latching backstop.
-    bool external_regulation = isfinite(control_chamber_c);
     if (external_regulation)
         s_local_cut = pb_heater_local_foldback_cut(cs == PB_NTC_OK, chamber_c, s_local_cut);
     else
@@ -614,8 +611,21 @@ void pb_heater_tick(void)          // control-task context; sole writer of s_on
     pb_heater_effective_foldback(pb_heater_get_fb_cut_c(), pb_ntc_rref_kohm(), &fb_cut, &fb_resume);
     s_fb_cut = pb_heater_foldback_cut(ps == PB_NTC_OK, ptc_c, s_fb_cut, fb_cut, fb_resume);
 
-    // Step 4 — drive the SSR only when regulation wants heat and neither soft limiter
-    // is holding it off. (Zero-cross SSR: plain on/off, no phase-cut.)
-    bool drive = s_heat_intent && !s_local_cut && !s_fb_cut;
+    // Step 4 — advance the common chamber PID. If either local soft safety layer
+    // inhibits the requested output, hold integration while still updating the
+    // measurement/derivative history. The safety layers remain downstream and
+    // authoritative regardless of PID demand.
+    bool safety_inhibited = s_local_cut || s_fb_cut;
+    float duty = 0.0f;
+    if (!pb_heater_pid_step(&s_pid, target, regulation_c,
+                            !safety_inhibited, &duty)) {
+        ESP_LOGE(TAG, "PID step rejected; forcing SSR off");
+        duty = 0.0f;
+    }
+
+    // Step 5 — time-proportion normalized duty through a slow 10 s window. This is
+    // still plain on/off drive of a zero-cross SSR; there is no phase cutting.
+    bool drive = !safety_inhibited &&
+                 pb_heater_pid_window_on(&s_pid, duty, esp_timer_get_time());
     if (drive != s_on) ssr_set(drive);
 }

--- a/components/pb_hil/pb_hil.c
+++ b/components/pb_hil/pb_hil.c
@@ -108,7 +108,8 @@ static cJSON *state_json(void)
 
     uint32_t zc_count = 0;
     uint32_t zc_interval_us = 0;
-    pb_fan_zc_diag(&zc_count, &zc_interval_us);
+    uint32_t zc_rejected_count = 0;
+    pb_fan_zc_diag(&zc_count, &zc_interval_us, &zc_rejected_count);
     cJSON *io = cJSON_AddObjectToObject(state, "io");
 #ifdef CONFIG_PB_HIL_DEVBOARD
     cJSON_AddStringToObject(io, "target", "devboard");
@@ -119,6 +120,7 @@ static cJSON *state_json(void)
 #endif
     cJSON_AddNumberToObject(io, "zero_cross_count", zc_count);
     cJSON_AddNumberToObject(io, "zero_cross_interval_us", zc_interval_us);
+    cJSON_AddNumberToObject(io, "zero_cross_rejected_count", zc_rejected_count);
     cJSON *leds = cJSON_AddObjectToObject(io, "leds");
     cJSON_AddStringToObject(leds, "power", led_pattern_str(pb_leds_get(PB_LED_POWER)));
     cJSON_AddStringToObject(leds, "auto", led_pattern_str(pb_leds_get(PB_LED_AUTO)));

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -338,8 +338,8 @@ static void control_task(void *arg)
             bool net = s_net_up;
             pb_policy_snapshot_t snap;
             pb_policy_get_snapshot(&snap);
-            uint32_t zc = 0, zciv = 0;
-            pb_fan_zc_diag(&zc, &zciv);
+            uint32_t zc = 0, zciv = 0, zcrej = 0;
+            pb_fan_zc_diag(&zc, &zciv, &zcrej);
             // Build the status line WITHOUT the ZC counters (which change every
             // sample). Collapse consecutive identical states into a single
             // "repeated Nx" instead of spamming a line every 2 s — this keeps the
@@ -398,14 +398,16 @@ static void control_task(void *arg)
             if (strcmp(key, s_dbg_last) == 0) {
                 s_dbg_rep++;
                 if (s_dbg_rep % 30 == 0)   // ~60 s liveness flush during a long run
-                    ESP_LOGI(TAG, "%s | repeated %lux | ZC n=%lu dt=%luus",
+                    ESP_LOGI(TAG, "%s | repeated %lux | ZC n=%lu dt=%luus rejected=%lu",
                              line, (unsigned long)s_dbg_rep,
-                             (unsigned long)zc, (unsigned long)zciv);
+                             (unsigned long)zc, (unsigned long)zciv,
+                             (unsigned long)zcrej);
             } else {
                 if (s_dbg_rep > 0)
                     ESP_LOGI(TAG, "(previous line repeated %lux)", (unsigned long)s_dbg_rep);
-                ESP_LOGI(TAG, "%s | ZC n=%lu dt=%luus",
-                         line, (unsigned long)zc, (unsigned long)zciv);
+                ESP_LOGI(TAG, "%s | ZC n=%lu dt=%luus rejected=%lu",
+                         line, (unsigned long)zc, (unsigned long)zciv,
+                         (unsigned long)zcrej);
                 strncpy(s_dbg_last, key, sizeof s_dbg_last - 1);
                 s_dbg_last[sizeof s_dbg_last - 1] = '\0';
                 s_dbg_rep = 0;

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -35,9 +35,7 @@ dependencies:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_portal
     version: v0.30.0
-  # Temporary exact pin for draft integration against dragon-core PR #54.
-  # Replace with the normal released/tagged dragon-core dependency after merge.
   dc_pid:
-    git: https://github.com/danielbrownjr/dragon-core.git
+    git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_pid
-    version: 3447fd4d7d76235c8d14b10aed18a7c169e3fc80
+    version: v0.31.0

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -35,3 +35,9 @@ dependencies:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_portal
     version: v0.30.0
+  # Temporary exact pin for draft integration against dragon-core PR #54.
+  # Replace with the normal released/tagged dragon-core dependency after merge.
+  dc_pid:
+    git: https://github.com/danielbrownjr/dragon-core.git
+    path: components/dc_pid
+    version: 3447fd4d7d76235c8d14b10aed18a7c169e3fc80

--- a/tests/hil/scenarios/devboard-auto.json
+++ b/tests/hil/scenarios/devboard-auto.json
@@ -2,7 +2,16 @@
   "name": "devboard AUTO environment injection",
   "targets": ["devboard"],
   "steps": [
-    {"name": "start safe", "send": {"cmd": "off"}},
+    {
+      "name": "start safe",
+      "send": {"cmd": "off"},
+      "expect": {
+        "ok": true,
+        "state.mode": "off",
+        "state.heater_output": false,
+        "state.io.mains_gpio_compiled_out": true
+      }
+    },
     {
       "name": "nominal chamber",
       "send": {"cmd": "sensor", "channel": "chamber", "status": "ok", "temp_c": 25}
@@ -22,7 +31,13 @@
     },
     {
       "name": "disconnected printer cannot engage",
-      "send": {"cmd": "env", "connected": false, "bed_c": 110}
+      "send": {
+        "cmd": "env",
+        "connected": false,
+        "bed_c": 110,
+        "src_target_c": 55,
+        "chamber_src_c": 25
+      }
     },
     {"name": "allow disconnected tick", "wait_s": 0.7},
     {
@@ -37,7 +52,13 @@
     },
     {
       "name": "connect at threshold",
-      "send": {"cmd": "env", "connected": true, "bed_c": 100}
+      "send": {
+        "cmd": "env",
+        "connected": true,
+        "bed_c": 100,
+        "src_target_c": 55,
+        "chamber_src_c": 25
+      }
     },
     {"name": "allow engaged tick", "wait_s": 0.7},
     {
@@ -46,12 +67,19 @@
       "expect": {
         "ok": true,
         "state.auto_engaged": true,
+        "state.effective_target_c": 55,
         "state.heater_output": true
       }
     },
     {
       "name": "disconnect live printer",
-      "send": {"cmd": "env", "connected": false, "bed_c": 100}
+      "send": {
+        "cmd": "env",
+        "connected": false,
+        "bed_c": 100,
+        "src_target_c": 55,
+        "chamber_src_c": 25
+      }
     },
     {"name": "allow fail-closed tick", "wait_s": 0.7},
     {

--- a/tests/hil/scenarios/devboard-buttons.json
+++ b/tests/hil/scenarios/devboard-buttons.json
@@ -3,6 +3,16 @@
   "targets": ["devboard"],
   "steps": [
     {
+      "name": "start safe",
+      "send": {"cmd": "off"},
+      "expect": {
+        "ok": true,
+        "state.mode": "off",
+        "state.heater_output": false,
+        "state.io.mains_gpio_compiled_out": true
+      }
+    },
+    {
       "name": "inject nominal chamber sensor",
       "send": {"cmd": "sensor", "channel": "chamber", "status": "ok", "temp_c": 25}
     },

--- a/tests/hil/scenarios/devboard-safety.json
+++ b/tests/hil/scenarios/devboard-safety.json
@@ -3,6 +3,16 @@
   "targets": ["devboard"],
   "steps": [
     {
+      "name": "start safe",
+      "send": {"cmd": "off"},
+      "expect": {
+        "ok": true,
+        "state.mode": "off",
+        "state.heater_output": false,
+        "state.io.mains_gpio_compiled_out": true
+      }
+    },
+    {
       "name": "boot is safe and mains GPIO is absent",
       "send": {"cmd": "state"},
       "expect": {

--- a/tests/hil/scenarios/panda-smoke.json
+++ b/tests/hil/scenarios/panda-smoke.json
@@ -8,7 +8,11 @@
       "expect": {
         "ok": true,
         "state.mode": "off",
-        "state.heater_output": false
+        "state.heater_output": false,
+        "state.fan_percent": 0
+      },
+      "save": {
+        "zc_before": "state.io.zero_cross_count"
       }
     },
     {
@@ -17,7 +21,37 @@
       "expect": {
         "ok": true,
         "state.io.target": "panda",
-        "state.io.mains_gpio_compiled_out": false
+        "state.io.mains_gpio_compiled_out": false,
+        "state.heater_output": false,
+        "state.fan_percent": 0,
+        "state.io.zero_cross_rejected_count": {"gte": 0}
+      }
+    },
+    {
+      "name": "observe five seconds of non-heating zero-cross cadence",
+      "wait_s": 5.0
+    },
+    {
+      "name": "verify filtered 60 Hz half-cycle cadence",
+      "send": {"cmd": "state"},
+      "expect": {
+        "ok": true,
+        "state.mode": "off",
+        "state.heater_output": false,
+        "state.fan_percent": 0,
+        "state.io.zero_cross_count": {"delta_between": ["$zc_before", 500, 700]},
+        "state.io.zero_cross_interval_us": {"between": [6500, 10000]},
+        "state.io.zero_cross_rejected_count": {"gte": 0}
+      }
+    },
+    {
+      "name": "finish safe",
+      "send": {"cmd": "off"},
+      "expect": {
+        "ok": true,
+        "state.mode": "off",
+        "state.heater_output": false,
+        "state.fan_percent": 0
       }
     }
   ]

--- a/tests/hil/scenarios/panda-smoke.json
+++ b/tests/hil/scenarios/panda-smoke.json
@@ -3,21 +3,21 @@
   "targets": ["panda"],
   "steps": [
     {
+      "name": "start safe",
+      "send": {"cmd": "off"},
+      "expect": {
+        "ok": true,
+        "state.mode": "off",
+        "state.heater_output": false
+      }
+    },
+    {
       "name": "identify real hardware target",
       "send": {"cmd": "state"},
       "expect": {
         "ok": true,
         "state.io.target": "panda",
         "state.io.mains_gpio_compiled_out": false
-      }
-    },
-    {
-      "name": "physical OFF is always accepted",
-      "send": {"cmd": "off"},
-      "expect": {
-        "ok": true,
-        "state.mode": "off",
-        "state.heater_output": false
       }
     }
   ]

--- a/tests/pb_fan_zc_host_test.c
+++ b/tests/pb_fan_zc_host_test.c
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+#include "pb_fan_zc_filter.h"
+
+#include <assert.h>
+#include <stdio.h>
+
+int main(void)
+{
+    pb_fan_zc_filter_t state = {0};
+    pb_fan_zc_filter_reset(&state);
+
+    assert(pb_fan_zc_filter_record(&state, 1000000));
+    assert(state.accepted_count == 1);
+    assert(state.accepted_interval_us == 0);
+
+    // The observed ~0.99 ms companion edge is rejected and cannot move the
+    // accepted timestamp or interval.
+    assert(!pb_fan_zc_filter_record(&state, 1000990));
+    assert(state.accepted_count == 1);
+    assert(state.rejected_count == 1);
+    assert(state.last_accepted_us == 1000000);
+    assert(state.accepted_interval_us == 0);
+
+    // The following real 60 Hz half-cycle remains 8.33 ms from the last
+    // accepted edge even though a rejected edge occurred in between.
+    assert(pb_fan_zc_filter_record(&state, 1008333));
+    assert(state.accepted_count == 2);
+    assert(state.accepted_interval_us == 8333);
+
+    // A 50 Hz half-cycle remains valid.
+    assert(pb_fan_zc_filter_record(&state, 1018333));
+    assert(state.accepted_count == 3);
+    assert(state.accepted_interval_us == 10000);
+
+    assert(!pb_fan_zc_filter_record(&state, 1022332));
+    assert(state.rejected_count == 2);
+    assert(state.last_accepted_us == 1018333);
+
+    // The threshold is inclusive: 3999 us is rejected, exactly 4000 us is
+    // accepted.
+    assert(pb_fan_zc_filter_record(&state, 1022333));
+    assert(state.accepted_count == 4);
+    assert(state.accepted_interval_us == PB_FAN_ZC_MIN_INTERVAL_US);
+
+    puts("pb_fan zero-cross filter checks: PASS");
+    return 0;
+}

--- a/tests/pb_heater_pid_host_test.c
+++ b/tests/pb_heater_pid_host_test.c
@@ -17,12 +17,12 @@ static void test_known_gains_and_heater_policy(void)
 
     CHECK(pb_heater_pid_step(&state, 60.0f, 52.0f, true, &duty));
     CHECK(isfinite(duty));
-    CHECK(duty > 0.19f && duty < 0.22f);
+    CHECK(duty > 0.80f && duty < 0.81f);
     CHECK(state.controller.initialized);
 
     for (int i = 0; i < 120; ++i)
         CHECK(pb_heater_pid_step(&state, 60.0f, 52.0f, true, &duty));
-    CHECK(duty > 0.30f && duty < 0.40f);
+    CHECK(duty > 0.99f && duty <= 1.0f);
 
     // DragonBreath is heater-only: exact/above target commands zero, while
     // dc_pid history remains coherent rather than being reset at every crossing.
@@ -48,10 +48,10 @@ static void test_approach_and_ssr_window(void)
     CHECK(pb_heater_pid_approach_max_duty(-0.1f) == 0.0f);
     CHECK(pb_heater_pid_approach_max_duty(0.0f) == 0.0f);
     CHECK(pb_heater_pid_approach_max_duty(0.1f) == 0.40f);
-    CHECK(pb_heater_pid_approach_max_duty(4.99f) == 0.40f);
-    CHECK(pb_heater_pid_approach_max_duty(5.0f) == 0.70f);
-    CHECK(pb_heater_pid_approach_max_duty(9.99f) == 0.70f);
-    CHECK(pb_heater_pid_approach_max_duty(10.0f) == 1.0f);
+    CHECK(pb_heater_pid_approach_max_duty(1.99f) == 0.40f);
+    CHECK(pb_heater_pid_approach_max_duty(2.0f) == 0.70f);
+    CHECK(pb_heater_pid_approach_max_duty(4.99f) == 0.70f);
+    CHECK(pb_heater_pid_approach_max_duty(5.0f) == 1.0f);
 
     pb_heater_pid_state_t state = {0};
     const int64_t start = 1000000;
@@ -68,42 +68,40 @@ static void test_approach_caps_prevent_integral_windup(void)
     pb_heater_pid_state_t state = {0};
     float duty = 0.0f;
 
-    // Justin's reported case: a fixed 4 C error remains under the 40% approach
+    // A fixed 1 C error remains under the 40% approach
     // ceiling for thousands of samples without storing demand behind that cap.
     for (int i = 0; i < 4000; ++i) {
-        CHECK(pb_heater_pid_step(&state, 60.0f, 56.0f, true, &duty));
+        CHECK(pb_heater_pid_step(&state, 60.0f, 59.0f, true, &duty));
         CHECK(duty <= 0.400001f);
     }
     float integral_at_40 = state.controller.integral;
-    float raw_at_40 = PB_HEATER_PID_KP * 4.0f + integral_at_40;
+    float raw_at_40 = PB_HEATER_PID_KP * 1.0f + integral_at_40;
     CHECK(integral_at_40 > 0.29f && integral_at_40 < 0.301f);
     CHECK(raw_at_40 <= 0.400001f);
 
-    // Relaxing the active ceiling does not reveal a hidden integral jump. Only
-    // the single normal integration increment for the new 6 C error is allowed.
-    CHECK(pb_heater_pid_step(&state, 60.0f, 54.0f, true, &duty));
-    CHECK(state.controller.integral > integral_at_40);
-    CHECK(state.controller.integral - integral_at_40 < 0.001f);
+    // Relaxing the active ceiling does not reveal a hidden integral jump.
+    CHECK(pb_heater_pid_step(&state, 60.0f, 56.0f, true, &duty));
+    CHECK_NEAR(state.controller.integral, integral_at_40, 0.000001f);
     CHECK(duty <= 0.700001f);
 
     pb_heater_pid_reset(&state);
     for (int i = 0; i < 4000; ++i) {
-        CHECK(pb_heater_pid_step(&state, 60.0f, 52.0f, true, &duty));
+        CHECK(pb_heater_pid_step(&state, 60.0f, 56.0f, true, &duty));
         CHECK(duty <= 0.700001f);
     }
-    float raw_at_70 = PB_HEATER_PID_KP * 8.0f + state.controller.integral;
-    CHECK(state.controller.integral > 0.49f && state.controller.integral < 0.501f);
+    float raw_at_70 = PB_HEATER_PID_KP * 4.0f + state.controller.integral;
+    CHECK(state.controller.integral > 0.29f && state.controller.integral < 0.301f);
     CHECK(raw_at_70 <= 0.700001f);
 
     // Outside the approach bands, the original full 0..1 controller range is
     // still available and converges against that unchanged ceiling.
     pb_heater_pid_reset(&state);
     for (int i = 0; i < 4000; ++i) {
-        CHECK(pb_heater_pid_step(&state, 60.0f, 48.0f, true, &duty));
+        CHECK(pb_heater_pid_step(&state, 60.0f, 54.0f, true, &duty));
         CHECK(duty <= 1.000001f);
     }
-    float raw_uncapped = PB_HEATER_PID_KP * 12.0f + state.controller.integral;
-    CHECK(state.controller.integral > 0.69f && state.controller.integral < 0.701f);
+    float raw_uncapped = PB_HEATER_PID_KP * 6.0f + state.controller.integral;
+    CHECK(state.controller.integral > 0.39f && state.controller.integral < 0.401f);
     CHECK(raw_uncapped <= 1.000001f);
     CHECK(duty > 0.99f);
 }
@@ -116,26 +114,26 @@ static void test_approach_cap_contraction_normalizes_stored_demand(void)
     // Accumulate meaningful integral in the full-output band without resetting
     // the controller between the approach bands the real chamber traverses.
     for (int i = 0; i < 4000; ++i)
-        CHECK(pb_heater_pid_step(&state, 60.0f, 48.0f, true, &duty));
-    CHECK(state.controller.integral > 0.69f);
+        CHECK(pb_heater_pid_step(&state, 60.0f, 54.0f, true, &duty));
+    CHECK(state.controller.integral > 0.39f);
     CHECK(duty > 0.99f);
 
     // Tightening to 70% back-calculates I so stored P+I matches the new range.
-    CHECK(pb_heater_pid_step(&state, 60.0f, 52.0f, true, &duty));
-    float stored_at_70 = PB_HEATER_PID_KP * 8.0f + state.controller.integral;
+    CHECK(pb_heater_pid_step(&state, 60.0f, 56.0f, true, &duty));
+    float stored_at_70 = PB_HEATER_PID_KP * 4.0f + state.controller.integral;
     CHECK(stored_at_70 <= 0.700001f);
     CHECK(duty > 0.05f && duty <= 0.700001f);
 
     // Tightening again to 40% performs the same normalization with no reset and
     // no negative-output kick from the retained derivative history.
-    CHECK(pb_heater_pid_step(&state, 60.0f, 56.0f, true, &duty));
-    float stored_at_40 = PB_HEATER_PID_KP * 4.0f + state.controller.integral;
+    CHECK(pb_heater_pid_step(&state, 60.0f, 58.5f, true, &duty));
+    float stored_at_40 = PB_HEATER_PID_KP * 1.5f + state.controller.integral;
     CHECK(stored_at_40 <= 0.400001f);
     CHECK(duty > 0.05f && duty <= 0.400001f);
 
     for (int i = 0; i < 4000; ++i) {
-        CHECK(pb_heater_pid_step(&state, 60.0f, 56.0f, true, &duty));
-        float stored = PB_HEATER_PID_KP * 4.0f + state.controller.integral;
+        CHECK(pb_heater_pid_step(&state, 60.0f, 58.5f, true, &duty));
+        float stored = PB_HEATER_PID_KP * 1.5f + state.controller.integral;
         CHECK(stored <= 0.400001f);
         CHECK(duty >= 0.0f && duty <= 0.400001f);
     }
@@ -143,9 +141,9 @@ static void test_approach_cap_contraction_normalizes_stored_demand(void)
     // Relaxing the cap reveals no stored-demand jump: only the next ordinary
     // integration increment is permitted.
     float integral_at_40 = state.controller.integral;
-    CHECK(pb_heater_pid_step(&state, 60.0f, 54.0f, true, &duty));
-    CHECK(state.controller.integral >= integral_at_40);
-    CHECK(state.controller.integral - integral_at_40 < 0.001f);
+    CHECK(pb_heater_pid_step(&state, 60.0f, 56.0f, true, &duty));
+    CHECK(state.controller.integral > integral_at_40);
+    CHECK(state.controller.integral - integral_at_40 < 0.003f);
     CHECK(duty <= 0.700001f);
 }
 
@@ -159,20 +157,48 @@ static void test_safety_inhibition_holds_integral(void)
     float held_integral = state.controller.integral;
     CHECK(held_integral > 0.0f);
 
-    // This is the path used while either local foldback governor forces the
-    // heater off: I is pinned, but the process-variable history still advances.
-    CHECK(pb_heater_pid_step(&state, 60.0f, 54.0f, false, &duty));
-    CHECK_NEAR(state.controller.integral, held_integral, 0.000001f);
-    CHECK(state.controller.prev_measurement == 54.0f);
-
+    // Enter the local chamber foldback at 72 C. The governor remains cut at
+    // the 67 C boundary and releases only after crossing below it.
     bool local_cut = pb_heater_local_foldback_cut(true, 72.0f, false);
     CHECK(local_cut);
+    CHECK(pb_heater_local_foldback_cut(true, 67.0f, local_cut));
+
+    // This is the path used while either local foldback governor forces the
+    // heater off: I is pinned across multiple samples, but process-variable
+    // history continues to follow every measurement.
+    const float held_measurements[] = {54.0f, 53.0f, 54.0f};
+    for (size_t i = 0; i < sizeof(held_measurements) / sizeof(held_measurements[0]); ++i) {
+        CHECK(pb_heater_pid_step(&state, 60.0f, held_measurements[i], false, &duty));
+        CHECK_NEAR(state.controller.integral, held_integral, 0.000001f);
+        CHECK(state.controller.prev_measurement == held_measurements[i]);
+    }
+
     CHECK(duty > 0.0f); // controller demand can exist behind the governor
     bool drive = !local_cut && pb_heater_pid_window_on(&state, duty, 1000000);
     CHECK(!drive);      // local thermal authority dominates PID demand
 
+    local_cut = pb_heater_local_foldback_cut(true, 66.9f, local_cut);
+    CHECK(!local_cut);
     CHECK(pb_heater_pid_step(&state, 60.0f, 54.0f, true, &duty));
     CHECK(state.controller.integral > held_integral);
+    CHECK(state.controller.integral - held_integral < 0.0031f);
+    CHECK(duty <= 1.0f);
+}
+
+static void test_invalid_input_and_corrupted_state_fail_safe(void)
+{
+    pb_heater_pid_state_t state = {0};
+    float duty = 1.0f;
+
+    CHECK(!pb_heater_pid_step(&state, 60.0f, NAN, true, &duty));
+    CHECK(duty == 0.0f);
+
+    state.controller.integral = NAN;
+    duty = 1.0f;
+    CHECK(!pb_heater_pid_step(&state, 60.0f, 54.0f, true, &duty));
+    CHECK(duty == 0.0f);
+    CHECK(state.controller.integral == 0.0f);
+    CHECK(!state.controller.initialized);
 }
 
 static void test_source_transition_reset(void)
@@ -208,6 +234,7 @@ int main(void)
     test_approach_caps_prevent_integral_windup();
     test_approach_cap_contraction_normalizes_stored_demand();
     test_safety_inhibition_holds_integral();
+    test_invalid_input_and_corrupted_state_fail_safe();
     test_source_transition_reset();
     puts("pb_heater dc_pid host checks: PASS");
     return 0;

--- a/tests/pb_heater_pid_host_test.c
+++ b/tests/pb_heater_pid_host_test.c
@@ -108,6 +108,47 @@ static void test_approach_caps_prevent_integral_windup(void)
     CHECK(duty > 0.99f);
 }
 
+static void test_approach_cap_contraction_normalizes_stored_demand(void)
+{
+    pb_heater_pid_state_t state = {0};
+    float duty = 0.0f;
+
+    // Accumulate meaningful integral in the full-output band without resetting
+    // the controller between the approach bands the real chamber traverses.
+    for (int i = 0; i < 4000; ++i)
+        CHECK(pb_heater_pid_step(&state, 60.0f, 48.0f, true, &duty));
+    CHECK(state.controller.integral > 0.69f);
+    CHECK(duty > 0.99f);
+
+    // Tightening to 70% back-calculates I so stored P+I matches the new range.
+    CHECK(pb_heater_pid_step(&state, 60.0f, 52.0f, true, &duty));
+    float stored_at_70 = PB_HEATER_PID_KP * 8.0f + state.controller.integral;
+    CHECK(stored_at_70 <= 0.700001f);
+    CHECK(duty > 0.05f && duty <= 0.700001f);
+
+    // Tightening again to 40% performs the same normalization with no reset and
+    // no negative-output kick from the retained derivative history.
+    CHECK(pb_heater_pid_step(&state, 60.0f, 56.0f, true, &duty));
+    float stored_at_40 = PB_HEATER_PID_KP * 4.0f + state.controller.integral;
+    CHECK(stored_at_40 <= 0.400001f);
+    CHECK(duty > 0.05f && duty <= 0.400001f);
+
+    for (int i = 0; i < 4000; ++i) {
+        CHECK(pb_heater_pid_step(&state, 60.0f, 56.0f, true, &duty));
+        float stored = PB_HEATER_PID_KP * 4.0f + state.controller.integral;
+        CHECK(stored <= 0.400001f);
+        CHECK(duty >= 0.0f && duty <= 0.400001f);
+    }
+
+    // Relaxing the cap reveals no stored-demand jump: only the next ordinary
+    // integration increment is permitted.
+    float integral_at_40 = state.controller.integral;
+    CHECK(pb_heater_pid_step(&state, 60.0f, 54.0f, true, &duty));
+    CHECK(state.controller.integral >= integral_at_40);
+    CHECK(state.controller.integral - integral_at_40 < 0.001f);
+    CHECK(duty <= 0.700001f);
+}
+
 static void test_safety_inhibition_holds_integral(void)
 {
     pb_heater_pid_state_t state = {0};
@@ -165,6 +206,7 @@ int main(void)
     test_process_variable_selection();
     test_approach_and_ssr_window();
     test_approach_caps_prevent_integral_windup();
+    test_approach_cap_contraction_normalizes_stored_demand();
     test_safety_inhibition_holds_integral();
     test_source_transition_reset();
     puts("pb_heater dc_pid host checks: PASS");

--- a/tests/pb_heater_pid_host_test.c
+++ b/tests/pb_heater_pid_host_test.c
@@ -63,6 +63,51 @@ static void test_approach_and_ssr_window(void)
     CHECK(!pb_heater_pid_window_on(&state, 0.0f, start + 10000001));
 }
 
+static void test_approach_caps_prevent_integral_windup(void)
+{
+    pb_heater_pid_state_t state = {0};
+    float duty = 0.0f;
+
+    // Justin's reported case: a fixed 4 C error remains under the 40% approach
+    // ceiling for thousands of samples without storing demand behind that cap.
+    for (int i = 0; i < 4000; ++i) {
+        CHECK(pb_heater_pid_step(&state, 60.0f, 56.0f, true, &duty));
+        CHECK(duty <= 0.400001f);
+    }
+    float integral_at_40 = state.controller.integral;
+    float raw_at_40 = PB_HEATER_PID_KP * 4.0f + integral_at_40;
+    CHECK(integral_at_40 > 0.29f && integral_at_40 < 0.301f);
+    CHECK(raw_at_40 <= 0.400001f);
+
+    // Relaxing the active ceiling does not reveal a hidden integral jump. Only
+    // the single normal integration increment for the new 6 C error is allowed.
+    CHECK(pb_heater_pid_step(&state, 60.0f, 54.0f, true, &duty));
+    CHECK(state.controller.integral > integral_at_40);
+    CHECK(state.controller.integral - integral_at_40 < 0.001f);
+    CHECK(duty <= 0.700001f);
+
+    pb_heater_pid_reset(&state);
+    for (int i = 0; i < 4000; ++i) {
+        CHECK(pb_heater_pid_step(&state, 60.0f, 52.0f, true, &duty));
+        CHECK(duty <= 0.700001f);
+    }
+    float raw_at_70 = PB_HEATER_PID_KP * 8.0f + state.controller.integral;
+    CHECK(state.controller.integral > 0.49f && state.controller.integral < 0.501f);
+    CHECK(raw_at_70 <= 0.700001f);
+
+    // Outside the approach bands, the original full 0..1 controller range is
+    // still available and converges against that unchanged ceiling.
+    pb_heater_pid_reset(&state);
+    for (int i = 0; i < 4000; ++i) {
+        CHECK(pb_heater_pid_step(&state, 60.0f, 48.0f, true, &duty));
+        CHECK(duty <= 1.000001f);
+    }
+    float raw_uncapped = PB_HEATER_PID_KP * 12.0f + state.controller.integral;
+    CHECK(state.controller.integral > 0.69f && state.controller.integral < 0.701f);
+    CHECK(raw_uncapped <= 1.000001f);
+    CHECK(duty > 0.99f);
+}
+
 static void test_safety_inhibition_holds_integral(void)
 {
     pb_heater_pid_state_t state = {0};
@@ -119,6 +164,7 @@ int main(void)
     test_known_gains_and_heater_policy();
     test_process_variable_selection();
     test_approach_and_ssr_window();
+    test_approach_caps_prevent_integral_windup();
     test_safety_inhibition_holds_integral();
     test_source_transition_reset();
     puts("pb_heater dc_pid host checks: PASS");

--- a/tests/pb_heater_pid_host_test.c
+++ b/tests/pb_heater_pid_host_test.c
@@ -1,0 +1,126 @@
+// Host regression coverage for DragonBreath's dc_pid adapter and product-owned
+// chamber/SSR shaping. Heater safety itself remains in pb_heater.h.
+#include "pb_heater.h"
+#include "pb_heater_pid.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define CHECK(x) do { if (!(x)) { fprintf(stderr, "%s:%d: CHECK failed: %s\n", __FILE__, __LINE__, #x); exit(1); } } while (0)
+#define CHECK_NEAR(a, b, eps) CHECK(fabsf((a) - (b)) <= (eps))
+
+static void test_known_gains_and_heater_policy(void)
+{
+    pb_heater_pid_state_t state = {0};
+    float duty = -1.0f;
+
+    CHECK(pb_heater_pid_step(&state, 60.0f, 52.0f, true, &duty));
+    CHECK(isfinite(duty));
+    CHECK(duty > 0.19f && duty < 0.22f);
+    CHECK(state.controller.initialized);
+
+    for (int i = 0; i < 120; ++i)
+        CHECK(pb_heater_pid_step(&state, 60.0f, 52.0f, true, &duty));
+    CHECK(duty > 0.30f && duty < 0.40f);
+
+    // DragonBreath is heater-only: exact/above target commands zero, while
+    // dc_pid history remains coherent rather than being reset at every crossing.
+    CHECK(pb_heater_pid_step(&state, 60.0f, 60.0f, true, &duty));
+    CHECK(duty == 0.0f);
+    CHECK(state.controller.initialized);
+    CHECK(pb_heater_pid_step(&state, 60.0f, 61.0f, true, &duty));
+    CHECK(duty == 0.0f);
+    CHECK(state.controller.prev_measurement == 61.0f);
+}
+
+static void test_process_variable_selection(void)
+{
+    bool external = true;
+    CHECK(pb_heater_pid_process_variable(53.0f, NAN, &external) == 53.0f);
+    CHECK(!external);
+    CHECK(pb_heater_pid_process_variable(53.0f, 31.0f, &external) == 31.0f);
+    CHECK(external);
+}
+
+static void test_approach_and_ssr_window(void)
+{
+    CHECK(pb_heater_pid_approach_max_duty(-0.1f) == 0.0f);
+    CHECK(pb_heater_pid_approach_max_duty(0.0f) == 0.0f);
+    CHECK(pb_heater_pid_approach_max_duty(0.1f) == 0.40f);
+    CHECK(pb_heater_pid_approach_max_duty(4.99f) == 0.40f);
+    CHECK(pb_heater_pid_approach_max_duty(5.0f) == 0.70f);
+    CHECK(pb_heater_pid_approach_max_duty(9.99f) == 0.70f);
+    CHECK(pb_heater_pid_approach_max_duty(10.0f) == 1.0f);
+
+    pb_heater_pid_state_t state = {0};
+    const int64_t start = 1000000;
+    CHECK(pb_heater_pid_window_on(&state, 0.30f, start));
+    CHECK(pb_heater_pid_window_on(&state, 0.30f, start + 2999999));
+    CHECK(!pb_heater_pid_window_on(&state, 0.30f, start + 3000000));
+    CHECK(!pb_heater_pid_window_on(&state, 0.30f, start + 9999999));
+    CHECK(pb_heater_pid_window_on(&state, 0.30f, start + 10000000));
+    CHECK(!pb_heater_pid_window_on(&state, 0.0f, start + 10000001));
+}
+
+static void test_safety_inhibition_holds_integral(void)
+{
+    pb_heater_pid_state_t state = {0};
+    float duty = 0.0f;
+    for (int i = 0; i < 80; ++i)
+        CHECK(pb_heater_pid_step(&state, 60.0f, 55.0f, true, &duty));
+
+    float held_integral = state.controller.integral;
+    CHECK(held_integral > 0.0f);
+
+    // This is the path used while either local foldback governor forces the
+    // heater off: I is pinned, but the process-variable history still advances.
+    CHECK(pb_heater_pid_step(&state, 60.0f, 54.0f, false, &duty));
+    CHECK_NEAR(state.controller.integral, held_integral, 0.000001f);
+    CHECK(state.controller.prev_measurement == 54.0f);
+
+    bool local_cut = pb_heater_local_foldback_cut(true, 72.0f, false);
+    CHECK(local_cut);
+    CHECK(duty > 0.0f); // controller demand can exist behind the governor
+    bool drive = !local_cut && pb_heater_pid_window_on(&state, duty, 1000000);
+    CHECK(!drive);      // local thermal authority dominates PID demand
+
+    CHECK(pb_heater_pid_step(&state, 60.0f, 54.0f, true, &duty));
+    CHECK(state.controller.integral > held_integral);
+}
+
+static void test_source_transition_reset(void)
+{
+    pb_heater_pid_state_t state = {0};
+    float duty = 0.0f;
+    CHECK(pb_heater_pid_set_source(&state, false));
+    CHECK(state.source_known);
+    CHECK(!state.using_external);
+    CHECK(pb_heater_pid_step(&state, 55.0f, 50.0f, true, &duty));
+    CHECK(state.controller.initialized);
+    CHECK(pb_heater_pid_window_on(&state, duty, 1000000));
+
+    CHECK(!pb_heater_pid_set_source(&state, false));
+    CHECK(state.controller.initialized); // same source preserves history
+
+    // Switching between the local NTC and Bambu telemetry discards history
+    // associated with the physically different process variable.
+    CHECK(pb_heater_pid_set_source(&state, true));
+    CHECK(!state.controller.initialized);
+    CHECK(state.controller.integral == 0.0f);
+    CHECK(state.window_start_us == 0);
+    CHECK(!state.window_initialized);
+    CHECK(state.source_known);
+    CHECK(state.using_external);
+}
+
+int main(void)
+{
+    test_known_gains_and_heater_policy();
+    test_process_variable_selection();
+    test_approach_and_ssr_window();
+    test_safety_inhibition_holds_integral();
+    test_source_transition_reset();
+    puts("pb_heater dc_pid host checks: PASS");
+    return 0;
+}

--- a/tests/pb_heater_safety_host_test.c
+++ b/tests/pb_heater_safety_host_test.c
@@ -28,7 +28,7 @@ int main(void)
     // --- All clear: nothing armed, temps nominal -> no trip. --------------------
     CHECK(pb_heater_eval_trip(OK, 25.0f, OK, 25.0f, /*armed=*/false, /*link=*/false)
           == PB_FAULT_NONE);
-    // Armed and healthy and link alive -> safe to run the bang-bang loop.
+    // Armed and healthy and link alive -> safe to run the control loop.
     CHECK(pb_heater_eval_trip(OK, 40.0f, OK, 50.0f, /*armed=*/true, /*link=*/false)
           == PB_FAULT_NONE);
 

--- a/tests/run_fan_zc_host_test.sh
+++ b/tests/run_fan_zc_host_test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+out="${TMPDIR:-/tmp}/dragonbreath-pb-fan-zc-test"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  -I"$root/components/pb_fan/include" \
+  "$root/components/pb_fan/pb_fan_zc_filter.c" \
+  "$root/tests/pb_fan_zc_host_test.c" \
+  -o "$out"
+
+"$out"

--- a/tests/run_heater_pid_host_test.sh
+++ b/tests/run_heater_pid_host_test.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+tmp="${TMPDIR:-/tmp}/dragonbreath-dc-pid"
+out="${TMPDIR:-/tmp}/dragonbreath-pb-heater-pid-test"
+
+# Keep host coverage on the exact temporary dependency used by the firmware
+# manifest. Delete this fetch/pin once dc_pid is consumed from a dragon-core tag.
+dc_pid_commit=3447fd4d7d76235c8d14b10aed18a7c169e3fc80
+base="https://raw.githubusercontent.com/danielbrownjr/dragon-core/$dc_pid_commit/components/dc_pid"
+mkdir -p "$tmp/include"
+curl -fsSL "$base/include/dc_pid.h" -o "$tmp/include/dc_pid.h"
+curl -fsSL "$base/dc_pid.c" -o "$tmp/dc_pid.c"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  -I"$root/components/pb_heater/include" \
+  -I"$root/tests/stubs" \
+  -I"$tmp/include" \
+  "$root/tests/pb_heater_pid_host_test.c" \
+  "$tmp/dc_pid.c" \
+  -lm -o "$out"
+
+"$out"

--- a/tests/run_heater_pid_host_test.sh
+++ b/tests/run_heater_pid_host_test.sh
@@ -5,10 +5,10 @@ root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 tmp="${TMPDIR:-/tmp}/dragonbreath-dc-pid"
 out="${TMPDIR:-/tmp}/dragonbreath-pb-heater-pid-test"
 
-# Keep host coverage on the exact temporary dependency used by the firmware
-# manifest. Delete this fetch/pin once dc_pid is consumed from a dragon-core tag.
-dc_pid_commit=3447fd4d7d76235c8d14b10aed18a7c169e3fc80
-base="https://raw.githubusercontent.com/danielbrownjr/dragon-core/$dc_pid_commit/components/dc_pid"
+# Keep host coverage on the exact released dependency used by the firmware
+# manifest.
+dc_pid_version=v0.31.0
+base="https://raw.githubusercontent.com/justinh-rahb/dragon-core/$dc_pid_version/components/dc_pid"
 mkdir -p "$tmp/include"
 curl -fsSL "$base/include/dc_pid.h" -o "$tmp/include/dc_pid.h"
 curl -fsSL "$base/dc_pid.c" -o "$tmp/dc_pid.c"

--- a/tests/test_hil_runner.py
+++ b/tests/test_hil_runner.py
@@ -41,6 +41,35 @@ class HilRunnerTest(unittest.TestCase):
         )
         self.assertEqual(value["lease_id"], "abc")
 
+    def test_saved_baseline_delta_expectation(self):
+        expected = hil.substitute(
+            {"state.count": {"delta_between": ["$before", 500, 700]}},
+            {"before": 1000},
+        )
+        hil.check_expectations({"state": {"count": 1600}}, expected)
+        with self.assertRaisesRegex(hil.HilError, "expected delta"):
+            hil.check_expectations({"state": {"count": 1800}}, expected)
+
+    def test_between_expectation(self):
+        hil.check_expectations(
+            {"state": {"interval_us": 8333}},
+            {"state.interval_us": {"between": [6500, 10000]}},
+        )
+        with self.assertRaisesRegex(hil.HilError, "expected value"):
+            hil.check_expectations(
+                {"state": {"interval_us": 990}},
+                {"state.interval_us": {"between": [6500, 10000]}},
+            )
+
+    def test_panda_smoke_checks_zero_cross_cadence(self):
+        scenario = hil.load_scenario(
+            hil.SCENARIO_DIR / "panda-smoke.json", "panda"
+        )
+        serialized = json.dumps(scenario)
+        self.assertIn("zero_cross_rejected_count", serialized)
+        self.assertIn("delta_between", serialized)
+        self.assertIn("zero_cross_interval_us", serialized)
+
     def test_heat_detection(self):
         self.assertTrue(
             hil.requests_heat(

--- a/tests/test_hil_runner.py
+++ b/tests/test_hil_runner.py
@@ -66,6 +66,36 @@ class HilRunnerTest(unittest.TestCase):
                         f"{path}: request id is reserved for runner correlation",
                     )
 
+    def test_each_scenario_starts_from_explicit_safe_state(self):
+        for path in sorted(hil.SCENARIO_DIR.glob("*.json")):
+            scenario = hil.load_scenario(path)
+            first = scenario["steps"][0]
+            self.assertEqual(first.get("send"), {"cmd": "off"}, path)
+            self.assertEqual(first.get("expect", {}).get("state.mode"), "off", path)
+            self.assertFalse(
+                first.get("expect", {}).get("state.heater_output", True), path
+            )
+
+    def test_auto_scenario_injects_current_source_target_policy(self):
+        scenario = hil.load_scenario(
+            hil.SCENARIO_DIR / "devboard-auto.json", "devboard"
+        )
+        env_steps = [
+            step["send"]
+            for step in scenario["steps"]
+            if step.get("send", {}).get("cmd") == "env"
+        ]
+        self.assertTrue(env_steps)
+        for command in env_steps:
+            self.assertEqual(command.get("src_target_c"), 55)
+            self.assertEqual(command.get("chamber_src_c"), 25)
+        self.assertTrue(
+            any(command.get("connected") is True for command in env_steps)
+        )
+        self.assertTrue(
+            any(command.get("connected") is False for command in env_steps)
+        )
+
     def test_suite_only_loads_scenarios_for_target(self):
         scenarios = hil.load_suite_scenarios("devboard")
         self.assertTrue(scenarios)

--- a/tools/hil.py
+++ b/tools/hil.py
@@ -43,6 +43,29 @@ def check_expectations(response: dict[str, Any], expected: dict[str, Any]) -> No
             if len(wanted) != 1:
                 raise HilError(f"{path}: assertion must contain exactly one operator")
             operator, operand = next(iter(wanted.items()))
+            if operator == "between":
+                if not isinstance(operand, list) or len(operand) != 2:
+                    raise HilError(f"{path}: between requires [minimum, maximum]")
+                passed = operand[0] <= actual <= operand[1]
+                if not passed:
+                    raise HilError(
+                        f"{path}: expected value in [{operand[0]!r}, {operand[1]!r}], "
+                        f"got {actual!r}"
+                    )
+                continue
+            if operator == "delta_between":
+                if not isinstance(operand, list) or len(operand) != 3:
+                    raise HilError(
+                        f"{path}: delta_between requires [baseline, minimum, maximum]"
+                    )
+                delta = actual - operand[0]
+                passed = operand[1] <= delta <= operand[2]
+                if not passed:
+                    raise HilError(
+                        f"{path}: expected delta in [{operand[1]!r}, {operand[2]!r}], "
+                        f"got {delta!r} from {actual!r} - {operand[0]!r}"
+                    )
+                continue
             operations = {
                 "eq": lambda: actual == operand,
                 "ne": lambda: actual != operand,
@@ -535,7 +558,8 @@ def run_scenario(
                 response = transport.request(
                     command, timeout_s=float(step.get("timeout_s", 4.0))
                 )
-                check_expectations(response, step.get("expect", {"ok": True}))
+                expected = substitute(step.get("expect", {"ok": True}), variables)
+                check_expectations(response, expected)
                 for variable, path in step.get("save", {}).items():
                     variables[variable] = dotted_get(response, path)
                 report["response"] = response


### PR DESCRIPTION
## Summary

Ports DragonBreath chamber control to the shared `dragon-core` `dc_pid` controller while preserving DragonBreath's product-owned heater policy and safety layers.

This PR is a downstream integration consumer of the `dc_pid` work merged in `justinh-rahb/dragon-core#54`.

## What changed

- Replace the private chamber PID backend with shared `dc_pid`.
- Use the hardware-selected Candidate A parameters:
  - Kp `0.100`
  - Ki `0.001`
  - Kd `0.040`
  - derivative alpha `0.20`
- Preserve the 500 ms controller cadence and 10-second SSR time-proportioning window.
- Apply DragonBreath-owned approach ceilings:
  - positive error below 2 C: 40%
  - positive error below 5 C: 70%
  - otherwise: 100%
- Expose the active approach ceiling to `dc_pid` and contract stored integral demand as that ceiling tightens, preventing hidden integral through the 100% -> 70% -> 40% trajectory.
- Force heater output off at/above target without discarding valid controller history.
- Preserve current temperature-source policy:
  - AUTO may use eligible fresh Bambu telemetry.
  - stale/missing/ineligible Bambu telemetry falls back to local NTC.
  - Manual and Drying remain local-NTC controlled.
- Reset controller history when the effective temperature source changes.
- Hold PID integration while local chamber or PTC foldback inhibits output.
- Leave existing local sensors, hard trips, foldbacks, watchdog, interlocks, target policy, fan behavior, and the single SSR writer authoritative and unchanged.
- Reject zero-cross edges arriving less than 4,000 us after the last accepted edge. Rejected edges do not advance accepted count/timing or trigger a fan transition; a separate rejected-edge counter is exposed to HIL and runtime logs.

## dragon-core dependency

All DragonBreath dragon-core components, including `dc_pid`, use the upstream release:

`justinh-rahb/dragon-core@v0.32.0`

The focused PID host runner uses the same upstream version as the production manifest. The temporary contributor-fork/SHA dependency has been removed.

## Code and CI validation

- 10/10 C host-test runners pass.
- Focused PID coverage validates source selection/fallback, source-transition reset, Candidate A gains, approach ceilings, the continuous 100% -> 70% -> 40% cap transition, SSR windowing, at-target heater cutoff, integration hold, and local foldback dominance.
- Zero-cross host coverage validates rejection of the observed approximately 1 ms duplicate edge, preservation of accepted timing across a rejection, valid 50/60 Hz intervals, and the exact 4,000 us threshold boundary.
- HIL runner unit suite: 19/19 pass.
- Panda smoke now keeps heater/fan off while checking accepted-edge cadence over five seconds, accepted interval range, and rejected-edge-counter observability.
- API v2 contract checks pass.
- Production ESP32-C3 build passes with first-party warnings treated as errors.
- Native-USB safe-HIL, UART safe-HIL, and native-USB production-network debug builds pass.
- GPIO/ADC compile-out verification passes for all safe dev-board profiles.
- Focused cppcheck over changed C sources passes.

Local cppcheck 2.19 reports an unchanged GNU `asm` parsing error in `db_portal.c`; this PR intentionally does not modify unrelated portal code.

## Hardware status

- Generic `dc_pid` correctness is validated by its upstream component tests and this product integration suite.
- DragonBreath product tuning adopted Candidate A from the real-Panda A/B results already recorded in this PR.
- Duplicate-edge ZCD handling is now fixed in software and protected by host/HIL coverage.
- Remaining hardware gate: run the non-heating Panda smoke scenario on a real Panda and verify approximately one accepted zero-cross per half-cycle (about 120/s on 60 Hz), accepted intervals near 8.33 ms, rejected duplicate/noise edges observable, and heater/fan remaining off.

This PR is not being represented as fully hardware-validated until that physical ZCD cadence requalification passes.

## Notes

The numerical behavior is not bit-for-bit identical to the private `pb_pid` implementation. `dc_pid` uses its documented derivative-on-measurement and anti-windup behavior.

This PR intentionally does not carry forward the old branch's private/selectable PID backends, controller-selection UI, experimental settings UX, PID diagnostics additions, HTTP-memory changes, SSE instrumentation, fallback experiments, or unrelated portal/source-policy changes.