### PR TITLE
build: require fixed ESP-IDF async HTTP server

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -115,10 +115,10 @@ jobs:
       # there is no committed lock to drift. The ESP-IDF build step re-solves and
       # validates the managed-component dependencies against the pinned manifests
       # (components/*/idf_component.yml) on every run, which is the validation.
-      - name: Build (ESP-IDF v5.3)
+      - name: Build (ESP-IDF v5.3.5)
         uses: espressif/esp-idf-ci-action@9d38657f3d789ca759b2b37aaf5ceffbc42c4f0d # v1
         with:
-          esp_idf_version: v5.3
+          esp_idf_version: v5.3.5
           target: esp32c3
           path: '.'
 
@@ -126,10 +126,10 @@ jobs:
         run: |
           sh tests/check_api_v2_contract.sh
 
-      - name: Build safe dev-board HIL profile (ESP-IDF v5.3)
+      - name: Build safe dev-board HIL profile (ESP-IDF v5.3.5)
         uses: espressif/esp-idf-ci-action@9d38657f3d789ca759b2b37aaf5ceffbc42c4f0d # v1
         with:
-          esp_idf_version: v5.3
+          esp_idf_version: v5.3.5
           target: esp32c3
           path: '.'
           command: |
@@ -145,10 +145,10 @@ jobs:
               build
             sh tests/check_hil_compileout.sh build-hil-devboard-uart
 
-      - name: Build native-USB production-network debug profile (ESP-IDF v5.3)
+      - name: Build native-USB production-network debug profile (ESP-IDF v5.3.5)
         uses: espressif/esp-idf-ci-action@9d38657f3d789ca759b2b37aaf5ceffbc42c4f0d # v1
         with:
-          esp_idf_version: v5.3
+          esp_idf_version: v5.3.5
           target: esp32c3
           path: '.'
           command: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,12 @@ project(dragonbreath)
 # asynchronous request worker still owns it. DragonBreath's SSE endpoint uses
 # that API, so require Espressif's 8b559ce61454 fix, first released in
 # ESP-IDF 5.3.2.
-if(IDF_VERSION VERSION_LESS "5.3.2")
+idf_build_get_property(DB_IDF_VERSION IDF_VER)
+if(NOT DB_IDF_VERSION MATCHES "^v?([0-9]+\\.[0-9]+\\.[0-9]+)")
+    message(FATAL_ERROR "Cannot determine ESP-IDF version from '${DB_IDF_VERSION}'")
+endif()
+set(DB_IDF_SEMVER "${CMAKE_MATCH_1}")
+if(DB_IDF_SEMVER VERSION_LESS "5.3.2")
     message(FATAL_ERROR
         "DragonBreath requires ESP-IDF v5.3.2 or newer: older releases can "
         "concurrently process sockets owned by asynchronous HTTP requests")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,16 @@ message(STATUS "DragonBreath version: ${PROJECT_VER}")
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(dragonbreath)
 
+# ESP-IDF 5.3.1's HTTP server can process and recycle a socket while an
+# asynchronous request worker still owns it. DragonBreath's SSE endpoint uses
+# that API, so require Espressif's 8b559ce61454 fix, first released in
+# ESP-IDF 5.3.2.
+if(IDF_VERSION VERSION_LESS "5.3.2")
+    message(FATAL_ERROR
+        "DragonBreath requires ESP-IDF v5.3.2 or newer: older releases can "
+        "concurrently process sockets owned by asynchronous HTTP requests")
+endif()
+
 # E1 (Phase E) — warnings-as-errors for OUR OWN first-party components only.
 # Applied here (after project(), when the per-component library targets exist) as a
 # PRIVATE option so it never leaks to ESP-IDF's own components or to dependents.

--- a/README.md
+++ b/README.md
@@ -308,7 +308,11 @@ serves both boards. Details + derivation:
 [`docs/NTC_CONVERSION.md`](docs/NTC_CONVERSION.md).
 
 ## Build
-Requires ESP-IDF v5.3+.
+Requires ESP-IDF v5.3.2 or newer. ESP-IDF v5.3.1 has a known asynchronous
+HTTP-request socket ownership defect that can corrupt concurrent responses;
+[Espressif fixed it in `8b559ce`](https://github.com/espressif/esp-idf/commit/8b559ce6145474f01fcbb8763604e6b8769ba84e).
+DragonBreath's CI and release builds use v5.3.5.
+
 ```bash
 git clone https://github.com/plastikman/DragonBreath
 cd DragonBreath


### PR DESCRIPTION
## Summary

Require an ESP-IDF release containing Espressif's asynchronous HTTP-request socket-ownership fix.

- Reject ESP-IDF older than v5.3.2 at configure time.
- Pin CI production and safe debug/HIL builds to v5.3.5.
- Document the minimum version and upstream fix.

## Root cause

ESP-IDF v5.3.1 could return an asynchronous HTTP session's socket to the main HTTP task. During DragonBreath SSE churn, the main task closed and reused that descriptor while the asynchronous SSE worker still held its copied request. A stale SSE chunk could therefore be written into a newly accepted ordinary HTTP response, producing DragonSniff's observed `BadStatusLine: 11\r\n`.

Espressif fixed the concurrency defect in `8b559ce6145474f01fcbb8763604e6b8769ba84e`, first included in v5.3.2.

## Validation

- Configure-time rejection verified with local ESP-IDF v5.3.1.
- GitHub workflow is fully green using v5.3.5:
  - all host tests
  - static analysis
  - ESP32-C3 production build
  - API v2 contract
  - safe dev-board HIL builds
  - native-USB production-network debug build
- Instrumented v5.3.5 hardware build passed:
  - 10 observation/capture/observation repetitions
  - 20/20 sequential SSE churn connections
  - 150/150 concurrent state/health requests
  - 101 SSE telemetry events
  - zero HTTP, transport, parse, or ownership-loss failures
  - zero `BadStatusLine`
  - SSE count recovered to its pre-run baseline
  - boot ID and heap remained stable

No DragonBreath controller, heater, fan, safety, source-selection, HTTP endpoint, or SSE architecture behavior changes are included.

Hardware evidence is tracked in danielbrownjr/DragonSniff#10.