### PR TITLE
feat(heater): expose PID duty telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+### Added
+- Expose product-owned heater control telemetry in API v2 state snapshots:
+  commanded SSR-window duty, the active PID approach limit, and the dominant
+  controller or thermal constraint. This is read-only observability and does
+  not change heater control or safety behavior.
+
 ## [1.1.15] - 2026-09-01
 
 ### Fixed

--- a/components/pb_heater/include/pb_heater.h
+++ b/components/pb_heater/include/pb_heater.h
@@ -32,6 +32,28 @@ typedef enum {
                                   // corrupt and mapped to a generic latched fault
 } pb_fault_reason_t;
 
+// Read-only control telemetry for diagnostics and hardware validation. These
+// values describe DragonBreath's product-owned control path; dc_pid remains a
+// board-neutral math primitive with no knowledge of approach limits, safety
+// governors, or the physical SSR.
+typedef enum {
+    PB_HEATER_CONSTRAINT_OFF = 0,
+    PB_HEATER_CONSTRAINT_NONE,
+    PB_HEATER_CONSTRAINT_APPROACH_LIMIT,
+    PB_HEATER_CONSTRAINT_TARGET_REACHED,
+    PB_HEATER_CONSTRAINT_LOCAL_FOLDBACK,
+    PB_HEATER_CONSTRAINT_ELEMENT_FOLDBACK,
+    PB_HEATER_CONSTRAINT_PID_ERROR,
+} pb_heater_constraint_t;
+
+typedef struct {
+    // PID output after DragonBreath's active approach limit (normalized 0..1).
+    float commanded_duty;
+    // Product-owned maximum duty for the current temperature error (0..1).
+    float approach_limit;
+    pb_heater_constraint_t constraint;
+} pb_heater_telemetry_t;
+
 // Pure fail-safe decision for the boot-time fault restore (pb_heater_load_fault),
 // inline so it can be host-tested without an NVS backend. Given the outcome of
 // reading the persisted latch/code, decides whether to come up latched and with
@@ -213,6 +235,11 @@ esp_err_t pb_heater_init(void);
 //                           HTTP 409. Heat is never queued behind a fault latch.
 esp_err_t pb_heater_set_target_c(float target_c);
 float pb_heater_get_target_c(void);
+
+// Copy one lock-consistent diagnostic snapshot. This is observational only and
+// has no effect on PID state, watchdogs, leases, or heater output.
+void pb_heater_get_telemetry(pb_heater_telemetry_t *out);
+const char *pb_heater_constraint_str(pb_heater_constraint_t constraint);
 
 // Optional external chamber measurement used ONLY for set-point regulation.
 // Pass NAN to fall back to the local chamber NTC. The local chamber NTC and PTC

--- a/components/pb_heater/pb_heater.c
+++ b/components/pb_heater/pb_heater.c
@@ -37,6 +37,9 @@ static bool        s_persist_pending;  // guarded by s_mux — a latch persist n
 static int64_t     s_persist_retry_us; // guarded by s_mux — last persist-retry timestamp
 static bool        s_on;            // written only by the control task; atomic read
 static pb_heater_pid_state_t s_pid; // control-task only — shared dc_pid state + SSR window
+static float       s_commanded_duty; // guarded by s_mux; PID output after approach limit
+static float       s_approach_limit; // guarded by s_mux; product-owned active duty ceiling
+static pb_heater_constraint_t s_constraint; // guarded by s_mux
 static bool        s_fb_cut;        // control-task only — element-foldback hysteresis latch:
                                     // true while the SSR is force-cut for element over-temp
                                     // (holds until the element cools below the resume point)
@@ -96,6 +99,40 @@ static void ssr_set(bool on)        // control-task context only
     s_on = on;
 }
 
