### PR TITLE
fix(wifi): restore standard radio behavior

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -11,6 +11,7 @@ on:
       - 'partitions.csv'
       - 'sdkconfig.defaults'
       - 'sdkconfig.hil-*'
+      - 'sdkconfig.debug-*'
       - 'tools/hil.py'
       - 'tools/idf-build.sh'
       - '.github/workflows/firmware-build.yml'
@@ -23,6 +24,7 @@ on:
       - 'partitions.csv'
       - 'sdkconfig.defaults'
       - 'sdkconfig.hil-*'
+      - 'sdkconfig.debug-*'
       - 'tools/hil.py'
       - 'tools/idf-build.sh'
   workflow_dispatch:
@@ -137,6 +139,20 @@ jobs:
               build
             sh tests/check_hil_compileout.sh build-hil-devboard-uart
 
+      - name: Build native-USB production-network debug profile (ESP-IDF v5.3)
+        uses: espressif/esp-idf-ci-action@9d38657f3d789ca759b2b37aaf5ceffbc42c4f0d # v1
+        with:
+          esp_idf_version: v5.3
+          target: esp32c3
+          path: '.'
+          command: |
+            set -e
+            idf.py -B build-debug-devboard-native \
+              -DSDKCONFIG="$PWD/build-debug-devboard-native/sdkconfig.profile" \
+              -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.debug-devboard-native" \
+              build
+            sh tests/check_devboard_compileout.sh build-debug-devboard-native
+
       - name: Upload firmware artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -147,4 +163,5 @@ jobs:
             build/partition_table/partition-table.bin
             build-hil-devboard/dragonbreath.bin
             build-hil-devboard-uart/dragonbreath.bin
+            build-debug-devboard-native/dragonbreath.bin
           if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ below into the GitHub Release notes.
   DHCP watchdog. The constrained-radio tuning remains available only to products
   that explicitly opt in.
 
+### Added
+- Add a native-USB ESP32-C3 debug profile that keeps production networking and
+  the web UI active while compiling out every Panda-specific GPIO/ADC backend.
+  Unlike HIL images, it exposes no JSON command console.
+
 ## [1.1.14] - 2026-08-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+### Fixed
+- Restore the standard-radio Wi-Fi path for DragonBreath. The firmware no longer
+  forces `WIFI_PS_NONE`, and **dragon-core v0.32.0** defaults normal-antenna
+  products to modem power-save, the original retry/boot budgets, and no aggressive
+  DHCP watchdog. The constrained-radio tuning remains available only to products
+  that explicitly opt in.
+
 ## [1.1.14] - 2026-08-26
 
 ### Changed

