### PR TITLE
docs: clarify chamber heater workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ below into the GitHub Release notes.
   and slicer/Klipper control explicitly alternative workflows, documents several
   valid heating orders, warns about OrcaSlicer's leading blocking `M191`, and
   covers printer-specific auxiliary-fan, bed-position, toolhead-position, homing,
-  and thermal-expansion considerations. It also explains why detecting an active
+  and thermal-expansion considerations. A recommended CoreXY starting pattern
+  starts bed/chamber together, parks the toolhead, raises the bed, circulates at
+  roughly 70%, then waits and soaks. It also explains why detecting an active
   `[dragonbreath]` controller hides AUTO; the Snapmaker U1/PAXX profile remains
   only a worked example.
 - Updated stale feature, control-source, API, and OEM-parity descriptions for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ below into the GitHub Release notes.
   printer/slicer workflow integration rather than "just working." It makes AUTO
   and slicer/Klipper control explicitly alternative workflows, documents several
   valid heating orders, warns about OrcaSlicer's leading blocking `M191`, and
-  explains why detecting an active `[dragonbreath]` controller hides AUTO. The
-  Snapmaker U1/PAXX profile remains only a worked example.
+  covers printer-specific auxiliary-fan, bed-position, toolhead-position, homing,
+  and thermal-expansion considerations. It also explains why detecting an active
+  `[dragonbreath]` controller hides AUTO; the Snapmaker U1/PAXX profile remains
+  only a worked example.
 - Updated stale feature, control-source, API, and OEM-parity descriptions for the
   current filament-follow AUTO behavior and the PrusaLink bed-follow exception.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ below into the GitHub Release notes.
 
 ## [Unreleased]
 
+### Documentation
+- Added a task-focused chamber-heater guide that makes AUTO and slicer/Klipper
+  control explicitly alternative workflows, documents that manual `M141`/`M191`
+  commands replace AUTO, warns that OrcaSlicer injects blocking `M191` before
+  Machine start G-code, and provides a simultaneous bed/chamber preheat macro.
+- Updated stale feature, control-source, API, and OEM-parity descriptions for the
+  current filament-follow AUTO behavior and the PrusaLink bed-follow exception.
+
 ### Added
 - Expose product-owned heater control telemetry in API v2 state snapshots:
   commanded SSR-window duty, the active PID approach limit, and the dominant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ below into the GitHub Release notes.
   printer/slicer workflow integration rather than "just working." It makes AUTO
   and slicer/Klipper control explicitly alternative workflows, documents several
   valid heating orders, warns about OrcaSlicer's leading blocking `M191`, and
-  includes the Snapmaker U1/PAXX profile only as a worked example.
+  explains why detecting an active `[dragonbreath]` controller hides AUTO. The
+  Snapmaker U1/PAXX profile remains only a worked example.
 - Updated stale feature, control-source, API, and OEM-parity descriptions for the
   current filament-follow AUTO behavior and the PrusaLink bed-follow exception.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ below into the GitHub Release notes.
 ## [Unreleased]
 
 ### Documentation
-- Added a task-focused chamber-heater guide that makes AUTO and slicer/Klipper
-  control explicitly alternative workflows, documents that manual `M141`/`M191`
-  commands replace AUTO, warns that OrcaSlicer injects blocking `M191` before
-  Machine start G-code, and provides both an exact Snapmaker U1/PAXX start-G-code
-  edit and a generic simultaneous bed/chamber preheat macro.
+- Added a task-focused chamber-heater guide explaining that a new heater requires
+  printer/slicer workflow integration rather than "just working." It makes AUTO
+  and slicer/Klipper control explicitly alternative workflows, documents several
+  valid heating orders, warns about OrcaSlicer's leading blocking `M191`, and
+  includes the Snapmaker U1/PAXX profile only as a worked example.
 - Updated stale feature, control-source, API, and OEM-parity descriptions for the
   current filament-follow AUTO behavior and the PrusaLink bed-follow exception.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ below into the GitHub Release notes.
 - Added a task-focused chamber-heater guide that makes AUTO and slicer/Klipper
   control explicitly alternative workflows, documents that manual `M141`/`M191`
   commands replace AUTO, warns that OrcaSlicer injects blocking `M191` before
-  Machine start G-code, and provides a simultaneous bed/chamber preheat macro.
+  Machine start G-code, and provides both an exact Snapmaker U1/PAXX start-G-code
+  edit and a generic simultaneous bed/chamber preheat macro.
 - Updated stale feature, control-source, API, and OEM-parity descriptions for the
   current filament-follow AUTO behavior and the PrusaLink bed-follow exception.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ re-implemented.
 > firmware with no warranty — read [`docs/SAFETY.md`](docs/SAFETY.md) and
 > supervise early runs.
 
+**Start here:** **[How to use the chamber heater](docs/USING_THE_HEATER.md)** —
+choose AUTO or slicer/Klipper control, and avoid OrcaSlicer's blocking-`M191`
+ordering trap.
+
 **Docs:** full feature set → [`docs/FEATURES.md`](docs/FEATURES.md) · control API →
 [`docs/api-v2.md`](docs/api-v2.md) · safety model → [`docs/SAFETY.md`](docs/SAFETY.md) ·
 OEM parity → [`docs/OEM_PARITY.md`](docs/OEM_PARITY.md) · hardware →
@@ -133,7 +137,7 @@ without touching the firmware.
 | Front-panel hard reset | ✅ **Hold Power + Auto 5 s** → LEDs flash 3× → wipes config (Wi-Fi/token/policy/calibration) + reboots to the setup AP. No computer needed; USB twin is `flash.py --erase-nvs` |
 | Web OTA update | ✅ Dual-OTA + rollback; upload from the UI, verified on hardware — accepts a DragonBreath **or** a stock `panda_breath` image (for revert); refused while heating |
 | HIL (`pb_hil` / `tools/hil.py`) | ✅ CH341 devboard suite and non-heating real-Panda UART build/flash/no-flash workflows qualified on hardware; native-USB runtime pending on the tested devboard |
-| Control source (`dc_source`/`dc_bambu`/`pb_ha`) | ✅ Single-select on `/setup` (mutually exclusive): Klipper/Moonraker (default, validated) · Home Assistant MQTT Discovery (validated on live HA) · Bambu LAN MQTT (validated on real hardware) |
+| Control source (`dc_source`) | ✅ Single-select on `/setup`: Klipper/Moonraker (default) · Klipper MQTT · Home Assistant MQTT Discovery · Bambu LAN MQTT · PrusaLink; optional HA telemetry remains read-only when another source controls heat |
 | On-device diagnostics pages | ✅ `/diag` (live SSE telemetry + trend + CSV) and `/console` (firmware `ESP_LOGx` viewer via auth-gated `GET /api/v2/console`) — shipped v0.8.0 |
 | Diagnostics (`tools/diag.py`) | ✅ Read-only 2 Hz logger (chamber/PTC/SSR/mode/fault + resolved Rref) → live view + CSV; run during a heat cycle to capture behavior. `python3 tools/diag.py [host] [token]` |
 
@@ -159,6 +163,12 @@ chamber given enough soak time will reach higher and hold it; a leaky one (taped
 seams, thin panels) plateaus lower no matter how long it runs. If you're stalling
 short of a target, add insulation and allow more warm-up time before assuming a
 hardware limit. 60–65 °C covers ASA/ABS comfortably.
+
+> **The heater does not automatically coordinate the bed.** On OrcaSlicer,
+> chamber-temperature control emits a blocking `M191` *before* Machine start
+> G-code, so the bed has normally not started yet. Choose either DragonBreath
+> AUTO or a slicer/Klipper start macro that starts both heaters; see
+> **[Using the chamber heater](docs/USING_THE_HEATER.md)**.
 
 ## Screenshots
 <p>