+static void telemetry_set(float commanded_duty, float approach_limit,
+                          pb_heater_constraint_t constraint)
+{
+    taskENTER_CRITICAL(&s_mux);
+    s_commanded_duty = commanded_duty;
+    s_approach_limit = approach_limit;
+    s_constraint = constraint;
+    taskEXIT_CRITICAL(&s_mux);
+}
+
+void pb_heater_get_telemetry(pb_heater_telemetry_t *out)
+{
+    if (!out) return;
+    taskENTER_CRITICAL(&s_mux);
+    out->commanded_duty = s_commanded_duty;
+    out->approach_limit = s_approach_limit;
+    out->constraint = s_constraint;
+    taskEXIT_CRITICAL(&s_mux);
+}
+
+const char *pb_heater_constraint_str(pb_heater_constraint_t constraint)
+{
+    switch (constraint) {
+    case PB_HEATER_CONSTRAINT_OFF:             return "off";
+    case PB_HEATER_CONSTRAINT_NONE:            return "none";
+    case PB_HEATER_CONSTRAINT_APPROACH_LIMIT:  return "approach_limit";
+    case PB_HEATER_CONSTRAINT_TARGET_REACHED:  return "target_reached";
+    case PB_HEATER_CONSTRAINT_LOCAL_FOLDBACK:  return "local_foldback";
+    case PB_HEATER_CONSTRAINT_ELEMENT_FOLDBACK:return "element_foldback";
+    case PB_HEATER_CONSTRAINT_PID_ERROR:       return "pid_error";
+    default:                                   return "unknown";
+    }
+}
+
 esp_err_t pb_heater_init(void)
 {
     if (!s_persist_lock) s_persist_lock = xSemaphoreCreateMutex();
@@ -119,6 +156,9 @@ esp_err_t pb_heater_init(void)
     s_fault_reason = NULL;
     s_fault_code = PB_FAULT_NONE;
     s_last_link_us = esp_timer_get_time();
+    s_commanded_duty = 0.0f;
+    s_approach_limit = 0.0f;
+    s_constraint = PB_HEATER_CONSTRAINT_OFF;
     // Conservative defaults ONLY — nvs isn't up yet; pb_heater_load_config()
     // applies persisted values later (called after nvs_init in app_main).
     s_max_target_c = PB_HEATER_MAX_TARGET_C_DEFAULT;
@@ -365,6 +405,9 @@ static void do_latch(pb_fault_reason_t code, const char *reason,
     if (inhibit) s_inhibited = true;
     s_fault_code = code;
     s_fault_reason = reason ? reason : pb_heater_fault_str(code);
+    s_commanded_duty = 0.0f;
+    s_approach_limit = 0.0f;
+    s_constraint = PB_HEATER_CONSTRAINT_OFF;
     taskEXIT_CRITICAL(&s_mux);
     if (persist && transition) {
         if (s_persist_lock) xSemaphoreTake(s_persist_lock, portMAX_DELAY);
@@ -579,6 +622,7 @@ void pb_heater_tick(void)          // control-task context; sole writer of s_on
         pb_heater_pid_reset(&s_pid);
         s_fb_cut      = false;   // drop foldback latches so the next arm starts clean
         s_local_cut   = false;
+        telemetry_set(0.0f, 0.0f, PB_HEATER_CONSTRAINT_OFF);
         return;
     }
 
@@ -617,15 +661,35 @@ void pb_heater_tick(void)          // control-task context; sole writer of s_on
     // authoritative regardless of PID demand.
     bool safety_inhibited = s_local_cut || s_fb_cut;
     float duty = 0.0f;
-    if (!pb_heater_pid_step(&s_pid, target, regulation_c,
-                            !safety_inhibited, &duty)) {
+    bool pid_ok = pb_heater_pid_step(&s_pid, target, regulation_c,
+                                     !safety_inhibited, &duty);
+    if (!pid_ok) {
         ESP_LOGE(TAG, "PID step rejected; forcing SSR off");
         duty = 0.0f;
     }
 
+    float approach_limit = pb_heater_pid_approach_max_duty(target - regulation_c);
+    pb_heater_constraint_t constraint = PB_HEATER_CONSTRAINT_NONE;
+    if (!pid_ok)
+        constraint = PB_HEATER_CONSTRAINT_PID_ERROR;
+    else if (s_fb_cut)
+        constraint = PB_HEATER_CONSTRAINT_ELEMENT_FOLDBACK;
+    else if (s_local_cut)
+        constraint = PB_HEATER_CONSTRAINT_LOCAL_FOLDBACK;
+    else if (regulation_c >= target)
+        constraint = PB_HEATER_CONSTRAINT_TARGET_REACHED;
+    else if (approach_limit < 1.0f && duty >= approach_limit - 0.0005f)
+        constraint = PB_HEATER_CONSTRAINT_APPROACH_LIMIT;
+
+    // This is the duty actually admitted to the SSR window after downstream
+    // thermal governors. Keep the underlying PID state private; diagnostics
+    // should report the command the actuator was allowed to receive.
+    float commanded_duty = safety_inhibited ? 0.0f : duty;
+    telemetry_set(commanded_duty, approach_limit, constraint);
+
     // Step 5 — time-proportion normalized duty through a slow 10 s window. This is
     // still plain on/off drive of a zero-cross SSR; there is no phase cutting.
-    bool drive = !safety_inhibited &&
-                 pb_heater_pid_window_on(&s_pid, duty, esp_timer_get_time());
+    bool drive = pb_heater_pid_window_on(
+        &s_pid, commanded_duty, esp_timer_get_time());
     if (drive != s_on) ssr_set(drive);
 }

--- a/components/pb_httpd/pb_httpd.c
+++ b/components/pb_httpd/pb_httpd.c
@@ -102,6 +102,13 @@ static void add_num1(cJSON *o, const char *key, float v)
     cJSON_AddRawToObject(o, key, b);
 }
 
+static void add_num3(cJSON *o, const char *key, float v)
+{
+    char b[20];
+    snprintf(b, sizeof b, "%.3f", (double)v);
+    cJSON_AddRawToObject(o, key, b);
+}
+
 static const char *fan_reason(const pb_policy_snapshot_t *s)
 {
     if (s->fault_latched || s->inhibited) return "fault";
@@ -136,8 +143,15 @@ static cJSON *state_json(const pb_policy_snapshot_t *s)
         config, "comms_ms", pb_heater_get_comms_timeout_ms());
 
     cJSON *heater = cJSON_AddObjectToObject(o, "heater");
+    pb_heater_telemetry_t heater_telemetry;
+    pb_heater_get_telemetry(&heater_telemetry);
     cJSON_AddBoolToObject(heater, "demand", s->heater_demand);
     cJSON_AddBoolToObject(heater, "output", s->heater_output);
+    add_num3(heater, "commanded_duty", heater_telemetry.commanded_duty);
+    add_num3(heater, "approach_limit", heater_telemetry.approach_limit);
+    cJSON_AddStringToObject(
+        heater, "constraint",
+        pb_heater_constraint_str(heater_telemetry.constraint));
 
     cJSON *fan = cJSON_AddObjectToObject(o, "fan");
     cJSON_AddNumberToObject(fan, "requested_percent", s->requested_fan_percent);

--- a/docs/api-v2.md
+++ b/docs/api-v2.md
@@ -59,7 +59,13 @@ The complete snapshot, not locally remembered intent, is the source of truth:
     "max_abs": 70.0,
     "comms_ms": 300000
   },