--- a/components/pb_board/pb_board.c
+++ b/components/pb_board/pb_board.c
@@ -7,8 +7,8 @@ static const char *TAG = "pb_board";
 
 void pb_board_init(void)
 {
-#ifdef CONFIG_PB_HIL_DEVBOARD
-    ESP_LOGW(TAG, "HIL dev-board target: production board GPIO init compiled out");
+#ifdef CONFIG_PB_DEVBOARD_SAFE
+    ESP_LOGW(TAG, "safe dev-board target: production board GPIO init compiled out");
 #else
     const gpio_config_t leds = {
         .pin_bit_mask = (1ULL << PB_GPIO_LED_K1) |
@@ -36,7 +36,7 @@ void pb_board_init(void)
 
 int pb_board_rref_kohm(void)
 {
-#ifdef CONFIG_PB_HIL_DEVBOARD
+#ifdef CONFIG_PB_DEVBOARD_SAFE
     return 82;
 #else
     // The Rref strap on GPIO19 selects the divider reference resistor (level 0 -> 82k,

--- a/components/pb_buttons/include/pb_buttons.h
+++ b/components/pb_buttons/include/pb_buttons.h
@@ -43,7 +43,7 @@ typedef void (*pb_button_cb_t)(pb_button_id_t id, pb_button_event_t ev);
 // task — keep it short and non-blocking.
 esp_err_t pb_buttons_start(pb_button_cb_t cb);
 
-#ifdef CONFIG_PB_HIL_DEVBOARD
+#ifdef CONFIG_PB_DEVBOARD_SAFE
 // HIL only: inject a raw electrical level (0/1) for a button, standing in for
 // gpio_get_level() so scenarios exercise the real debounce/long-press timing.
 void pb_buttons_hil_set_level(pb_button_id_t id, int level);

--- a/components/pb_buttons/pb_buttons.c
+++ b/components/pb_buttons/pb_buttons.c
@@ -7,7 +7,7 @@
 #include "freertos/task.h"
 #include "esp_log.h"
 
-#ifndef CONFIG_PB_HIL_DEVBOARD
+#ifndef CONFIG_PB_DEVBOARD_SAFE
 #include "driver/gpio.h"
 #endif
 
@@ -31,7 +31,7 @@ static btn_t s_btns[PB_BUTTON_COUNT] = {
 static pb_button_cb_t s_cb;
 static TaskHandle_t   s_task;
 
-#ifdef CONFIG_PB_HIL_DEVBOARD
+#ifdef CONFIG_PB_DEVBOARD_SAFE
 // Injected electrical levels; default 1 (idle high, matching the pull-up) so a
 // button reads released until a scenario drives it low.
 static _Atomic int s_hil_level[PB_BUTTON_COUNT] = { 1, 1, 1, 1 };
@@ -113,7 +113,7 @@ esp_err_t pb_buttons_start(pb_button_cb_t cb)
     s_cb = cb;
 
     for (int i = 0; i < PB_BUTTON_COUNT; ++i) {
-#ifndef CONFIG_PB_HIL_DEVBOARD
+#ifndef CONFIG_PB_DEVBOARD_SAFE
         configure_pin(s_btns[i].pin);
 #endif
         // Seed from a live sample so a button held through boot (or a shorted
@@ -125,8 +125,8 @@ esp_err_t pb_buttons_start(pb_button_cb_t cb)
         s_task = NULL;
         return ESP_ERR_NO_MEM;
     }
-#ifdef CONFIG_PB_HIL_DEVBOARD
-    ESP_LOGW(TAG, "HIL dev-board backend: button levels injected over serial");
+#ifdef CONFIG_PB_DEVBOARD_SAFE
+    ESP_LOGW(TAG, "safe dev-board backend: button GPIO reads compiled out");
 #else
     ESP_LOGI(TAG, "front-panel buttons running (poll %d ms)", PB_BTN_TICK_MS);
 #endif

--- a/components/pb_fan/include/pb_fan.h
+++ b/components/pb_fan/include/pb_fan.h
@@ -24,7 +24,7 @@ uint8_t pb_fan_get_level(void);
 // (ZCD not working / no mains) — lets us verify the detector without firing.
 void pb_fan_zc_diag(uint32_t *count_out, uint32_t *interval_us_out);
 
-#ifdef CONFIG_PB_HIL_DEVBOARD
+#ifdef CONFIG_PB_DEVBOARD_SAFE
 // Inject one or more zero-cross events into the dev-board backend.
 void pb_fan_hil_zero_cross(uint32_t count, uint32_t interval_us);
 #endif

--- a/components/pb_fan/pb_fan.c
+++ b/components/pb_fan/pb_fan.c
@@ -25,7 +25,7 @@ static volatile uint32_t s_zc_count;
 static volatile uint32_t s_zc_interval_us;
 static volatile uint64_t s_zc_last_us;
 
-#ifndef CONFIG_PB_HIL_DEVBOARD
+#ifndef CONFIG_PB_DEVBOARD_SAFE
 static void IRAM_ATTR zcd_isr(void *arg)
 {
     uint64_t now = esp_timer_get_time();
@@ -43,13 +43,13 @@ static void IRAM_ATTR zcd_isr(void *arg)
 
 esp_err_t pb_fan_init(void)
 {
-#ifdef CONFIG_PB_HIL_DEVBOARD
+#ifdef CONFIG_PB_DEVBOARD_SAFE
     s_want_on = false;
     s_applied = false;
     s_zc_count = 0;
     s_zc_interval_us = 0;
     s_zc_last_us = 0;
-    ESP_LOGW(TAG, "HIL dev-board backend: fan gate and ZCD GPIOs compiled out");
+    ESP_LOGW(TAG, "safe dev-board backend: fan gate and ZCD GPIOs compiled out");
     return ESP_OK;
 #else
     const gpio_config_t gate = {
@@ -88,7 +88,7 @@ void pb_fan_set_level(uint8_t percent)
     bool on = (percent > 0);
     s_want_on = on;
     if (!on) {                                     // turn OFF immediately (don't wait for a ZC)
-#ifndef CONFIG_PB_HIL_DEVBOARD
+#ifndef CONFIG_PB_DEVBOARD_SAFE
         gpio_set_level(PB_GPIO_FAN_GATE, 0);
 #endif
         s_applied = false;
@@ -104,7 +104,7 @@ void pb_fan_zc_diag(uint32_t *count_out, uint32_t *interval_us_out)
     if (interval_us_out) *interval_us_out = s_zc_interval_us;
 }
 
-#ifdef CONFIG_PB_HIL_DEVBOARD
+#ifdef CONFIG_PB_DEVBOARD_SAFE
 void pb_fan_hil_zero_cross(uint32_t count, uint32_t interval_us)
 {
     if (count == 0) return;

--- a/components/pb_heater/pb_heater.c
+++ b/components/pb_heater/pb_heater.c
@@ -91,7 +91,7 @@ static uint32_t c_to_centi(float c)
 
 static void ssr_set(bool on)        // control-task context only
 {
-#ifndef CONFIG_PB_HIL_DEVBOARD
+#ifndef CONFIG_PB_DEVBOARD_SAFE
     gpio_set_level(PB_GPIO_RELAY, on ? 1 : 0);
 #endif
     s_on = on;
@@ -100,7 +100,7 @@ static void ssr_set(bool on)        // control-task context only
 esp_err_t pb_heater_init(void)
 {
     if (!s_persist_lock) s_persist_lock = xSemaphoreCreateMutex();
-#ifndef CONFIG_PB_HIL_DEVBOARD
+#ifndef CONFIG_PB_DEVBOARD_SAFE
     const gpio_config_t io = {
         .pin_bit_mask = (1ULL << PB_GPIO_RELAY),
         .mode = GPIO_MODE_OUTPUT,
@@ -126,8 +126,8 @@ esp_err_t pb_heater_init(void)
     s_cool_release_c = PB_HEATER_COOL_RELEASE_C_DEFAULT;
     s_fb_cut_c = 0.0f;   // auto (per-Rref default) until a user override is loaded/set
     taskEXIT_CRITICAL(&s_mux);
-#ifdef CONFIG_PB_HIL_DEVBOARD
-    ESP_LOGW(TAG, "HIL dev-board backend: relay GPIO compiled out");
+#ifdef CONFIG_PB_DEVBOARD_SAFE
+    ESP_LOGW(TAG, "safe dev-board backend: relay GPIO compiled out");
 #else
     ESP_LOGI(TAG, "init: SSR forced OFF");
 #endif

--- a/components/pb_hil/Kconfig.projbuild
+++ b/components/pb_hil/Kconfig.projbuild
@@ -1,4 +1,13 @@
-menu "DragonBreath hardware-in-loop"
+menu "DragonBreath development hardware"
+
+config PB_DEVBOARD_SAFE
+    bool "Compile out Panda-specific physical I/O"
+    default n
+    help
+        Replace the Panda relay, fan, thermistor ADC, LEDs, buttons, and board
+        strap backends with safe logical development-board backends. Production
+        networking and the web UI remain enabled unless PB_HIL_DEVBOARD is also
+        selected. Use this for native-USB debugging on a generic ESP32-C3 board.
 
 config PB_HIL_CONSOLE
     bool "Enable the serial HIL command console"
@@ -11,6 +20,7 @@ config PB_HIL_CONSOLE
 config PB_HIL_DEVBOARD
     bool "Build for a safe ESP32-C3 development board"
     depends on PB_HIL_CONSOLE
+    select PB_DEVBOARD_SAFE
     default n
     help
         Compile out every Panda mains GPIO write. Thermistors, zero-cross, and

--- a/components/pb_leds/pb_leds.c
+++ b/components/pb_leds/pb_leds.c
@@ -28,7 +28,7 @@ static _Atomic bool s_enabled = true;
 #define CODE_OFF_TICKS     3    // 150 ms between pulses within a burst
 #define CODE_GAP_TICKS    16    // 800 ms quiet gap after each burst
 
-#ifndef CONFIG_PB_HIL_DEVBOARD
+#ifndef CONFIG_PB_DEVBOARD_SAFE
 static const gpio_num_t s_gpio[PB_LED_COUNT] = {
     PB_GPIO_LED_K1, PB_GPIO_LED_K2, PB_GPIO_LED_K3, PB_GPIO_LED_POWER,
 };
@@ -100,7 +100,7 @@ static void led_task(void *arg)
             // indication is preserved), but when disabled the physical output is
             // forced off — the LEDs simply are not driven.
             if (!atomic_load(&s_enabled)) on = 0;
-#ifndef CONFIG_PB_HIL_DEVBOARD
+#ifndef CONFIG_PB_DEVBOARD_SAFE
             gpio_set_level(s_gpio[i], on ? 1 : 0);
 #else
             (void)on;
@@ -118,12 +118,12 @@ void pb_leds_flash_all(uint8_t times, uint16_t on_ms, uint16_t off_ms)
     // resume it — the caller reboots right after this returns.
     if (s_task) vTaskSuspend(s_task);
     for (uint8_t n = 0; n < times; n++) {
-#ifndef CONFIG_PB_HIL_DEVBOARD
+#ifndef CONFIG_PB_DEVBOARD_SAFE
         for (int i = 0; i < PB_LED_COUNT; i++)
             if (PB_LED_DRIVEN(i)) gpio_set_level(s_gpio[i], 1);
 #endif
         vTaskDelay(pdMS_TO_TICKS(on_ms));
-#ifndef CONFIG_PB_HIL_DEVBOARD
+#ifndef CONFIG_PB_DEVBOARD_SAFE
         for (int i = 0; i < PB_LED_COUNT; i++)
             if (PB_LED_DRIVEN(i)) gpio_set_level(s_gpio[i], 0);
 #endif
@@ -135,7 +135,7 @@ esp_err_t pb_leds_start(void)
 {
     if (s_task) return ESP_ERR_INVALID_STATE;
 
-#ifndef CONFIG_PB_HIL_DEVBOARD
+#ifndef CONFIG_PB_DEVBOARD_SAFE
     uint64_t mask = 0;
     for (int i = 0; i < PB_LED_COUNT; i++)
         if (PB_LED_DRIVEN(i)) mask |= 1ULL << s_gpio[i];   // skip GPIO21 unless enabled
@@ -152,7 +152,7 @@ esp_err_t pb_leds_start(void)
     for (int i = 0; i < PB_LED_COUNT; i++) {
         atomic_store(&s_pat[i], PB_LED_OFF);
         atomic_store(&s_code[i], 0);
-#ifndef CONFIG_PB_HIL_DEVBOARD
+#ifndef CONFIG_PB_DEVBOARD_SAFE
         if (PB_LED_DRIVEN(i)) gpio_set_level(s_gpio[i], 0);
 #endif
     }
@@ -161,8 +161,8 @@ esp_err_t pb_leds_start(void)
         s_task = NULL;
         return ESP_ERR_NO_MEM;
     }
-#ifdef CONFIG_PB_HIL_DEVBOARD
-    ESP_LOGW(TAG, "HIL dev-board backend: LED GPIO writes compiled out");
+#ifdef CONFIG_PB_DEVBOARD_SAFE
+    ESP_LOGW(TAG, "safe dev-board backend: LED GPIO writes compiled out");
 #else
     ESP_LOGI(TAG, "started");
 #endif

--- a/components/pb_ntc/include/pb_ntc.h
+++ b/components/pb_ntc/include/pb_ntc.h
@@ -121,7 +121,7 @@ esp_err_t pb_ntc_set_offset_c(pb_ntc_channel_t ch, float offset_c);
 // Current (clamped) calibration offset for the channel, in °C.
 float pb_ntc_get_offset_c(pb_ntc_channel_t ch);
 
-#ifdef CONFIG_PB_HIL_DEVBOARD
+#ifdef CONFIG_PB_DEVBOARD_SAFE
 // Dev-board HIL backend. Production builds do not expose or compile this API.
 void pb_ntc_hil_set(pb_ntc_channel_t ch, pb_ntc_status_t status, float temp_c);
 void pb_ntc_hil_reset(void);

--- a/components/pb_ntc/pb_ntc.c
+++ b/components/pb_ntc/pb_ntc.c
@@ -8,7 +8,7 @@
 #include <stdatomic.h>
 #include "esp_log.h"
 #include "nvs.h"
-#ifdef CONFIG_PB_HIL_DEVBOARD
+#ifdef CONFIG_PB_DEVBOARD_SAFE
 #include "freertos/FreeRTOS.h"
 #else
 #include "esp_adc/adc_oneshot.h"
@@ -91,7 +91,7 @@ esp_err_t pb_ntc_set_offset_c(pb_ntc_channel_t ch, float offset_c)
 
 float pb_ntc_get_offset_c(pb_ntc_channel_t ch) { return ntc_offset_c(ch); }
 
-#ifdef CONFIG_PB_HIL_DEVBOARD
+#ifdef CONFIG_PB_DEVBOARD_SAFE
 
 static portMUX_TYPE s_hil_mux = portMUX_INITIALIZER_UNLOCKED;
 static float s_hil_temp[2];
@@ -124,7 +124,7 @@ esp_err_t pb_ntc_init(void)
 {
     pb_ntc_hil_reset();
     s_ready = true;
-    ESP_LOGW(TAG, "HIL dev-board backend: ADC disabled; temperatures are injected");
+    ESP_LOGW(TAG, "safe dev-board backend: ADC disabled; temperatures default to nominal");
     return ESP_OK;
 }
 

--- a/docs/HIL.md
+++ b/docs/HIL.md
@@ -81,6 +81,30 @@ CONFIG_ESP_CONSOLE_UART_DEFAULT=y
 | Devboard | USB-to-UART bridge | `sdkconfig.hil-devboard-uart` | `/dev/ttyUSB0` | Panda I/O compiled out |
 | Panda | On-board UART bridge | `sdkconfig.hil-panda` | `/dev/ttyUSB0` | Real hardware active |
 
+## Native-USB production-network debugging
+
+`sdkconfig.debug-devboard-native` is a non-HIL debug profile for a generic
+ESP32-C3 development board. It runs DragonBreath's production networking, portal,
+dashboard, and control-source clients with normal ESP-IDF logs on native USB
+Serial/JTAG. Panda-specific relay, fan, ADC, LED, button, and strap backends are
+compiled out, so GPIO18/19 remain available to USB and the image cannot drive
+Panda mains hardware. The HIL JSON command console is disabled.
+
+Build, audit, flash, and monitor it with:
+
+```bash
+source ~/esp/esp-idf/export.sh
+idf.py -B build-debug-devboard-native \
+  -DSDKCONFIG="$PWD/build-debug-devboard-native/sdkconfig.profile" \
+  -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.debug-devboard-native" \
+  build
+sh tests/check_devboard_compileout.sh build-debug-devboard-native
+idf.py -B build-debug-devboard-native -p /dev/ttyACM0 flash monitor
+```
+
+This profile is for development boards only. Do not flash it onto a Panda Breath:
+its physical sensors, buttons, LEDs, fan, and heater are intentionally unavailable.
+
 When `--transport` is omitted, the runner infers `native` from `/dev/ttyACM*`
 and `uart` from `/dev/ttyUSB*`. Pass it explicitly for other device naming
 schemes.

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -31,7 +31,6 @@
 #include "pb_hil.h"
 #include "dc_evlog.h"
 
-#include "esp_wifi.h"
 #include "esp_mac.h"
 #include "dc_wifi.h"
 #include "dc_moonraker.h"
@@ -500,9 +499,6 @@ void app_main(void)
     // abort/reboot and tear down the safety loop that's already running above.
     if ((e = dc_wifi_start()) != ESP_OK)
         ESP_LOGE(TAG, "dc_wifi_start: %s (continuing; safety loop unaffected)", esp_err_to_name(e));
-    // Mains-powered device: disable WiFi modem-sleep so the control API stays
-    // responsive (power-save adds ~0.5s latency spikes to incoming requests).
-    esp_wifi_set_ps(WIFI_PS_NONE);
     // Control-source selector: start ONLY the bound client. Klipper is the
     // default and the shipped path; Bambu/HA are opt-in. Each is log-and-continue
     // like the rest of network bring-up — a source that fails to init just leaves

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -2,36 +2,36 @@ dependencies:
   dc_prusa:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_prusa
-    version: v0.30.0
+    version: v0.32.0
   dc_evlog:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_evlog
-    version: v0.30.0
+    version: v0.32.0
   dc_source:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_source
-    version: v0.30.0
+    version: v0.32.0
   dc_bambu:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_bambu
-    version: v0.30.0
+    version: v0.32.0
   dc_wifi:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_wifi
-    version: v0.30.0
+    version: v0.32.0
   dc_moonraker:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_moonraker
-    version: v0.30.0
+    version: v0.32.0
   dc_ui:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_ui
-    version: v0.30.0
+    version: v0.32.0
   dc_mqtt:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_mqtt
-    version: v0.30.0
+    version: v0.32.0
   dc_portal:
     git: https://github.com/justinh-rahb/dragon-core.git
     path: components/dc_portal
-    version: v0.30.0
+    version: v0.32.0

--- a/sdkconfig.debug-devboard-native
+++ b/sdkconfig.debug-devboard-native
@@ -1,0 +1,8 @@
+# ESP32-C3 native-USB debug profile with production networking and web UI.
+# Panda-specific GPIO and ADC backends are compiled out so GPIO18/19 remain
+# available to USB Serial/JTAG. The HIL JSON command console stays disabled.
+CONFIG_PB_DEVBOARD_SAFE=y
+# CONFIG_PB_HIL_CONSOLE is not set
+# CONFIG_PB_POWER_LED is not set
+# CONFIG_ESP_CONSOLE_UART_DEFAULT is not set
+CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y

--- a/sdkconfig.hil-devboard
+++ b/sdkconfig.hil-devboard
@@ -4,6 +4,7 @@
 #     -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.hil-devboard" build
 CONFIG_PB_HIL_CONSOLE=y
 CONFIG_PB_HIL_DEVBOARD=y
+CONFIG_PB_DEVBOARD_SAFE=y
 
 # This dual-USB-C dev board is connected through the ESP32-C3 native USB port.
 # Use the built-in USB Serial/JTAG device for flashing, commands, and log capture.

--- a/sdkconfig.hil-devboard-uart
+++ b/sdkconfig.hil-devboard-uart
@@ -4,6 +4,7 @@
 #     -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.hil-devboard-uart" build
 CONFIG_PB_HIL_CONSOLE=y
 CONFIG_PB_HIL_DEVBOARD=y
+CONFIG_PB_DEVBOARD_SAFE=y
 
 # Match Panda hardware transport while retaining the GPIO-free devboard backend.
 # GPIO21 is UART0 TX, so the optional Panda power LED must remain disabled.

--- a/tests/check_devboard_compileout.sh
+++ b/tests/check_devboard_compileout.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+set -eu
+
+build_dir="${1:-build-debug-devboard-native}"
+config="$build_dir/config/sdkconfig.h"
+nm_tool="${CROSS_COMPILE:-riscv32-esp-elf-}nm"
+
+if ! command -v "$nm_tool" >/dev/null 2>&1; then
+    echo "dev-board compile-out check requires $nm_tool in PATH" >&2
+    exit 1
+fi
+if [ ! -f "$config" ]; then
+    echo "missing dev-board build config: $config" >&2
+    exit 1
+fi
+
+grep -q '^#define CONFIG_PB_DEVBOARD_SAFE 1$' "$config"
+if ! grep -Eq \
+    '^#define CONFIG_ESP_CONSOLE_(USB_SERIAL_JTAG|UART_DEFAULT) 1$' "$config"; then
+    echo "safe dev-board build requires a supported serial console" >&2
+    exit 1
+fi
+if grep -q '^#define CONFIG_PB_POWER_LED 1$' "$config"; then
+    echo "safe dev-board build must not claim the Panda Power LED" >&2
+    exit 1
+fi
+
+for component in pb_board pb_heater pb_fan pb_leds pb_buttons; do
+    archive="$build_dir/esp-idf/$component/lib$component.a"
+    if [ ! -f "$archive" ]; then
+        echo "missing safe dev-board component archive: $archive" >&2
+        exit 1
+    fi
+    if ! undefined_symbols=$("$nm_tool" -u "$archive"); then
+        echo "$nm_tool failed to inspect $archive" >&2
+        exit 1
+    fi
+    if printf '%s\n' "$undefined_symbols" | grep -Eq \
+        'gpio_(config|set_level|get_level|install_isr_service|isr_handler_add)'; then
+        echo "$component still references physical GPIO in safe dev-board build" >&2
+        exit 1
+    fi
+done
+
+archive="$build_dir/esp-idf/pb_ntc/libpb_ntc.a"
+if [ ! -f "$archive" ]; then
+    echo "missing safe dev-board component archive: $archive" >&2
+    exit 1
+fi
+if ! undefined_symbols=$("$nm_tool" -u "$archive"); then
+    echo "$nm_tool failed to inspect $archive" >&2
+    exit 1
+fi
+if printf '%s\n' "$undefined_symbols" | grep -Eq 'adc_(oneshot|cali)'; then
+    echo "pb_ntc still references the ADC backend in safe dev-board build" >&2
+    exit 1
+fi
+
+echo "safe dev-board compile-out check: PASS"

--- a/tests/check_hil_compileout.sh
+++ b/tests/check_hil_compileout.sh
@@ -3,12 +3,6 @@ set -eu
 
 build_dir="${1:-build-hil-devboard}"
 config="$build_dir/config/sdkconfig.h"
-nm_tool="${CROSS_COMPILE:-riscv32-esp-elf-}nm"
-
-if ! command -v "$nm_tool" >/dev/null 2>&1; then
-    echo "HIL compile-out check requires $nm_tool in PATH" >&2
-    exit 1
-fi
 if [ ! -f "$config" ]; then
     echo "missing HIL build config: $config" >&2
     exit 1
@@ -16,45 +10,6 @@ fi
 
 grep -q '^#define CONFIG_PB_HIL_CONSOLE 1$' "$config"
 grep -q '^#define CONFIG_PB_HIL_DEVBOARD 1$' "$config"
-if ! grep -Eq \
-    '^#define CONFIG_ESP_CONSOLE_(USB_SERIAL_JTAG|UART_DEFAULT) 1$' "$config"; then
-    echo "dev-board HIL requires a supported serial console" >&2
-    exit 1
-fi
-if grep -q '^#define CONFIG_PB_POWER_LED 1$' "$config"; then
-    echo "dev-board HIL must not claim the Panda Power LED" >&2
-    exit 1
-fi
-
-for component in pb_board pb_heater pb_fan pb_leds pb_buttons; do
-    archive="$build_dir/esp-idf/$component/lib$component.a"
-    if [ ! -f "$archive" ]; then
-        echo "missing HIL component archive: $archive" >&2
-        exit 1
-    fi
-    if ! undefined_symbols=$("$nm_tool" -u "$archive"); then
-        echo "$nm_tool failed to inspect $archive" >&2
-        exit 1
-    fi
-    if printf '%s\n' "$undefined_symbols" | grep -Eq \
-        'gpio_(config|set_level|get_level|install_isr_service|isr_handler_add)'; then
-        echo "$component still references physical GPIO in dev-board HIL" >&2
-        exit 1
-    fi
-done
-
-archive="$build_dir/esp-idf/pb_ntc/libpb_ntc.a"
-if [ ! -f "$archive" ]; then
-    echo "missing HIL component archive: $archive" >&2
-    exit 1
-fi
-if ! undefined_symbols=$("$nm_tool" -u "$archive"); then
-    echo "$nm_tool failed to inspect $archive" >&2
-    exit 1
-fi
-if printf '%s\n' "$undefined_symbols" | grep -Eq 'adc_(oneshot|cali)'; then
-    echo "pb_ntc still references the ADC backend in dev-board HIL" >&2
-    exit 1
-fi
+sh "$(dirname "$0")/check_devboard_compileout.sh" "$build_dir"
 
 echo "HIL compile-out check: PASS"

--- a/tests/hil/scenarios/devboard-auto.json
+++ b/tests/hil/scenarios/devboard-auto.json
@@ -36,8 +36,13 @@
       }
     },
     {
-      "name": "connect at threshold",
-      "send": {"cmd": "env", "connected": true, "bed_c": 100}
+      "name": "connect with an active source zone",
+      "send": {
+        "cmd": "env",
+        "connected": true,
+        "bed_c": 100,
+        "src_target_c": 55
+      }
     },
     {"name": "allow engaged tick", "wait_s": 0.7},
     {
@@ -51,7 +56,12 @@
     },
     {
       "name": "disconnect live printer",
-      "send": {"cmd": "env", "connected": false, "bed_c": 100}
+      "send": {
+        "cmd": "env",
+        "connected": false,
+        "bed_c": 100,
+        "src_target_c": 55
+      }
     },
     {"name": "allow fail-closed tick", "wait_s": 0.7},
     {


### PR DESCRIPTION
## Summary

- pin all shared dragon-core components to v0.32.0
- remove DragonBreath’s explicit `WIFI_PS_NONE` override
- leave DragonBreath on dragon-core’s default `DC_WIFI_RADIO_STANDARD` profile
- update the dev-board AUTO HIL scenario to the current source-zone contract
- add a non-HIL native-USB debug profile that runs production networking with physical Panda I/O compiled out

This restores the pre-v0.30 standard-radio behavior: minimum modem power save, the original retry and boot budgets, and no aggressive no-DHCP watchdog. The constrained-radio tuning remains available only to products that explicitly opt in.

## Validation

- normal production ESP32-C3 firmware build (ESP-IDF 5.3.1): PASS
- safe native-USB debug firmware build: PASS
- clean dev-board HIL firmware build: PASS
- dependency-lock validation against dragon-core v0.32.0: PASS
- API v2 static contract: PASS
- 8 C host-test scripts: PASS
- HIL runner unit tests (14): PASS
- generic debug and HIL physical-I/O compile-out audits: PASS

### Hardware — ESP32-C3 native USB

Validated on an ESP32-C3 rev 0.4 dev board with 4 MB embedded flash over native USB Serial/JTAG (`/dev/cu.usbmodem31101`).

Safe dev-board HIL:

- verified flash and native-USB command transport: PASS
- complete checked-in HIL suite: PASS (66/66 steps)
  - source-zone AUTO and disconnect fail-closed: 14/14
  - front-panel buttons, panic-off, and recovery: 32/32
  - safety, fault latching, lease invalidation, and zero-cross injection: 20/20
- final device state: OFF, heater output false, mains GPIO compiled out

Non-HIL safe debug profile:

- production networking and web/API startup enabled; HIL JSON console disabled
- physical heater, NTC ADC, fan, LED, and button backends compiled out
- joined the configured Wi-Fi network and obtained DHCP on hardware
- ESP-IDF reported `Set ps type: 1` and `pm start, type: 1`, directly confirming `WIFI_PS_MIN_MODEM` rather than `WIFI_PS_NONE`
- `GET /api/v2/health`: HTTP 200 with live RSSI/channel data
- device remained OFF with the safe physical-I/O compile-out active

The new `sdkconfig.debug-devboard-native` profile is intended only for ESP32-C3 dev-board diagnostics: it preserves the production network/UI path and native USB console while making accidental connection to Panda mains-control hardware inert.