@@ -217,6 +227,9 @@ others are disabled — there is exactly one controller.
   [dragonbreath-klipper](https://github.com/plastikman/dragonbreath-klipper) helper it
   shows up as `[heater_generic dragonbreath]` (M141/M191) plus a fan-only filtration
   toggle, and AUTO mode follows the loaded filament's zone profile. Validated end-to-end on hardware.
+  The active helper is a manual controller and should be disabled for AUTO;
+  `M141`/`M191` must not be emitted in that workflow. See
+  [the heater workflow guide](docs/USING_THE_HEATER.md).
 - **Klipper MQTT** — an alternative for managed Klipper installs that permit
   `moonraker.conf`, `printer.cfg`, and broker configuration but cannot install a
   Klippy extra. Save its broker settings on `/setup`, then open `/km-config` to

--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ others are disabled — there is exactly one controller.
   [dragonbreath-klipper](https://github.com/plastikman/dragonbreath-klipper) helper it
   shows up as `[heater_generic dragonbreath]` (M141/M191) plus a fan-only filtration
   toggle, and AUTO mode follows the loaded filament's zone profile. Validated end-to-end on hardware.
-  The active helper is a manual controller and should be disabled for AUTO;
-  `M141`/`M191` must not be emitted in that workflow. See
+  When an active `[dragonbreath]` helper config is detected, slicer/Klipper owns
+  chamber heat and AUTO is hidden. Disable the helper config to use AUTO. See
   [the heater workflow guide](docs/USING_THE_HEATER.md).
 - **Klipper MQTT** — an alternative for managed Klipper installs that permit
   `moonraker.conf`, `printer.cfg`, and broker configuration but cannot install a

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -36,10 +36,11 @@ loaded filament's zone profile; validated on a real printer), or **PrusaLink**
 identical and source-independent.
 
 For Klipper users, AUTO and slicer-issued `M141`/`M191` are alternative workflows.
-Positive targets from those commands request a manual POWER_ON session and replace AUTO. OrcaSlicer also
-emits a blocking `M191` before Machine start G-code when chamber control is enabled,
+When an active `[dragonbreath]` Klippy configuration is detected, slicer/Klipper
+owns chamber heat and the UI hides AUTO. OrcaSlicer also emits a blocking `M191`
+before Machine start G-code when its filament-level automatic control is enabled,
 before the normal bed command. See [`USING_THE_HEATER.md`](USING_THE_HEATER.md) for
-the two supported workflows and a bed-plus-chamber preheat macro.
+workflow and ordering choices.
 
 AUTO and filament drying are implemented and validated end-to-end on hardware;
 see [`OEM_PARITY.md`](OEM_PARITY.md).

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,8 +1,8 @@
 # DragonBreath — feature set
 
-Current as of **v1.0.1-rc1**. Open ESP-IDF firmware for the BIGTREETECH Panda Breath
+Current as of **v1.1.16**. Open ESP-IDF firmware for the BIGTREETECH Panda Breath
 (ESP32-C3) chamber heater with a selectable control source (Klipper/Moonraker, Home
-Assistant, or Bambu LAN) + local web control.
+Assistant, Bambu LAN, or PrusaLink) + local web control.
 
 See [`OEM_PARITY.md`](OEM_PARITY.md) for the explicit implemented/planned/
 intentionally-changed feature matrix.
@@ -16,8 +16,8 @@ heat after a reboot.
 | Mode | What it does | How it's triggered |
 |---|---|---|
 | **Off** | Heater off. | Boot default; `off` command (always accepted). |
-| **Manual / Power-On** | Holds the chamber at a set target. Remote sessions take a device-issued lease and must heartbeat to stay alive. | `power_on` command (web "Manual heat", or Klipper `M141`/`SET_HEATER_TEMPERATURE`). |
-| **Automatic (follow bed)** | Watches the printer's bed temperature (via Moonraker) and heats the chamber to the target whenever the bed is at/above a threshold; disengages below threshold − 3 °C. Autonomous (no host heartbeat), requires the Moonraker link. | `auto` command / web "Follow printer bed". |
+| **Manual / Power-On** | Holds the chamber at a set target. Remote sessions take a device-issued lease and must heartbeat to stay alive. | `power_on` command (web "Manual heat", or Klipper `M141`/`M191`/`SET_HEATER_TEMPERATURE`). |
+| **Automatic** | For filament-aware Klipper and Bambu sources, follows the active print's configured filament-zone target. For bed-only PrusaLink, heats to the configured target when the bed setpoint reaches its threshold. Waits with heat off if the source or required profile data is unavailable. | `auto` command / dashboard Auto control / front-panel Auto button. |
 | **Filament drying** | Holds the chamber at a target for a bounded duration (1–12 h), then auto-off. Material presets pre-fill target + duration. | `drying_start` / web "Filament drying". |
 | **Fan-only filtration** | Runs the chamber blower with **no heat** to filter/circulate air. Two paths: (a) the automatic **standing band** — the blower runs alone whenever `filter_auto` is enabled (**off by default**) + the source is connected + the bed **setpoint** reaches `filter_temp` (default 30 °C), independent of mode (even while idle); (b) a mode-independent manual toggle. Enabling manual filtration is idle-only (rejected while heating/cooling); turning it off always works. | `filter` command / web "Filtration" button; standing band via `filter_temp`/`filter_auto`. |
 
@@ -27,17 +27,22 @@ accepted and never cached.
 
 **Control source (choose one).** The device binds to exactly one printer/controller
 at a time, selected on `/setup`: **Klipper/Moonraker** (default, hardware-validated),
+**Klipper MQTT** (for managed installs that cannot add a Klippy extra),
 **Home Assistant** (native MQTT Discovery — climate entity + chamber/element sensors;
-validated against a live HA instance), or **Bambu LAN** (read-only, follows the
-loaded filament's zone profile; validated on a real printer). They are mutually exclusive; the
-selection drives AUTO's bed feed and is reported as `environment.control_source`
-(`klipper`/`bambu`/`ha`) in the state API. The heater safety model is identical and
-source-independent.
+validated against a live HA instance), **Bambu LAN** (read-only, follows the
+loaded filament's zone profile; validated on a real printer), or **PrusaLink**
+(bed-follow). They are mutually exclusive and reported as
+`environment.control_source` in the state API. The heater safety model is
+identical and source-independent.
 
-AUTO and filament drying are implemented in the policy/API; drying is validated
-end-to-end on hardware. The AUTO dashboard control is still tracked as partial
-until its user-facing feedback is fully validated; see
-[`OEM_PARITY.md`](OEM_PARITY.md).
+For Klipper users, AUTO and slicer-issued `M141`/`M191` are alternative workflows.
+Positive targets from those commands request a manual POWER_ON session and replace AUTO. OrcaSlicer also
+emits a blocking `M191` before Machine start G-code when chamber control is enabled,
+before the normal bed command. See [`USING_THE_HEATER.md`](USING_THE_HEATER.md) for
+the two supported workflows and a bed-plus-chamber preheat macro.
+
+AUTO and filament drying are implemented and validated end-to-end on hardware;
+see [`OEM_PARITY.md`](OEM_PARITY.md).
 
 ## Safety
 
@@ -79,9 +84,9 @@ Defense-in-depth — see [`SAFETY.md`](SAFETY.md) for the full model.
   (on/off, **default off** — opt-in) control the fan-only filtration band. It is a
   **standing** band (stock-shaped): once enabled, whenever Moonraker is connected the
   blower runs alone once the print's bed **setpoint** reaches `filter_temp` —
-  independent of mode, so it filters even on prints that never reach the AUTO
-  heat-engage threshold and while idle. The heater still engages only in AUTO at the
-  higher bed threshold. (Off-by-default diverges from stock; see
+  independent of mode, so it filters even while idle. AUTO heat engagement is
+  separate and uses either the active filament zone or, for a bed-follow source,
+  its configured bed threshold. (Off-by-default diverges from stock; see
   [`OEM_PARITY.md`](OEM_PARITY.md).)
 
 Exposed via `GET`/`POST /settings` and the web UI's Settings cards. The fixed
@@ -194,13 +199,11 @@ exact-lease heartbeats, reactor-safe). Deploy lockstep with the firmware.
 The dashboard can also be embedded in the Fluidd/Mainsail printer view via a
 Moonraker `[webcam]` `iframe` — see the DragonBreath README.
 
-For AUTO mode, DragonBreath reads the bed state from whichever **control source** is
-selected on `/setup` (see *Control modes* above): Moonraker (Klipper, default), Home
-Assistant over MQTT, or a Bambu printer over its LAN MQTT. This mirrors the stock
-firmware's own multi-source support (Moonraker / Bambu MQTT / Home Assistant MQTT) —
-Klipper is the default and hardware-validated path, and HA and Bambu are both
-validated on real hardware. None of these require a vendor cloud (Bambu uses the
-printer's on-device LAN broker).
+For AUTO mode, DragonBreath reads print/material state from the **control source**
+selected on `/setup`. Klipper/Moonraker and Bambu are filament-aware; PrusaLink is
+bed-follow because it does not report filament type. Home Assistant and Klipper-MQTT
+drive target/mode commands instead of supplying AUTO environment data. None of
+these require a vendor cloud (Bambu uses the printer's on-device LAN broker).
 
 ## Platform / release
 

--- a/docs/KLIPPER_DISTRIBUTION_INTEGRATION.md
+++ b/docs/KLIPPER_DISTRIBUTION_INTEGRATION.md
@@ -49,6 +49,23 @@ There are two independent network relationships in Klipper control-source mode:
 No MQTT broker, Moonraker plug-in, or special Moonraker configuration is
 required for the native Klippy-extra path.
 
+### AUTO and manual G-code are alternative workflows
+
+The helper's Python file can be installed while DragonBreath AUTO is used, but its
+active `[dragonbreath]` configuration is a manual controller. As required below,
+it sends a safety OFF on connect, orderly disconnect, and Klippy shutdown; a
+reconnect can therefore disarm AUTO. Slicer-issued `M141`, `M191`, and
+`SET_HEATER_TEMPERATURE` commands with a positive target also start a manual
+POWER_ON session and replace AUTO. A distribution should provide a way to disable the active helper config,
+tell users to choose one workflow, and link to
+[`USING_THE_HEATER.md`](USING_THE_HEATER.md).
+
+OrcaSlicer deserves an explicit warning. With chamber-temperature control enabled,
+it emits a blocking `M191` before Machine start G-code. The usual bed command has
+not run yet, so warm-up is sequential. For simultaneous bed/chamber warm-up, disable
+Orca's injected command, pass its chamber value to `PRINT_START`, start the bed and
+chamber non-blocking, and then wait for each inside the printer macro.
+
 ## Responsibilities and safety boundaries
 
 ### DragonBreath firmware

--- a/docs/KLIPPER_DISTRIBUTION_INTEGRATION.md
+++ b/docs/KLIPPER_DISTRIBUTION_INTEGRATION.md
@@ -51,13 +51,11 @@ required for the native Klippy-extra path.
 
 ### AUTO and manual G-code are alternative workflows
 
-The helper's Python file can be installed while DragonBreath AUTO is used, but its
-active `[dragonbreath]` configuration is a manual controller. As required below,
-it sends a safety OFF on connect, orderly disconnect, and Klippy shutdown; a
-reconnect can therefore disarm AUTO. Slicer-issued `M141`, `M191`, and
-`SET_HEATER_TEMPERATURE` commands with a positive target also start a manual
-POWER_ON session and replace AUTO. A distribution should provide a way to disable the active helper config,
-tell users to choose one workflow, and link to
+An active `[dragonbreath]` configuration declares slicer/Klipper ownership of
+chamber heat. The UI therefore hides AUTO when it detects that configuration,
+rather than presenting two controls that cannot safely own the same target. A
+distribution should provide a way to disable the active helper config and restart
+Klipper for users who prefer AUTO. Link users to
 [`USING_THE_HEATER.md`](USING_THE_HEATER.md).
 
 OrcaSlicer deserves an explicit warning. With chamber-temperature control enabled,

--- a/docs/OEM_PARITY.md
+++ b/docs/OEM_PARITY.md
@@ -4,7 +4,7 @@ DragonBreath is not intended to reproduce the stock firmware byte-for-byte. This
 matrix records which user-visible Panda Breath behaviors are implemented, still
 planned, deliberately changed for safety, or intentionally omitted.
 
-Current as of **v1.0.1-rc1**. Since the earlier matrix: v0.8.0 added a selectable
+Current as of **v1.1.16**. Since the earlier matrix: v0.8.0 added a selectable
 control source (Klipper / Bambu / Home Assistant) plus the `/diag` and `/console` web
 pages; v1.0.0 moved to a no-USB install/revert model on the stock partition layout;
 v1.0.1 makes the fan-only filtration band a standing behavior (opt-in, off by default).
@@ -12,13 +12,13 @@ v1.0.1 makes the fan-only filtration band a standing behavior (opt-in, off by de
 | Stock/OEM behavior | DragonBreath status | Notes |
 |---|---|---|
 | Manual chamber target | **Implemented** | Local Web UI and Klipper `M141`/`M191`; device-side regulation and limits remain authoritative. |
-| Follow-printer-bed automatic mode | **Partial** | Policy/API support is present: live Moonraker bed temperature, 3 °C disengage hysteresis, and fail-off on disconnect. The shipped dashboard control is not yet accepted as end-to-end validated. |
+| Automatic chamber mode | **Implemented** | Klipper/Moonraker and Bambu follow the active print's configured filament-zone target. PrusaLink, which has no filament metadata, follows its bed setpoint and the configured bed threshold. Missing source/profile data fails to heat-off. |
 | Timed filament drying | **Implemented** | A target plus a bounded 1–12 hour duration with automatic shutoff, driven from the dashboard Dry screen and API v2 (`drying_start` / `drying_stop`). Material presets are implemented (PLA 45 °C/6 h, PETG 65 °C/4 h, ABS 70 °C/4 h, Nylon 55 °C/8 h — one tap pre-fills target + duration). Validated on hardware. |
 | Chamber and PTC temperature display | **Implemented** | Both sensors and their health are exposed in the dashboard and API v2 state. |
 | Sensor-fault and over-temperature shutdown | **Implemented** | Heater fails closed; fixed 85 °C chamber and 105 °C PTC cutoffs are not user-configurable. |
 | Fan follows heater | **Implemented** | TRIAC is held on/off and never phase-angle PWM'd. |
 | Residual-heat fan purge | **Implemented** | Session-gated cooldown with hysteresis around the configurable `cool_release` temp (30–65 °C, default 40 °C): engages one 3 °C band above it, releases only once **both** chamber and PTC are below it; an unknown sensor keeps the fan on. Strictly session-gated: the fan never starts on temperature alone, and a power-cycle-while-hot does not spin it. The opt-in temperature-latched policy was **intentionally not added** for that reason. Fault airflow remains unconditional. |
-| Front-panel mode LEDs | **Implemented** | All four outputs are driven from the authoritative policy snapshot: Power is solid whenever the device is up and blinks on fault; On, Auto, and Dry each light for their own mode. Auto slow-blinks when armed but not engaged (no Moonraker link, or bed below the threshold). Power is release-only — GPIO21 is also the serial console TX. |
+| Front-panel mode LEDs | **Implemented** | All four outputs are driven from the authoritative policy snapshot: Power is solid whenever the device is up and blinks on fault; On, Auto, and Dry each light for their own mode. Auto slow-blinks when armed but not engaged (for example, no source link or no matching filament zone). Power is release-only — GPIO21 is also the serial console TX. |
 | Front-panel buttons | **Implemented** | All four (Power GPIO9, Auto GPIO8, On GPIO10, Dry GPIO2) are polled with debounce and short/long-press detection. A short press toggles the button's labeled mode (arming from the remembered parameters); a 2 s long-press latches a panic-off, except a long-press on Power while faulted attempts a fault clear. Every button action is attributed to the panel and invalidates any remote lease. A button held at power-on is ignored until released (GPIO9/8/2 are strapping pins). |
 | Local status/configuration UI | **Implemented** | Responsive, touch-first single-page dashboard with manual/automatic/drying control screens, a settings screen (safety limits, sensor calibration, LEDs), an at-a-glance status panel (fan + reason, controller, auto/drying, printer, fault), and setup/OTA pages. Also a read-only **`/diag`** page (live SSE telemetry — chamber/PTC/SSR/mode/fault + trend + CSV) and a **`/console`** page (firmware `ESP_LOGx` ring viewer, backed by auth-gated `GET /api/v2/console`). Light/dark themes. |
 | Wi-Fi captive setup and mDNS | **Implemented** | Product identity is DragonBreath; reachable as `dragonbreath.local` when mDNS works. |

--- a/docs/USING_THE_HEATER.md
+++ b/docs/USING_THE_HEATER.md
@@ -1,121 +1,171 @@
 # Using the chamber heater
 
-DragonBreath does not decide how a print should warm up. It carries out the
-workflow selected by the user, slicer, or printer configuration. In particular,
-it does **not** automatically turn on the bed when the chamber heater starts.
+Adding a chamber heater to a printer that was not designed or configured for one
+requires changes to the print workflow. DragonBreath provides heater control and
+safety; it cannot know how a particular printer should home, position its bed,
+run its fans, heat-soak, or sequence its bed, nozzle, and chamber.
 
-For Klipper, choose **one** of these workflows:
+It therefore does **not** automatically turn on the bed when chamber heating
+starts, and installing a Klipper integration does not rewrite slicer profiles or
+print-start macros. The integration supplies tools, not a universal startup policy.
 
-| Workflow | Who chooses the chamber target? | Does the print wait for it? |
+## What the Klipper integration provides
+
+- `M141 S<temperature>` starts chamber heating without waiting.
+- `M191 S<temperature>` starts chamber heating and waits for the chamber target.
+- `M141 S0` turns chamber heating off.
+- `SET_HEATER_TEMPERATURE HEATER=dragonbreath TARGET=<temperature>` is the
+  corresponding native Klipper command.
+- The `heater_generic` object exposes chamber state to Klipper front ends and
+  macros.
+
+DragonBreath remains responsible for its independent sensor checks, target clamp,
+element foldback, over-temperature shutdown, cooldown airflow, and communications
+watchdog. The printer configuration remains responsible for when to issue those
+commands.
+
+## First choose who controls the target
+
+Use exactly one of these control workflows:
+
+| Workflow | Target source | Print-start behavior |
 |---|---|---|
-| [DragonBreath AUTO](#workflow-1-dragonbreath-auto) | DragonBreath's filament-zone settings | No |
-| [Slicer / Klipper control](#workflow-2-slicer--klipper-control) | Orca or a Klipper start macro | Yes, when the macro uses `M191` |
+| [DragonBreath AUTO](#dragonbreath-auto) | DragonBreath filament-zone settings | Follows an active print; does not block print start |
+| [Slicer / Klipper control](#slicer--klipper-control) | Slicer settings and printer G-code | Completely defined by the user's start/end G-code |
 
-Do not combine them. `M141`, `M191`, and
-`SET_HEATER_TEMPERATURE HEATER=dragonbreath ...` are manual Klipper commands.
-Sending a positive target replaces AUTO with a manual `POWER_ON` session; sending
-zero turns the heater off. Two independent pieces of software cannot own the
-target at the same time.
+Do not mix them. A positive `M141`, `M191`, or `SET_HEATER_TEMPERATURE`
+request starts a manual `POWER_ON` session and replaces AUTO.
 
-The `dragonbreath-klipper` Python file may remain installed in either workflow,
-but its active `[dragonbreath]` configuration is itself a manual controller. It
-sends a safety OFF when it connects, disconnects, or Klippy shuts down, so a
-reconnect can disarm AUTO even if the slicer sends no heater command. For a
-reliable AUTO workflow, disable the active helper configuration as well as its
-G-code commands. DragonBreath's direct Moonraker connection supplies AUTO with
-printer state; the Klippy helper is not required for that path.
+The `dragonbreath-klipper` Python file may remain installed for AUTO, but its
+active `[dragonbreath]` configuration is itself a manual controller. It sends a
+safety OFF when it connects, disconnects, or Klippy shuts down, so a reconnect
+can disarm AUTO. DragonBreath's direct Moonraker connection supplies AUTO with
+printer state; the Klippy helper is not required for that workflow.
+
+## Decide the order of operations
+
+There is no single correct heating sequence. Choose one that suits the printer,
+material, enclosure, and desired soak time.
+
+| Desired behavior | Command shape |
+|---|---|
+| Start bed and chamber together, then wait for both | `M140`, `M141`, later `M190`, `M191` |
+| Heat and soak the chamber before starting the bed | `M141`, `M191`, then `M140`, `M190` |
+| Heat the bed before starting the chamber | `M140`, `M190`, then `M141`, optionally `M191` |
+| Start both but do not delay printing for the chamber | `M140`, `M141`, later `M190`; omit `M191` |
+| Add a fixed soak after temperatures are reached | Wait with `M190`/`M191`, then use the printer's dwell or soak macro |
+
+These are examples, not requirements. A printer may need to home before lowering
+or raising the bed, keep electronics-cooling fans running, park the toolhead away
+from a hot area, or limit its chamber target. Put those printer-specific decisions
+in its start macro or Machine start G-code.
 
 ## The OrcaSlicer trap
 
-When both **Support control chamber temperature** (printer preset) and
-**Activate temperature control** (filament preset) are enabled, OrcaSlicer emits
-this before the printer's Machine start G-code:
+When both **Support controlling chamber temperature** (printer preset) and
+**Activate temperature control** (filament preset) are enabled, OrcaSlicer emits:
 
 ```gcode
 M191 S<chamber-temperature>
 ```
 
-`M191` means **set the chamber target and wait until the chamber reaches it**.
-Because Orca places it before Machine start G-code, the usual bed command has not
-run yet. The chamber therefore warms without help from the bed, and the rest of
-the start sequence appears stuck. This is
+before the printer's entire Machine start G-code. `M191` is blocking, so the usual
+bed command has not run yet. The chamber heats alone and the rest of the startup
+appears stuck. This is
 [Orca's documented command ordering](https://github.com/OrcaSlicer/OrcaSlicer/wiki/material_temperatures#print-chamber-temperature),
 not a DragonBreath fault.
 
-After changing a preset, slice a small model and inspect the first lines of the
-generated G-code. Preset inheritance can leave the chamber option enabled in a
-derived filament or printer profile.
+Orca's default is effectively the “chamber first” policy. That may be desirable
+for some printers, but it is not automatic bed/chamber coordination. If a different
+policy is wanted, place the commands manually:
 
-### PAXX does not choose a warm-up workflow
+1. Leave the printer preset's **Support controlling chamber temperature** enabled.
+2. In each filament preset, set the desired chamber temperature but leave
+   **Activate temperature control unchecked**.
+3. Add `M141`/`M191` where they belong in Machine start G-code or the printer's
+   `PRINT_START` macro.
+4. Add `M141 S0` to the end workflow.
+5. Slice a small object and inspect the generated G-code to verify the actual
+   command order and rendered temperatures.
 
-Enabling the DragonBreath/Panda Breath component in PAXX installs the Klipper
-integration that makes `M141`, `M191`, and the `heater_generic` object work. It
-cannot safely rewrite each user's Orca presets or decide whether their bed, axes,
-fans, and chamber should preheat sequentially or together. PAXX users must still
-choose one of the workflows below and configure their slicer/start macro to match.
+Keeping the chamber temperature set while **Activate temperature control** is
+unchecked leaves Orca's `overall_chamber_temperature` and `chamber_temperature`
+placeholders available without its automatically injected `M191`/`M141` commands.
 
-## Workflow 1: DragonBreath AUTO
+## Slicer / Klipper control
 
-Use this when you want DragonBreath to follow the active filament without the
-slicer directly controlling the heater.
+For the common “start together, wait later” policy, find the printer's early
+non-blocking bed command:
 
-1. On the DragonBreath setup page, select **Klipper / Moonraker** and configure
-   the printer's Moonraker address.
-2. In DragonBreath Settings, configure the desired **Filament zones**.
-3. Arm **AUTO** from the DragonBreath dashboard or front-panel Auto button.
+```gcode
+M140 S{bed_temperature}
+```
+
+and start the chamber beside it:
+
+```gcode
+M140 S{bed_temperature}
+M141 S{chamber_temperature}
+```
+
+Then find the later bed wait:
+
+```gcode
+M190 S{bed_temperature}
+```
+
+and wait for the chamber beside it:
+
+```gcode
+M190 S{bed_temperature}
+M191 S{chamber_temperature}
+```
+
+This starts both heaters together. When execution reaches the waits, the bed stays
+hot while the chamber finishes. Moving `M191`, omitting it, or adding a soak after
+it produces the other policies described above.
+
+The placeholders shown here are illustrative. Use the variable names already
+provided by the slicer/printer profile. In Orca, the chamber target is normally
+`{overall_chamber_temperature}` (highest target across all filaments) or
+`{chamber_temperature[0]}` (first filament only).
+
+If the printer uses a parameterized `PRINT_START`, pass the bed and chamber values
+to that macro and put the same command sequence inside it. Do not duplicate its
+existing `M140`/`M190` calls. At print end, explicitly issue `M141 S0` unless an
+existing end hook already turns DragonBreath off.
+
+## DragonBreath AUTO
+
+Use AUTO when DragonBreath should follow its filament-zone settings without
+slicer-issued heater commands:
+
+1. Select **Klipper / Moonraker** on the DragonBreath setup page and configure the
+   printer's Moonraker address.
+2. Configure the desired **Filament zones** in DragonBreath Settings.
+3. Disable the active `dragonbreath-klipper`/printer-distribution chamber-heater
+   configuration. Leave DragonBreath's own Moonraker source enabled.
+4. In each Orca filament preset, leave the chamber temperature set if desired but
+   clear **Activate temperature control**. Leave **Support controlling chamber
+   temperature** enabled. Verify that sliced G-code contains no `M141` or `M191`.
+5. Arm **AUTO** from the DragonBreath dashboard or front-panel Auto button.
    DragonBreath always boots OFF, so AUTO must be armed again after a reboot.
-4. Disable the active `dragonbreath-klipper`/PAXX chamber-heater integration. The
-   device's own Moonraker control source remains enabled and supplies AUTO data.
-5. In each Orca filament preset, leave the chamber temperature set but clear
-   **Activate temperature control** so Orca does not emit `M191` at the start or
-   `M141` at the end. Leave the printer's **Support controlling chamber
-   temperature** option enabled. Verify the generated G-code contains neither
-   command.
 
-During an active print, DragonBreath reads the loaded material from Moonraker
-and applies its matching filament-zone target. With no active print, no material,
-no matching zone, or no Moonraker connection, AUTO waits with the heater off.
+During an active print, DragonBreath reads the loaded material from Moonraker and
+applies its matching filament-zone target. With no active print, no material, no
+matching zone, or no Moonraker connection, AUTO waits with the heater off.
 
-AUTO starts heating when the print becomes active, but it does **not** pause the
-print-start sequence until the chamber is hot. Use slicer/Klipper control if the
-print must heat-soak before extrusion begins.
+AUTO starts heating when the print becomes active, but it does not pause print
+start until the chamber is hot. Use slicer/Klipper control when a blocking heat
+soak is required.
 
-## Workflow 2: Slicer / Klipper control
+## Worked example: Snapmaker U1 / PAXX Orca profile
 
-Use this when the print-start sequence must coordinate the bed and chamber or
-must wait for a heat soak. Leave DragonBreath AUTO off. `M141` starts chamber
-heating without waiting; `M191` starts it and blocks until the target is reached.
+This is one application of the common “start together, wait later” policy. It is
+not a required DragonBreath sequence. The underscores below are normal G-code
+underscores; do not type backslashes before them.
 
-Do not use Orca's automatically injected `M191` if you want the bed and chamber
-to warm together. It runs before Machine start G-code, so adding an earlier bed
-command *inside* Machine start G-code cannot get ahead of it. Leave the printer's
-**Support controlling chamber temperature** option enabled, but clear the
-filament preset's **Activate temperature control** checkbox. Then verify the
-generated file no longer begins with `M191`.
-
-### Snapmaker U1 / PAXX Orca profile
-
-Do these steps exactly. The underscores shown below are normal G-code underscores;
-do not type backslashes before them.
-
-#### 1. Stop Orca from inserting its own early `M191`
-
-1. Open the **Filament settings** for each heated-chamber material.
-2. Under **Temperature → Print chamber temperature**, set the desired chamber
-   temperature but leave **Activate temperature control unchecked**.
-3. Save the filament preset.
-
-This distinction matters: the temperature value remains available to Machine
-start G-code through Orca's `overall_chamber_temperature` placeholder, while the
-unchecked **Activate temperature control** option prevents Orca from automatically
-placing a blocking `M191` ahead of Machine start G-code. The printer preset's
-**Support controlling chamber temperature** option must remain enabled.
-
-#### 2. Start the chamber beside the bed
-
-Open **Printer settings → Machine G-code → Machine start G-code**.
-
-Find these three consecutive lines near the top:
+In **Printer settings → Machine G-code → Machine start G-code**, find:
 
 ```gcode
 TIMELAPSE_START
@@ -123,8 +173,7 @@ M140 S{bed_temperature_initial_layer_single}
 M104 T{initial_extruder} S140
 ```
 
-Insert the new `M141` line immediately **after `M140` and before `M104`**, so the
-block reads exactly:
+Insert `M141` immediately after `M140`:
 
 ```gcode
 TIMELAPSE_START
@@ -133,13 +182,7 @@ M141 S{overall_chamber_temperature} ; start chamber, do not wait
 M104 T{initial_extruder} S140
 ```
 
-Do not delete or move the `M140` line. `M140` starts the bed and `M141` starts
-DragonBreath; neither command waits, so they now heat together during the U1's
-existing calibration and nozzle-cleaning sequence.
-
-#### 3. Wait for the chamber beside the existing bed wait
-
-Farther down in the same Machine start G-code, find these four consecutive lines:
+Later, find:
 
 ```gcode
 M106 S255
@@ -148,8 +191,7 @@ M190 S{bed_temperature_initial_layer_single}
 M107 P2
 ```
 
-Insert the new `M191` line immediately **after `M190` and before `M107 P2`**, so
-the block reads exactly:
+Insert `M191` immediately after `M190`:
 
 ```gcode
 M106 S255
@@ -159,95 +201,32 @@ M191 S{overall_chamber_temperature} ; wait for chamber; bed remains hot
 M107 P2
 ```
 
-`overall_chamber_temperature` uses the highest configured chamber target when a
-print contains multiple filaments. `{chamber_temperature[0]}` is the Orca
-alternative for the first filament only.
-
-Do not remove or relocate the existing `WAIT_CHAMBER_TEMP TIMEOUT=180` below this
-block. This edit preserves the U1's homing, feed/flow calibration, nozzle cleaning,
-bed-plate detection, chamber wait, and mesh sequence. The bed and chamber begin
-heating together during the existing preparation work. At the later waits, the
-bed reaches target first and remains hot while `M191` lets the chamber finish and
-soak.
-
-#### 4. Turn DragonBreath off when the print ends
-
-Open **Printer settings → Machine G-code → Machine end G-code** and add this as
-the first line unless the end G-code already contains it:
+Do not remove the profile's existing `WAIT_CHAMBER_TEMP TIMEOUT=180`. Add this as
+the first line of Machine end G-code unless it is already present:
 
 ```gcode
 M141 S0 ; chamber off
 ```
 
-#### 5. Verify one sliced file
-
-Slice a small test object, export the G-code, and inspect it as text. Confirm all
-four of these before printing:
-
-1. There is no `M191` before `SET_PRINT_AUTO_BED_LEVELING` or before Machine start
-   G-code.
-2. Near the top, `M140 ...` is immediately followed by `M141 S<number>`, where
-   the number is the expected non-zero chamber target.
-3. Later, `M190 ...` is immediately followed by `M191 S<number>` with the same
-   chamber target.
-4. The end G-code contains `M141 S0`.
-
-If Orca reports `overall_chamber_temperature` as an unknown placeholder, use
-`{chamber_temperature[0]}` in both added lines instead. Do not use different
-placeholders for the start and wait commands. If either command renders as `S0`,
-return to the filament preset and set a non-zero chamber temperature—but keep
-**Activate temperature control unchecked**.
-
-### Other Klipper profiles
-
-For a profile built around parameterized macros, pass the bed and chamber targets
-to a preheat macro. Parameter names vary between profiles, but its heating phase
-should have this shape:
-
-```ini
-[gcode_macro CHAMBER_PREHEAT]
-description: Start bed and DragonBreath together, then wait for both
-gcode:
-    {% set bed = params.BED|default(0)|float %}
-    {% set chamber = params.CHAMBER|default(0)|float %}
-    M140 S{bed}          ; start the bed; do not wait
-    M141 S{chamber}      ; start DragonBreath; do not wait
-    {% if bed > 0 %}
-        M190 S{bed}      ; wait for the bed
-    {% endif %}
-    {% if chamber > 0 %}
-        M191 S{chamber}  ; wait for the chamber; bed stays hot and soaking
-    {% endif %}
-```
-
-Call it from the printer's start macro with the bed and chamber temperatures
-supplied by the slicer. If the existing start G-code already starts or waits for
-the bed, merge these four commands into that heating phase instead of heating the
-bed twice.
-
-This sequence starts both heaters together, waits for the bed, and then keeps the
-bed at temperature while the chamber finishes. Bed position, homing, circulation
-fans, and any extra timed soak are printer-specific decisions and belong in the
-printer's start macro, not in the generic `M141`/`M191` definitions.
-
-At print end, explicitly stop the chamber with `M141 S0` unless the printer's end
-macro already does so.
+After slicing, verify that there is no `M191` before
+`SET_PRINT_AUTO_BED_LEVELING`, that the early `M140`/`M141` and later
+`M190`/`M191` pairs render in that order, and that both chamber commands contain
+the same expected non-zero numeric target. If Orca rejects
+`overall_chamber_temperature`, use `{chamber_temperature[0]}` in both places.
 
 ## Quick diagnosis
 
 - **Chamber heats first; bed stays cold:** Orca probably injected `M191` before
   Machine start G-code. Inspect the generated file, not only the preset UI.
-- **AUTO changes to On/Manual at print start:** the G-code sent `M141`, `M191`, or
-  `SET_HEATER_TEMPERATURE`. Remove those commands for the AUTO workflow.
+- **AUTO changes to On/Manual at print start:** the G-code sent a positive `M141`,
+  `M191`, or `SET_HEATER_TEMPERATURE`, or the active helper reconnected.
 - **AUTO is armed but not heating:** check that a print is active, Moonraker is
   connected, its active material is detected, and that material has a non-zero
   DragonBreath filament zone.
+- **A rendered chamber command says `S0`:** set a non-zero chamber temperature in
+  the filament preset, while keeping **Activate temperature control unchecked**.
 - **`M191` never completes:** confirm the requested value does not exceed the
   device's configured maximum (hard ceiling 70 °C) and is realistically reachable
   in the enclosure.
 - **Displayed chamber temperature seems wrong:** compare it with a trusted probe,
   then use the bounded sensor calibration in Settings. Do not calibrate by feel.
-
-DragonBreath remains responsible for its independent sensor checks, target clamp,
-element foldback, over-temperature shutdown, cooldown airflow, and communications
-watchdog in both workflows.

--- a/docs/USING_THE_HEATER.md
+++ b/docs/USING_THE_HEATER.md
@@ -60,6 +60,37 @@ or raising the bed, keep electronics-cooling fans running, park the toolhead awa
 from a hot area, or limit its chamber target. Put those printer-specific decisions
 in its start macro or Machine start G-code.
 
+## Auxiliary fan, bed, and toolhead position
+
+Heating commands are only part of chamber preheating. The printer's physical
+state can substantially change warm-up time and temperature uniformity:
+
+- **Auxiliary circulation fan:** a printer-owned aux fan can mix the chamber air
+  and move bed heat through the enclosure. Decide whether it should run during
+  preheat, at what speed, and when it should stop. This is separate from the
+  DragonBreath blower, which DragonBreath controls automatically whenever its
+  heater is operating. Do not assume an Orca fan number such as `P2` maps to the
+  same hardware on every printer.
+- **Bed position:** a bed parked in the middle of the enclosure may divide or
+  obstruct circulation. Moving it higher or lower can improve airflow on one
+  printer and make it worse on another. It may also change how much the bed helps
+  heat the chamber. Check cables, bellows, purge hardware, and the full collision
+  envelope before choosing a preheat position.
+- **Toolhead position:** park the toolhead where it will not block circulation,
+  overheat a probe or carriage component, or drip softened filament onto the build
+  area. Keep any fans required to protect toolhead electronics running.
+- **Homing and movement:** do not copy generic `G28` or `G1` sequences from another
+  printer. Machines home in different directions and have different safe-move,
+  probe, tool-changer, and bed-motion prerequisites. Reuse that printer's existing
+  homing and parking macros.
+- **Thermal expansion:** homing, Z-offset measurement, and bed meshing before or
+  after the heat soak can produce different results. Decide which operations need
+  a thermally stable bed, frame, and chamber for the specific machine.
+
+There is no universal bed coordinate, toolhead park position, auxiliary-fan
+command, or homing order that is safe and effective for every printer. Treat these
+as printer-profile decisions, test them cautiously, and supervise initial runs.
+
 ## The OrcaSlicer trap
 
 When both **Support controlling chamber temperature** (printer preset) and
@@ -91,6 +122,9 @@ policy is wanted, place the commands manually:
 Keeping the chamber temperature set while **Activate temperature control** is
 unchecked leaves Orca's `overall_chamber_temperature` and `chamber_temperature`
 placeholders available without its automatically injected `M191`/`M141` commands.
+It also means Orca will not automatically manage an auxiliary fan around its
+injected chamber wait. If circulation is wanted, place the correct printer-specific
+aux-fan commands in the custom start sequence as well.
 
 ## Slicer / Klipper control
 
@@ -208,6 +242,13 @@ the first line of Machine end G-code unless it is already present:
 ```gcode
 M141 S0 ; chamber off
 ```
+
+The supplied U1 start G-code also contains `M106 P2 S0` and later `M107 P2`. If
+this profile maps `P2` to the printer's auxiliary circulation fan, the `S0` leaves
+that fan off during warm-up. Users who want forced circulation can change it to
+their desired 0–255 speed and keep or relocate the later fan-off command. Verify
+the printer's fan mapping first; this fan is separate from DragonBreath's
+automatically controlled blower.
 
 After slicing, verify that there is no `M191` before
 `SET_PRINT_AUTO_BED_LEVELING`, that the early `M140`/`M141` and later

--- a/docs/USING_THE_HEATER.md
+++ b/docs/USING_THE_HEATER.md
@@ -1,0 +1,138 @@
+# Using the chamber heater
+
+DragonBreath does not decide how a print should warm up. It carries out the
+workflow selected by the user, slicer, or printer configuration. In particular,
+it does **not** automatically turn on the bed when the chamber heater starts.
+
+For Klipper, choose **one** of these workflows:
+
+| Workflow | Who chooses the chamber target? | Does the print wait for it? |
+|---|---|---|
+| [DragonBreath AUTO](#workflow-1-dragonbreath-auto) | DragonBreath's filament-zone settings | No |
+| [Slicer / Klipper control](#workflow-2-slicer--klipper-control) | Orca or a Klipper start macro | Yes, when the macro uses `M191` |
+
+Do not combine them. `M141`, `M191`, and
+`SET_HEATER_TEMPERATURE HEATER=dragonbreath ...` are manual Klipper commands.
+Sending a positive target replaces AUTO with a manual `POWER_ON` session; sending
+zero turns the heater off. Two independent pieces of software cannot own the
+target at the same time.
+
+The `dragonbreath-klipper` Python file may remain installed in either workflow,
+but its active `[dragonbreath]` configuration is itself a manual controller. It
+sends a safety OFF when it connects, disconnects, or Klippy shuts down, so a
+reconnect can disarm AUTO even if the slicer sends no heater command. For a
+reliable AUTO workflow, disable the active helper configuration as well as its
+G-code commands. DragonBreath's direct Moonraker connection supplies AUTO with
+printer state; the Klippy helper is not required for that path.
+
+## The OrcaSlicer trap
+
+When both **Support control chamber temperature** (printer preset) and
+**Activate temperature control** (filament preset) are enabled, OrcaSlicer emits
+this before the printer's Machine start G-code:
+
+```gcode
+M191 S<chamber-temperature>
+```
+
+`M191` means **set the chamber target and wait until the chamber reaches it**.
+Because Orca places it before Machine start G-code, the usual bed command has not
+run yet. The chamber therefore warms without help from the bed, and the rest of
+the start sequence appears stuck. This is
+[Orca's documented command ordering](https://github.com/OrcaSlicer/OrcaSlicer/wiki/material_temperatures#print-chamber-temperature),
+not a DragonBreath fault.
+
+After changing a preset, slice a small model and inspect the first lines of the
+generated G-code. Preset inheritance can leave the chamber option enabled in a
+derived filament or printer profile.
+
+### PAXX does not choose a warm-up workflow
+
+Enabling the DragonBreath/Panda Breath component in PAXX installs the Klipper
+integration that makes `M141`, `M191`, and the `heater_generic` object work. It
+cannot safely rewrite each user's Orca presets or decide whether their bed, axes,
+fans, and chamber should preheat sequentially or together. PAXX users must still
+choose one of the workflows below and configure their slicer/start macro to match.
+
+## Workflow 1: DragonBreath AUTO
+
+Use this when you want DragonBreath to follow the active filament without the
+slicer directly controlling the heater.
+
+1. On the DragonBreath setup page, select **Klipper / Moonraker** and configure
+   the printer's Moonraker address.
+2. In DragonBreath Settings, configure the desired **Filament zones**.
+3. Arm **AUTO** from the DragonBreath dashboard or front-panel Auto button.
+   DragonBreath always boots OFF, so AUTO must be armed again after a reboot.
+4. Disable the active `dragonbreath-klipper`/PAXX chamber-heater integration. The
+   device's own Moonraker control source remains enabled and supplies AUTO data.
+5. In Orca, disable automatic chamber-temperature control so it does not emit
+   `M191` at the start or `M141` at the end. Verify the generated G-code contains
+   neither command.
+
+During an active print, DragonBreath reads the loaded material from Moonraker
+and applies its matching filament-zone target. With no active print, no material,
+no matching zone, or no Moonraker connection, AUTO waits with the heater off.
+
+AUTO starts heating when the print becomes active, but it does **not** pause the
+print-start sequence until the chamber is hot. Use slicer/Klipper control if the
+print must heat-soak before extrusion begins.
+
+## Workflow 2: Slicer / Klipper control
+
+Use this when the print-start sequence must coordinate the bed and chamber or
+must wait for a heat soak. Leave DragonBreath AUTO off. `M141` starts chamber
+heating without waiting; `M191` starts it and blocks until the target is reached.
+
+Do not use Orca's automatically injected `M191` if you want the bed and chamber
+to warm together. Disable that option and pass the chamber target into your
+existing `PRINT_START` macro instead. Parameter names vary between printer
+profiles, but the macro's heating phase should have this shape:
+
+```ini
+[gcode_macro CHAMBER_PREHEAT]
+description: Start bed and DragonBreath together, then wait for both
+gcode:
+    {% set bed = params.BED|default(0)|float %}
+    {% set chamber = params.CHAMBER|default(0)|float %}
+    M140 S{bed}          ; start the bed; do not wait
+    M141 S{chamber}      ; start DragonBreath; do not wait
+    {% if bed > 0 %}
+        M190 S{bed}      ; wait for the bed
+    {% endif %}
+    {% if chamber > 0 %}
+        M191 S{chamber}  ; wait for the chamber; bed stays hot and soaking
+    {% endif %}
+```
+
+Call it from the printer's start macro with the bed and chamber temperatures
+supplied by the slicer. If the existing `PRINT_START` already starts or waits for
+the bed, merge these four commands into that heating phase instead of heating the
+bed twice.
+
+This sequence starts both heaters together, waits for the bed, and then keeps the
+bed at temperature while the chamber finishes. Bed position, homing, circulation
+fans, and any extra timed soak are printer-specific decisions and belong in the
+printer's start macro, not in the generic `M141`/`M191` definitions.
+
+At print end, explicitly stop the chamber with `M141 S0` unless the printer's end
+macro already does so.
+
+## Quick diagnosis
+
+- **Chamber heats first; bed stays cold:** Orca probably injected `M191` before
+  Machine start G-code. Inspect the generated file, not only the preset UI.
+- **AUTO changes to On/Manual at print start:** the G-code sent `M141`, `M191`, or
+  `SET_HEATER_TEMPERATURE`. Remove those commands for the AUTO workflow.
+- **AUTO is armed but not heating:** check that a print is active, Moonraker is
+  connected, its active material is detected, and that material has a non-zero
+  DragonBreath filament zone.
+- **`M191` never completes:** confirm the requested value does not exceed the
+  device's configured maximum (hard ceiling 70 °C) and is realistically reachable
+  in the enclosure.
+- **Displayed chamber temperature seems wrong:** compare it with a trusted probe,
+  then use the bounded sensor calibration in Settings. Do not calibrate by feel.
+
+DragonBreath remains responsible for its independent sensor checks, target clamp,
+element foldback, over-temperature shutdown, cooldown airflow, and communications
+watchdog in both workflows.

--- a/docs/USING_THE_HEATER.md
+++ b/docs/USING_THE_HEATER.md
@@ -55,6 +55,39 @@ material, enclosure, and desired soak time.
 | Start both but do not delay printing for the chamber | `M140`, `M141`, later `M190`; omit `M191` |
 | Add a fixed soak after temperatures are reached | Wait with `M190`/`M191`, then use the printer's dwell or soak macro |
 
+### Recommended starting pattern
+
+For many enclosed printers—particularly CoreXY machines—a useful starting pattern
+is:
+
+1. Start the bed with `M140` and DragonBreath with `M141`, without waiting.
+2. Use the printer's safe homing/parking logic to move the toolhead out of the
+   primary circulation path.
+3. Move the bed high in the chamber, where that is safe for the machine, to leave
+   more open circulation volume below it.
+4. Run the printer's auxiliary circulation fan at about **70%**.
+5. Wait for the bed with `M190`, wait for the chamber with `M191`, then run the
+   desired timed or temperature-based soak.
+6. Restore whatever toolhead, bed, and fan state the printer needs, then continue
+   its normal probing, cleaning, and print-start sequence.
+
+In outline—not as copy-paste G-code for an unknown printer:
+
+```gcode
+M140 S{bed_temperature}       ; start bed
+M141 S{chamber_temperature}   ; start chamber
+<printer-specific safe home and toolhead park>
+<printer-specific high-bed position for CoreXY>
+<printer-specific auxiliary fan at 70%>
+M190 S{bed_temperature}       ; wait for bed
+M191 S{chamber_temperature}   ; wait for chamber
+<printer-specific soak>
+```
+
+This recommendation is deliberately a pattern rather than a universal macro.
+Confirm the safe motion order, bed coordinate, aux-fan mapping, and soak condition
+for the actual printer before implementing it.
+
 These are examples, not requirements. A printer may need to home before lowering
 or raising the bed, keep electronics-cooling fans running, park the toolhead away
 from a hot area, or limit its chamber target. Put those printer-specific decisions
@@ -245,10 +278,10 @@ M141 S0 ; chamber off
 
 The supplied U1 start G-code also contains `M106 P2 S0` and later `M107 P2`. If
 this profile maps `P2` to the printer's auxiliary circulation fan, the `S0` leaves
-that fan off during warm-up. Users who want forced circulation can change it to
-their desired 0–255 speed and keep or relocate the later fan-off command. Verify
-the printer's fan mapping first; this fan is separate from DragonBreath's
-automatically controlled blower.
+that fan off during warm-up. For the recommended 70% circulation starting point,
+change it to `M106 P2 S179` after confirming the U1 profile's `P2` mapping. Keep or
+relocate the later `M107 P2` depending on when circulation should stop. This fan is
+separate from DragonBreath's automatically controlled blower.
 
 After slicing, verify that there is no `M191` before
 `SET_PRINT_AUTO_BED_LEVELING`, that the early `M140`/`M141` and later

--- a/docs/USING_THE_HEATER.md
+++ b/docs/USING_THE_HEATER.md
@@ -36,11 +36,11 @@ Use exactly one of these control workflows:
 Do not mix them. A positive `M141`, `M191`, or `SET_HEATER_TEMPERATURE`
 request starts a manual `POWER_ON` session and replaces AUTO.
 
-The `dragonbreath-klipper` Python file may remain installed for AUTO, but its
-active `[dragonbreath]` configuration is itself a manual controller. It sends a
-safety OFF when it connects, disconnects, or Klippy shuts down, so a reconnect
-can disarm AUTO. DragonBreath's direct Moonraker connection supplies AUTO with
-printer state; the Klippy helper is not required for that workflow.
+The UI reflects that ownership choice. When an active `[dragonbreath]` Klippy
+configuration is detected, slicer/Klipper owns chamber heat and AUTO is hidden.
+This is expected—not a missing feature. Disable the active helper configuration
+and restart Klipper to use AUTO; DragonBreath's direct Moonraker connection
+supplies the printer state for that workflow.
 
 ## Decide the order of operations
 
@@ -144,7 +144,8 @@ slicer-issued heater commands:
    printer's Moonraker address.
 2. Configure the desired **Filament zones** in DragonBreath Settings.
 3. Disable the active `dragonbreath-klipper`/printer-distribution chamber-heater
-   configuration. Leave DragonBreath's own Moonraker source enabled.
+   configuration and restart Klipper. Leave DragonBreath's own Moonraker source
+   enabled; the AUTO control becomes available when no active helper is detected.
 4. In each Orca filament preset, leave the chamber temperature set if desired but
    clear **Activate temperature control**. Leave **Support controlling chamber
    temperature** enabled. Verify that sliced G-code contains no `M141` or `M191`.
@@ -218,8 +219,9 @@ the same expected non-zero numeric target. If Orca rejects
 
 - **Chamber heats first; bed stays cold:** Orca probably injected `M191` before
   Machine start G-code. Inspect the generated file, not only the preset UI.
-- **AUTO changes to On/Manual at print start:** the G-code sent a positive `M141`,
-  `M191`, or `SET_HEATER_TEMPERATURE`, or the active helper reconnected.
+- **AUTO is not shown:** an active `[dragonbreath]` Klippy configuration was
+  detected, so slicer/Klipper owns chamber heat. Disable it and restart Klipper if
+  AUTO is the desired workflow.
 - **AUTO is armed but not heating:** check that a print is active, Moonraker is
   connected, its active material is detected, and that material has a non-zero
   DragonBreath filament zone.

--- a/docs/USING_THE_HEATER.md
+++ b/docs/USING_THE_HEATER.md
@@ -85,9 +85,124 @@ must wait for a heat soak. Leave DragonBreath AUTO off. `M141` starts chamber
 heating without waiting; `M191` starts it and blocks until the target is reached.
 
 Do not use Orca's automatically injected `M191` if you want the bed and chamber
-to warm together. Disable that option and pass the chamber target into your
-existing `PRINT_START` macro instead. Parameter names vary between printer
-profiles, but the macro's heating phase should have this shape:
+to warm together. It runs before Machine start G-code, so adding an earlier bed
+command *inside* Machine start G-code cannot get ahead of it. Disable Orca's
+automatic chamber commands and verify the generated file no longer begins with
+`M191`.
+
+### Snapmaker U1 / PAXX Orca profile
+
+Do these steps exactly. The underscores shown below are normal G-code underscores;
+do not type backslashes before them.
+
+#### 1. Stop Orca from inserting its own early `M191`
+
+1. Open the **Filament settings** for each heated-chamber material.
+2. Under **Temperature → Print chamber temperature**, enable **Activate
+   temperature control**, set the desired chamber temperature, and save the
+   filament preset.
+3. Open **Printer settings**.
+4. Switch Orca to **Advanced** mode if the next option is hidden.
+5. Open **Basic information → Accessory**.
+6. Clear **Support controlling chamber temperature**.
+7. Save the printer preset.
+
+Keep the desired chamber temperature in the filament preset. The Machine start
+G-code below reads it through Orca's `overall_chamber_temperature` placeholder.
+Turning off printer-level support prevents Orca from automatically placing a
+blocking `M191` ahead of Machine start G-code.
+
+#### 2. Start the chamber beside the bed
+
+Open **Printer settings → Machine G-code → Machine start G-code**.
+
+Find these three consecutive lines near the top:
+
+```gcode
+TIMELAPSE_START
+M140 S{bed_temperature_initial_layer_single}
+M104 T{initial_extruder} S140
+```
+
+Insert the new `M141` line immediately **after `M140` and before `M104`**, so the
+block reads exactly:
+
+```gcode
+TIMELAPSE_START
+M140 S{bed_temperature_initial_layer_single}
+M141 S{overall_chamber_temperature} ; start chamber, do not wait
+M104 T{initial_extruder} S140
+```
+
+Do not delete or move the `M140` line. `M140` starts the bed and `M141` starts
+DragonBreath; neither command waits, so they now heat together during the U1's
+existing calibration and nozzle-cleaning sequence.
+
+#### 3. Wait for the chamber beside the existing bed wait
+
+Farther down in the same Machine start G-code, find these four consecutive lines:
+
+```gcode
+M106 S255
+M109 S{nozzle_temperature[initial_extruder] - 90}
+M190 S{bed_temperature_initial_layer_single}
+M107 P2
+```
+
+Insert the new `M191` line immediately **after `M190` and before `M107 P2`**, so
+the block reads exactly:
+
+```gcode
+M106 S255
+M109 S{nozzle_temperature[initial_extruder] - 90}
+M190 S{bed_temperature_initial_layer_single}
+M191 S{overall_chamber_temperature} ; wait for chamber; bed remains hot
+M107 P2
+```
+
+`overall_chamber_temperature` uses the highest configured chamber target when a
+print contains multiple filaments. `{chamber_temperature[0]}` is the Orca
+alternative for the first filament only.
+
+Do not remove or relocate the existing `WAIT_CHAMBER_TEMP TIMEOUT=180` below this
+block. This edit preserves the U1's homing, feed/flow calibration, nozzle cleaning,
+bed-plate detection, chamber wait, and mesh sequence. The bed and chamber begin
+heating together during the existing preparation work. At the later waits, the
+bed reaches target first and remains hot while `M191` lets the chamber finish and
+soak.
+
+#### 4. Turn DragonBreath off when the print ends
+
+Open **Printer settings → Machine G-code → Machine end G-code** and add this as
+the first line unless the end G-code already contains it:
+
+```gcode
+M141 S0 ; chamber off
+```
+
+#### 5. Verify one sliced file
+
+Slice a small test object, export the G-code, and inspect it as text. Confirm all
+four of these before printing:
+
+1. There is no `M191` before `SET_PRINT_AUTO_BED_LEVELING` or before Machine start
+   G-code.
+2. Near the top, `M140 ...` is immediately followed by `M141 S<number>`, where
+   the number is the expected non-zero chamber target.
+3. Later, `M190 ...` is immediately followed by `M191 S<number>` with the same
+   chamber target.
+4. The end G-code contains `M141 S0`.
+
+If Orca reports `overall_chamber_temperature` as an unknown placeholder, use
+`{chamber_temperature[0]}` in both added lines instead. Do not use different
+placeholders for the start and wait commands. If either command renders as `S0`,
+return to the filament preset and set/activate its chamber temperature.
+
+### Other Klipper profiles
+
+For a profile built around parameterized macros, pass the bed and chamber targets
+to a preheat macro. Parameter names vary between profiles, but its heating phase
+should have this shape:
 
 ```ini
 [gcode_macro CHAMBER_PREHEAT]
@@ -106,7 +221,7 @@ gcode:
 ```
 
 Call it from the printer's start macro with the bed and chamber temperatures
-supplied by the slicer. If the existing `PRINT_START` already starts or waits for
+supplied by the slicer. If the existing start G-code already starts or waits for
 the bed, merge these four commands into that heating phase instead of heating the
 bed twice.
 

--- a/docs/USING_THE_HEATER.md
+++ b/docs/USING_THE_HEATER.md
@@ -66,9 +66,11 @@ slicer directly controlling the heater.
    DragonBreath always boots OFF, so AUTO must be armed again after a reboot.
 4. Disable the active `dragonbreath-klipper`/PAXX chamber-heater integration. The
    device's own Moonraker control source remains enabled and supplies AUTO data.
-5. In Orca, disable automatic chamber-temperature control so it does not emit
-   `M191` at the start or `M141` at the end. Verify the generated G-code contains
-   neither command.
+5. In each Orca filament preset, leave the chamber temperature set but clear
+   **Activate temperature control** so Orca does not emit `M191` at the start or
+   `M141` at the end. Leave the printer's **Support controlling chamber
+   temperature** option enabled. Verify the generated G-code contains neither
+   command.
 
 During an active print, DragonBreath reads the loaded material from Moonraker
 and applies its matching filament-zone target. With no active print, no material,
@@ -86,9 +88,10 @@ heating without waiting; `M191` starts it and blocks until the target is reached
 
 Do not use Orca's automatically injected `M191` if you want the bed and chamber
 to warm together. It runs before Machine start G-code, so adding an earlier bed
-command *inside* Machine start G-code cannot get ahead of it. Disable Orca's
-automatic chamber commands and verify the generated file no longer begins with
-`M191`.
+command *inside* Machine start G-code cannot get ahead of it. Leave the printer's
+**Support controlling chamber temperature** option enabled, but clear the
+filament preset's **Activate temperature control** checkbox. Then verify the
+generated file no longer begins with `M191`.
 
 ### Snapmaker U1 / PAXX Orca profile
 
@@ -98,19 +101,15 @@ do not type backslashes before them.
 #### 1. Stop Orca from inserting its own early `M191`
 
 1. Open the **Filament settings** for each heated-chamber material.
-2. Under **Temperature → Print chamber temperature**, enable **Activate
-   temperature control**, set the desired chamber temperature, and save the
-   filament preset.
-3. Open **Printer settings**.
-4. Switch Orca to **Advanced** mode if the next option is hidden.
-5. Open **Basic information → Accessory**.
-6. Clear **Support controlling chamber temperature**.
-7. Save the printer preset.
+2. Under **Temperature → Print chamber temperature**, set the desired chamber
+   temperature but leave **Activate temperature control unchecked**.
+3. Save the filament preset.
 
-Keep the desired chamber temperature in the filament preset. The Machine start
-G-code below reads it through Orca's `overall_chamber_temperature` placeholder.
-Turning off printer-level support prevents Orca from automatically placing a
-blocking `M191` ahead of Machine start G-code.
+This distinction matters: the temperature value remains available to Machine
+start G-code through Orca's `overall_chamber_temperature` placeholder, while the
+unchecked **Activate temperature control** option prevents Orca from automatically
+placing a blocking `M191` ahead of Machine start G-code. The printer preset's
+**Support controlling chamber temperature** option must remain enabled.
 
 #### 2. Start the chamber beside the bed
 
@@ -196,7 +195,8 @@ four of these before printing:
 If Orca reports `overall_chamber_temperature` as an unknown placeholder, use
 `{chamber_temperature[0]}` in both added lines instead. Do not use different
 placeholders for the start and wait commands. If either command renders as `S0`,
-return to the filament preset and set/activate its chamber temperature.
+return to the filament preset and set a non-zero chamber temperature—but keep
+**Activate temperature control unchecked**.
 
 ### Other Klipper profiles
 

--- a/docs/api-v2.md
+++ b/docs/api-v2.md
@@ -128,8 +128,8 @@ authenticated response that creates a POWER_ON lease returns it.
 transitions; ordinary temperature samples and successful heartbeats do not
 increment it.
 
-`environment.control_source` is the configured control binding — `klipper`,
-`bambu`, or `ha` — chosen on `/setup` (distinct from the top-level `source`, which is
+`environment.control_source` is the configured control binding — for example
+`klipper`, `bambu`, `prusa`, or `ha` — chosen on `/setup` (distinct from the top-level `source`, which is
 the last actor that changed state). The printer's configured Bambu serial is intentionally
 not exposed by the public state API; it remains internal to the Bambu MQTT connection.
 `environment.bed_target_c` is the **commanded** bed setpoint from the active source and
@@ -149,8 +149,9 @@ cutoff.
 `environment.auto_filtering` is `true` while the fan-only filtration band is driving
 the blower — whenever `filter_auto` is enabled, Moonraker is connected, and the bed
 **setpoint** is at/above `filter_temp_c`. This is a **standing** band, independent of
-mode (it runs even while idle); the heater still engages only in AUTO at the higher
-bed threshold.
+mode (it runs even while idle). AUTO heat engagement is separate: filament-aware
+sources use the active filament-zone target, while bed-follow sources use their
+configured target and bed threshold.
 
 `params` reports the *remembered* mode parameters — the values most recently
 accepted for each mode, used to pre-fill the UI and to re-arm a mode when the
@@ -181,8 +182,9 @@ Supported commands:
   safer OFF.
 - `{"name":"power_on","target_c":45}` — creates a new device-issued remote
   lease and invalidates any previous lease.
-- `{"name":"auto","target_c":45,"bed_threshold_c":60}` — device policy follows
-  the observed Moonraker bed state.
+- `{"name":"auto","target_c":45,"bed_threshold_c":60}` — arms device AUTO.
+  Filament-aware sources use the active filament-zone target; bed-follow sources
+  use `target_c` once the observed bed setpoint reaches `bed_threshold_c`.
 - `{"name":"drying_start","target_c":50,"hours":4}` — bounded to 1–12 hours.
 - `{"name":"drying_stop"}` — unconditional safer stop.
 - `{"name":"filter","percent":100}` — manual fan-only filtration blower (0 = off,

--- a/docs/control-source.md
+++ b/docs/control-source.md
@@ -9,15 +9,16 @@ feature. So there is always a single owner of the setpoint — never several.
 
 | Source | What it does |
 |---|---|
-| **Klipper (Moonraker)** | Follows the printer over the Moonraker WebSocket. AUTO mode triggers on the **bed setpoint**. The default, and the shipped path. |
-| **Bambu (LAN)** | Follows a Bambu Lab printer's chamber/bed over LAN MQTT (read-only from the printer; DragonBreath still owns the heater). |
+| **Klipper (Moonraker)** | Follows the printer over the Moonraker WebSocket. AUTO follows the active print's DragonBreath filament-zone target. The default and shipped path. |
+| **Bambu (LAN)** | Follows a Bambu Lab printer over LAN MQTT. AUTO follows the active print's DragonBreath filament-zone target (read-only from the printer; DragonBreath still owns the heater). |
+| **Prusa (PrusaLink)** | Follows the printer over PrusaLink. Because PrusaLink does not report filament type, AUTO follows the bed setpoint and the configured bed threshold. |
 | **Home Assistant** | HA is the **controller** — a climate entity + sensors auto-appear via MQTT discovery, and HA sets target / on / off. |
 | **None (unbound)** | No external controller. The heater is driven only from the DragonBreath web UI (or left idle). |
 
-Only the **selected** source is connected. If you pick Klipper, the Bambu and HA
-clients do not run at all — and vice-versa. In particular, **Home Assistant is
-full-control only while it is the selected source.** When a printer (Klipper or
-Bambu) is bound, HA is not connected — there is no background HA link.
+Only the **selected** source has control. In particular, **Home Assistant is
+full-control only while it is the selected source.** It may optionally publish
+read-only telemetry alongside a printer source, but it cannot send heater commands
+in that monitor role.
 
 ## Switching sources — and why there's an Unbind
 
@@ -32,10 +33,26 @@ page mirrors stock's "disconnect":
 Unbinding a printer is how you "make HA the primary": once no printer is bound,
 select Home Assistant and it becomes the sole controller with full control.
 
-> **Why not run HA as a read-only monitor alongside Klipper/Bambu?** We considered
-> it and chose not to: a second always-on connection — even read-only — muddies
-> "who owns the heater" and invites exactly the ownership confusion the single-source
-> rule exists to prevent. One source, one owner, no ambiguity.
+## Control source is not control mode
+
+Selecting **Klipper / Moonraker** as the source does not mean that slicer commands
+and AUTO can drive the target together. In Klipper source mode, choose either:
+
+- DragonBreath AUTO, with no `M141`/`M191` heater commands in the sliced G-code; or
+- manual slicer/Klipper control through `M141`, `M191`, or
+  `SET_HEATER_TEMPERATURE`, with AUTO off.
+
+The helper's Python file may stay installed, but its active `[dragonbreath]`
+configuration is a manual controller and sends a safety OFF when it connects or
+disconnects. Disable that configuration for a reliable AUTO workflow. Issuing one
+of its heater commands with a positive target starts a manual POWER_ON session and
+replaces AUTO. See
+[`USING_THE_HEATER.md`](USING_THE_HEATER.md) for setup recipes and OrcaSlicer's
+important command-ordering behavior.
+
+Read-only Home Assistant telemetry does not create a second owner: the device does
+not subscribe to HA command topics in monitor mode. One selected control source
+still owns heater intent.
 
 ## Safety note
 

--- a/docs/control-source.md
+++ b/docs/control-source.md
@@ -42,11 +42,9 @@ and AUTO can drive the target together. In Klipper source mode, choose either:
 - manual slicer/Klipper control through `M141`, `M191`, or
   `SET_HEATER_TEMPERATURE`, with AUTO off.
 
-The helper's Python file may stay installed, but its active `[dragonbreath]`
-configuration is a manual controller and sends a safety OFF when it connects or
-disconnects. Disable that configuration for a reliable AUTO workflow. Issuing one
-of its heater commands with a positive target starts a manual POWER_ON session and
-replaces AUTO. See
+An active `[dragonbreath]` Klippy configuration declares slicer/Klipper ownership,
+so the UI hides AUTO. Disable that configuration and restart Klipper to make AUTO
+available. See
 [`USING_THE_HEATER.md`](USING_THE_HEATER.md) for setup recipes and OrcaSlicer's
 important command-ordering behavior.
 


### PR DESCRIPTION
## Summary

- explain that adding a chamber heater provides control primitives, not a universal print-start policy; slicer and printer workflow changes are required
- make DragonBreath AUTO and slicer/Klipper control explicit, mutually exclusive ownership models
- document that detecting an active `[dragonbreath]` Klippy configuration hides AUTO, leaving one compatible control path visible
- document several valid bed/chamber ordering choices and a practical CoreXY starting pattern: start bed/chamber together, safely park the toolhead, raise the bed, run the verified aux fan around 70%, then wait and soak
- cover printer-specific auxiliary-fan behavior, bed and toolhead positioning, homing constraints, and thermal expansion without prescribing unsafe universal moves
- explain OrcaSlicer's leading blocking `M191` behavior and how to retain chamber targets while manually placing commands
- retain the Snapmaker U1/PAXX sequence as a worked example rather than the primary guidance
- correct stale AUTO, control-source, API, and OEM-parity descriptions

## Validation

- `git diff --check`
- documentation-only change; firmware tests not run