-  "heater": {"demand": true, "output": true},
+  "heater": {
+    "demand": true,
+    "output": true,
+    "commanded_duty": 0.700,
+    "approach_limit": 0.700,
+    "constraint": "approach_limit"
+  },
   "fan": {
     "requested_percent": 100,
     "effective_percent": 100,
@@ -106,6 +112,14 @@ The complete snapshot, not locally remembered intent, is the source of truth:
   }
 }
 ```
+
+`heater.commanded_duty` is the normalized duty admitted to the 10-second SSR
+window after the PID approach policy and non-latching thermal governors. It is
+not phase-angle modulation; `heater.output` remains the instantaneous on/off SSR
+command. `heater.approach_limit` reports the product-owned duty ceiling selected
+for the current control error. `heater.constraint` is one of `off`, `none`,
+`approach_limit`, `target_reached`, `local_foldback`, `element_foldback`,
+`pid_error`, or `unknown`.
 
 Temperatures are JSON `null` when their sensor status is not `ok`. Public
 state and SSE snapshots intentionally omit the raw lease ID; only the

--- a/tests/check_api_v2_contract.sh
+++ b/tests/check_api_v2_contract.sh
@@ -99,6 +99,15 @@ for field in printer_chamber_temperature_c printer_chamber_age_ms; do
     }
 done
 
+# Product-owned heater diagnostics must make the PID command, approach policy,
+# and dominant constraint observable without moving actuator policy into core.
+for field in commanded_duty approach_limit constraint; do
+    grep -q "\"$field\"" "$httpd" || {
+        echo "state document is missing heater.$field" >&2
+        exit 1
+    }
+done
+
 # Ownership boundary: core owns HTTP/provisioning/recovery; the product adapter
 # supplies API registration, authorization, heater safety and image identity.
 grep -q 'dc_portal_start(&cfg)' "$adapter"


### PR DESCRIPTION
## Summary

- expose the duty admitted to DragonBreath's 10-second SSR window
- expose the active product-owned approach limit and dominant constraint
- keep the telemetry snapshot lock-consistent and observational only
- document the additive API v2 fields and constraint vocabulary
- add static API contract coverage and changelog entry

## Architecture

This remains DragonBreath-owned rather than moving into dragon-core. `dc_pid` supplies generic PID math and results; DragonBreath owns approach shaping, local and element foldback, SSR time proportioning, safety authority, and the product API.

The new state shape is:

```json
"heater": {
  "demand": true,
  "output": false,
  "commanded_duty": 0.400,
  "approach_limit": 0.400,
  "constraint": "approach_limit"
}
```

`commanded_duty` is post-approach and post-foldback: the normalized command actually admitted to the SSR window. `output` remains the instantaneous physical SSR command.

## Safety

This is behavior-neutral observability. It does not alter PID gains, approach thresholds, safety limits, fault handling, watchdog behavior, leases, or output timing. Reading the telemetry does not mutate controller state or refresh any authority.

## Validation

Passed locally:

- all `tests/run_*_host_test.sh` suites
- `tests/check_api_v2_contract.sh`
- `git diff --check`

ESP32-C3 firmware build remains for CI.

Closes #96.
Supports diagnosis and retest of #95.
